### PR TITLE
Options to require filters in connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 - Executable Tool Specifications can be used to run any (shell) command. This enhancement
   duplicates the functionality of Gimlet project items and makes them obsolete.
+- There is now an option to select if new scenarios or tools are automatically used
+  for filtering in Link properties.
+- The new "Filer validation" button in Link properties allows forcing at least one scenario or tool
+  filter to be checked.
 
 ### Changed
 - The console settings of Python tools as well as the command and shell settings of executable tools

--- a/spinetoolbox/link.py
+++ b/spinetoolbox/link.py
@@ -316,14 +316,11 @@ class _SvgIcon(_IconBase):
 class _TextIcon(_IconBase):
     """A font awesome icon to show over a Link."""
 
-    FONT_SIZE_PIXELS = 16  # Using pixel size to prevent font scaling by system.
-
     def __init__(self, parent, extent, char, tooltip=None, active=False):
         super().__init__(0, 0, extent, extent, parent, tooltip=tooltip, active=active)
         self._text_item = QGraphicsTextItem(self)
         font = QFont('Font Awesome 5 Free Solid', weight=QFont.Bold)
         self._text_item.setFont(font)
-        self._text_item.setDefaultTextColor(self._fg_color)
         self._text_item.setPlainText(char)
         self._text_item.setPos(self.sceneBoundingRect().center() - self._text_item.sceneBoundingRect().center())
         self.setPen(Qt.NoPen)
@@ -332,6 +329,15 @@ class _TextIcon(_IconBase):
         """Cleans up icon's resources."""
         self._text_item.deleteLater()
         self.scene().removeItem(self)
+
+
+class _WarningTextIcon(_TextIcon):
+    """A font awesome icon to show over a Link."""
+
+    def __init__(self, parent, extent, char, tooltip):
+        super().__init__(parent, extent, char, tooltip, active=True)
+        self._fg_color = QColor("red")
+        self._text_item.setDefaultTextColor(self._fg_color)
 
 
 class JumpOrLink(LinkBase):
@@ -460,6 +466,7 @@ class Link(JumpOrLink):
     _MEMORY = "\uf538"
     _FILTERS = "\uf0b0"
     _PURGE = "\uf0e7"
+    _WARNING = "\uf06a"
     _DATAPACKAGE = ":/icons/datapkg.svg"
 
     def __init__(self, toolbox, src_connector, dst_connector, connection):
@@ -493,6 +500,10 @@ class Link(JumpOrLink):
             sibling_conns = self._toolbox.project().incoming_connections(self.connection.destination)
             active = any(l.write_index > 1 for l in sibling_conns)
             self._icons.append(_TextIcon(self, self._icon_extent, str(self._connection.write_index), active=active))
+        notifications = self._connection.notifications()
+        if notifications:
+            tooltip = "Check Link properties. " + " ".join(notifications)
+            self._icons.append(_WarningTextIcon(self, self._icon_extent, self._WARNING, tooltip))
         self._place_icons()
 
     @property

--- a/spinetoolbox/spine_engine_manager.py
+++ b/spinetoolbox/spine_engine_manager.py
@@ -19,7 +19,7 @@ import queue
 import threading
 import json
 from spinetoolbox.server.engine_client import EngineClient, ClientSecurityModel
-from spine_engine.exception import RemoteEngineInitFailed
+from spine_engine.exception import EngineInitFailed, RemoteEngineInitFailed
 from spine_engine.server.util.event_data_converter import EventDataConverter
 
 
@@ -150,7 +150,8 @@ class LocalSpineEngineManager(SpineEngineManagerBase):
         return self._engine.get_event()
 
     def stop_engine(self):
-        self._engine.stop()
+        if self._engine is not None:
+            self._engine.stop()
 
     def answer_prompt(self, item_name, accepted):
         self._engine.answer_prompt(item_name, accepted)

--- a/spinetoolbox/ui/link_properties.py
+++ b/spinetoolbox/ui/link_properties.py
@@ -55,6 +55,15 @@ class Ui_Form(object):
 
         self.horizontalLayout_3.addWidget(self.auto_check_filters_check_box)
 
+        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_3.addItem(self.horizontalSpacer_3)
+
+        self.open_filter_validation_menu_button = QPushButton(self.frame)
+        self.open_filter_validation_menu_button.setObjectName(u"open_filter_validation_menu_button")
+
+        self.horizontalLayout_3.addWidget(self.open_filter_validation_menu_button)
+
 
         self.verticalLayout_2.addLayout(self.horizontalLayout_3)
 
@@ -120,6 +129,7 @@ class Ui_Form(object):
     def retranslateUi(self, Form):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
         self.auto_check_filters_check_box.setText(QCoreApplication.translate("Form", u"Check new filters automatically", None))
+        self.open_filter_validation_menu_button.setText(QCoreApplication.translate("Form", u"Filter validation", None))
         self.label_write_index.setText(QCoreApplication.translate("Form", u"Write index (lower writes earlier):", None))
         self.checkBox_purge_before_writing.setText(QCoreApplication.translate("Form", u"Purge before writing", None))
 #if QT_CONFIG(tooltip)

--- a/spinetoolbox/ui/link_properties.ui
+++ b/spinetoolbox/ui/link_properties.ui
@@ -60,6 +60,26 @@
           </property>
          </widget>
         </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="open_filter_validation_menu_button">
+          <property name="text">
+           <string>Filter validation</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>

--- a/spinetoolbox/widgets/link_properties_widget.py
+++ b/spinetoolbox/widgets/link_properties_widget.py
@@ -17,6 +17,10 @@ Link properties widget.
 """
 
 from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QMenu
+
+from spinedb_api.filters.scenario_filter import SCENARIO_FILTER_TYPE
+from spinedb_api.filters.tool_filter import TOOL_FILTER_TYPE
 from .properties_widget import PropertiesWidgetBase
 from .custom_qwidgets import PurgeSettingsDialog
 from ..project_commands import SetConnectionOptionsCommand, SetConnectionDefaultFilterOnlineStatus
@@ -37,7 +41,10 @@ class LinkPropertiesWidget(PropertiesWidgetBase):
         self._purge_settings_dialog = None
         self.ui = Ui_Form()
         self.ui.setupUi(self)
+        self._filter_validation_menu = QMenu(self)
+        self._filter_validation_actions = self._populate_filter_validation_menu()
         self.ui.auto_check_filters_check_box.clicked.connect(self._handle_auto_check_filters_state_changed)
+        self.ui.open_filter_validation_menu_button.setMenu(self._filter_validation_menu)
         self.ui.spinBox_write_index.valueChanged.connect(self._handle_write_index_value_changed)
         self.ui.checkBox_use_datapackage.stateChanged.connect(self._handle_use_datapackage_state_changed)
         self.ui.checkBox_use_memory_db.stateChanged.connect(self._handle_use_memory_db_state_changed)
@@ -63,6 +70,7 @@ class LinkPropertiesWidget(PropertiesWidgetBase):
         self.ui.treeView_filters.setEnabled(may_have_filters)
         self.ui.auto_check_filters_check_box.setChecked(self._connection.is_filter_online_by_default)
         self.ui.auto_check_filters_check_box.setEnabled(may_have_filters)
+        self.ui.open_filter_validation_menu_button.setEnabled(may_have_filters)
         self.ui.spinBox_write_index.setEnabled(self._connection.may_have_write_index())
         self.ui.label_write_index.setEnabled(self._connection.may_have_write_index())
         self.ui.checkBox_use_memory_db.setEnabled(self._connection.may_use_memory_db())
@@ -91,6 +99,33 @@ class LinkPropertiesWidget(PropertiesWidgetBase):
             checked (bool): True if the checkbox is checked
         """
         self.ui.auto_check_filters_check_box.setChecked(checked)
+
+    def _populate_filter_validation_menu(self):
+        """Adds actions to filter validation menu.
+
+        Returns:
+            dict: menu actions
+        """
+        action_data = {
+            "Require at least one checked scenario": SCENARIO_FILTER_TYPE,
+            "Require at least one checked tool": TOOL_FILTER_TYPE,
+        }
+        actions = {}
+        for label, filter_type in action_data.items():
+            action = self._filter_validation_menu.addAction(label)
+            action.setCheckable(True)
+            action.toggled.connect(self._update_filter_validation_options)
+            actions[filter_type] = action
+        return actions
+
+    @Slot(bool)
+    def _update_filter_validation_options(self, checked):
+        """"""
+        for filter_type, action in self._filter_validation_actions.items():
+            if self._connection.require_filter_online(filter_type) != action.isChecked():
+                options = {"require_" + filter_type: checked}
+                self._toolbox.undo_stack.push(SetConnectionOptionsCommand(self._connection, options))
+                return
 
     @Slot(int)
     def _handle_write_index_value_changed(self, value):
@@ -149,6 +184,10 @@ class LinkPropertiesWidget(PropertiesWidgetBase):
         self._purge_settings_dialog = None
 
     def load_connection_options(self):
+        for filter_type, action in self._filter_validation_actions.items():
+            action.toggled.disconnect()
+            action.setChecked(self._connection.require_filter_online(filter_type))
+            action.toggled.connect(self._update_filter_validation_options)
         self.ui.checkBox_use_datapackage.setChecked(self._connection.use_datapackage)
         self.ui.checkBox_use_memory_db.setChecked(self._connection.use_memory_db)
         self.ui.checkBox_purge_before_writing.setChecked(self._connection.purge_before_writing)


### PR DESCRIPTION
This adds widgets to the Link properties tab that allow users to set if the link should require at least one scenario or tool filter. An exclamation icon is added to the link's icons if no filters are checked.

See also the accompanying PR spine-tools/spine-engine#74

Fixes #1928

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
