### PR TITLE
Improve database purge and export dialogs

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/select_databases.py
+++ b/spinetoolbox/spine_db_editor/ui/select_databases.py
@@ -11,7 +11,7 @@
 ######################################################################################################################
 
 ################################################################################
-## Form generated from reading UI file 'select_database_items_dialog.ui'
+## Form generated from reading UI file 'select_databases.ui'
 ##
 ## Created by: Qt User Interface Compiler version 6.4.1
 ##
@@ -25,18 +25,18 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
-    QGridLayout, QGroupBox, QHBoxLayout, QPushButton,
-    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QGridLayout, QGroupBox, QHBoxLayout,
+    QPushButton, QSizePolicy, QSpacerItem, QVBoxLayout,
+    QWidget)
 
-class Ui_Dialog(object):
-    def setupUi(self, Dialog):
-        if not Dialog.objectName():
-            Dialog.setObjectName(u"Dialog")
-        Dialog.resize(400, 300)
-        self.root_layout = QVBoxLayout(Dialog)
-        self.root_layout.setObjectName(u"root_layout")
-        self.databases_group_box = QGroupBox(Dialog)
+class Ui_Form(object):
+    def setupUi(self, Form):
+        if not Form.objectName():
+            Form.setObjectName(u"Form")
+        Form.resize(400, 300)
+        self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.databases_group_box = QGroupBox(Form)
         self.databases_group_box.setObjectName(u"databases_group_box")
         self.verticalLayout_2 = QVBoxLayout(self.databases_group_box)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
@@ -65,37 +65,24 @@ class Ui_Dialog(object):
         self.verticalLayout_2.addLayout(self.horizontalLayout)
 
 
-        self.root_layout.addWidget(self.databases_group_box)
-
-        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
-
-        self.root_layout.addItem(self.verticalSpacer)
-
-        self.button_box = QDialogButtonBox(Dialog)
-        self.button_box.setObjectName(u"button_box")
-        self.button_box.setOrientation(Qt.Horizontal)
-        self.button_box.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
-
-        self.root_layout.addWidget(self.button_box)
+        self.verticalLayout.addWidget(self.databases_group_box)
 
 
-        self.retranslateUi(Dialog)
-        self.button_box.accepted.connect(Dialog.accept)
-        self.button_box.rejected.connect(Dialog.reject)
+        self.retranslateUi(Form)
 
-        QMetaObject.connectSlotsByName(Dialog)
+        QMetaObject.connectSlotsByName(Form)
     # setupUi
 
-    def retranslateUi(self, Dialog):
-        Dialog.setWindowTitle(QCoreApplication.translate("Dialog", u"Dialog", None))
-        self.databases_group_box.setTitle(QCoreApplication.translate("Dialog", u"Databases", None))
+    def retranslateUi(self, Form):
+        Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
+        self.databases_group_box.setTitle(QCoreApplication.translate("Form", u"Databases", None))
 #if QT_CONFIG(tooltip)
-        self.select_all_button.setToolTip(QCoreApplication.translate("Dialog", u"Select all databases.", None))
+        self.select_all_button.setToolTip(QCoreApplication.translate("Form", u"Select all databases.", None))
 #endif // QT_CONFIG(tooltip)
-        self.select_all_button.setText(QCoreApplication.translate("Dialog", u"Select all", None))
+        self.select_all_button.setText(QCoreApplication.translate("Form", u"Select all", None))
 #if QT_CONFIG(tooltip)
-        self.deselect_all_button.setToolTip(QCoreApplication.translate("Dialog", u"Deselect all databases.", None))
+        self.deselect_all_button.setToolTip(QCoreApplication.translate("Form", u"Deselect all databases.", None))
 #endif // QT_CONFIG(tooltip)
-        self.deselect_all_button.setText(QCoreApplication.translate("Dialog", u"Deselect all", None))
+        self.deselect_all_button.setText(QCoreApplication.translate("Form", u"Deselect all", None))
     # retranslateUi
 

--- a/spinetoolbox/spine_db_editor/ui/select_databases.ui
+++ b/spinetoolbox/spine_db_editor/ui/select_databases.ui
@@ -12,8 +12,8 @@
 ######################################################################################################################
 -->
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -23,9 +23,9 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="root_layout">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="databases_group_box">
      <property name="title">
@@ -75,64 +75,8 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>button_box</sender>
-   <signal>accepted()</signal>
-   <receiver>Dialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>button_box</sender>
-   <signal>rejected()</signal>
-   <receiver>Dialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
@@ -15,65 +15,93 @@ Classes for custom QDialogs to add edit and remove database items.
 :author: M. Marin (KTH)
 :date:   13.5.2018
 """
+from PySide6.QtWidgets import QCheckBox, QDialogButtonBox, QWidget
+from PySide6.QtCore import Signal, Slot
 
-from PySide6.QtWidgets import QDialog, QDialogButtonBox, QCheckBox
-from PySide6.QtCore import Slot, Qt, Signal
-from spinetoolbox.widgets.select_database_items import add_check_boxes, SelectDatabaseItems
+from spinetoolbox.widgets.custom_qwidgets import SelectDatabaseItemsDialog
+from spinetoolbox.widgets.select_database_items import add_check_boxes
 
 
-class MassSelectItemsDialog(QDialog):
+class _SelectDatabases(QWidget):
+    """A widget that shows checkboxes for each database."""
+
+    checked_state_changed = Signal(int)
+
+    def __init__(self, db_maps, checked_states, parent):
+        """
+        Args:
+            db_maps (tuple of DatabaseMappingBase): database maps
+            checked_states (dict, optional): mapping from item name to check state boolean
+            parent (QWidget): parent widget
+        """
+        super().__init__(parent)
+        from ..ui.select_databases import Ui_Form  # pylint: disable=import-outside-toplevel
+
+        self._ui = Ui_Form()
+        self._ui.setupUi(self)
+        self._check_boxes = {db_map: QCheckBox(db_map.codename, self) for db_map in db_maps}
+        add_check_boxes(
+            self._check_boxes,
+            checked_states,
+            self._ui.select_all_button,
+            self._ui.deselect_all_button,
+            self.checked_state_changed,
+            self._ui.databases_grid_layout,
+        )
+
+    def checked_states(self):
+        """Collects the checked states of databases.
+
+        Returns:
+            dict: mapping from database mapping to checked state boolean
+        """
+        return {db_map: box.isChecked() for db_map, box in self._check_boxes.items()}
+
+    def any_checked(self):
+        """Checks if any of the checkboxes is checked.
+
+        Returns:
+            bool: True if any check box is checked, False otherwise
+        """
+        return any(box.isChecked() for box in self._check_boxes.values())
+
+
+class MassSelectItemsDialog(SelectDatabaseItemsDialog):
     """A dialog to query a selection of dbs and items from the user."""
 
     state_storing_requested = Signal(dict)
 
-    def __init__(self, parent, db_mngr, *db_maps, stored_state=None):
+    def __init__(self, parent, db_mngr, *db_maps, stored_state, ok_button_text):
         """
         Args:
             parent (SpineDBEditor): parent widget
             db_mngr (SpineDBManager): database manager
             *db_maps: the dbs to select items from
             stored_state (dict, Optional): widget's previous state
+            ok_button_text (str, optional): alternative label for the OK button
         """
-        from ..ui.select_database_items_dialog import Ui_Dialog  # pylint: disable=import-outside-toplevel
-
-        super().__init__(parent)
-        self.setWindowFlag(Qt.WindowType.WindowContextHelpButtonHint, False)
-        self.setAttribute(Qt.WA_DeleteOnClose)
-        self.db_mngr = db_mngr
-        self.db_maps = db_maps
-        self._database_checked_states = (
-            stored_state["databases"]
-            if stored_state is not None
-            else {db_map.codename: True for db_map in self.db_maps}
+        super().__init__(stored_state["items"] if stored_state is not None else None, ok_button_text, parent)
+        self._db_mngr = db_mngr
+        database_checked_states = (
+            stored_state["databases"] if stored_state is not None else {db_map: True for db_map in db_maps}
         )
-        self._ui = Ui_Dialog()
-        self._ui.setupUi(self)
-        item_state = stored_state["items"] if stored_state is not None else None
-        self._item_check_boxes_widget = SelectDatabaseItems(item_state, self)
-        self._item_check_boxes_widget.checked_state_changed.connect(self._handle_check_box_state_changed)
-        self._ui.root_layout.insertWidget(1, self._item_check_boxes_widget)
-        self._ok_button = self._ui.button_box.button(QDialogButtonBox.StandardButton.Ok)
-        self._db_map_check_boxes = {db_map: QCheckBox(db_map.codename, self) for db_map in self.db_maps}
-        check_boxes = {box.text(): box for box in self._db_map_check_boxes.values()}
-        add_check_boxes(
-            check_boxes,
-            self._database_checked_states,
-            self._ui.select_all_button,
-            self._ui.deselect_all_button,
-            self._handle_check_box_state_changed,
-            self._ui.databases_grid_layout,
-        )
+        self._database_check_boxes_widget = _SelectDatabases(tuple(db_maps), database_checked_states, self)
+        self._database_check_boxes_widget.checked_state_changed.connect(self._handle_check_box_state_changed)
+        self._ui.root_layout.insertWidget(0, self._database_check_boxes_widget)
 
     @Slot(int)
     def _handle_check_box_state_changed(self, _checked):
-        self._ok_button.setEnabled(
-            any(x.isChecked() for x in self._db_map_check_boxes.values())
-            and self._item_check_boxes_widget.any_checked()
-        )
+        """Enables or disables the OK button."""
+        super()._handle_check_box_state_changed(_checked)
+        if self._ui.button_box.button(QDialogButtonBox.StandardButton.Ok).isEnabled():
+            self._ui.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(self._database_check_boxes_widget.any_checked())
 
     def accept(self):
         super().accept()
-        state = {"databases": self._database_checked_states, "items": self._item_check_boxes_widget.checked_states()}
+        state = {
+            "databases": self._database_check_boxes_widget.checked_states(),
+            "items": self._item_check_boxes_widget.checked_states(),
+        }
         self.state_storing_requested.emit(state)
 
 
@@ -89,23 +117,25 @@ class MassRemoveItemsDialog(MassSelectItemsDialog):
             db_maps (DiffDatabaseMapping): the dbs to select items from
             stored_state (dict, Optional): widget's previous state
         """
-        super().__init__(parent, db_mngr, *db_maps, stored_state=stored_state)
+        super().__init__(parent, db_mngr, *db_maps, stored_state=stored_state, ok_button_text="Purge")
         self.setWindowTitle("Purge items")
 
     def accept(self):
         super().accept()
         item_checked_states = self._item_check_boxes_widget.checked_states()
+        database_checked_states = self._database_check_boxes_widget.checked_states()
         db_map_purge_data = {
             db_map: {item_type for item_type, checked in item_checked_states.items() if checked}
-            for db_map, check_box in self._db_map_check_boxes.items()
-            if check_box.isChecked()
+            for db_map, is_checked in database_checked_states.items()
+            if is_checked
         }
-        self.db_mngr.purge_items(db_map_purge_data)
+        self._db_mngr.purge_items(db_map_purge_data)
 
 
 class MassExportItemsDialog(MassSelectItemsDialog):
     """A dialog to let users chose items for JSON export."""
 
+    _warn_checked_non_data_items = False
     data_submitted = Signal(dict)
 
     def __init__(self, parent, db_mngr, *db_maps, stored_state=None):
@@ -116,14 +146,15 @@ class MassExportItemsDialog(MassSelectItemsDialog):
             db_maps (DiffDatabaseMapping): the dbs to select items from
             stored_state (dict, Optional): widget's previous state
         """
-        super().__init__(parent, db_mngr, *db_maps, stored_state=stored_state)
+        super().__init__(parent, db_mngr, *db_maps, stored_state=stored_state, ok_button_text="Export")
         self.setWindowTitle("Export items")
 
     def accept(self):
         super().accept()
         item_checked_states = self._item_check_boxes_widget.checked_states()
         checked_items = [item_type for item_type, checked in item_checked_states.items() if checked]
+        database_checked_states = self._database_check_boxes_widget.checked_states()
         db_map_items_for_export = {
-            db_map: checked_items for db_map, check_box in self._db_map_check_boxes.items() if check_box.isChecked()
+            db_map: checked_items for db_map, is_checked in database_checked_states.items() if is_checked
         }
         self.data_submitted.emit(db_map_items_for_export)

--- a/spinetoolbox/ui/select_database_items.py
+++ b/spinetoolbox/ui/select_database_items.py
@@ -33,7 +33,7 @@ class Ui_Form(object):
     def setupUi(self, Form):
         if not Form.objectName():
             Form.setObjectName(u"Form")
-        Form.resize(400, 300)
+        Form.resize(409, 300)
         self.verticalLayout = QVBoxLayout(Form)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.groupBox = QGroupBox(Form)
@@ -52,15 +52,15 @@ class Ui_Form(object):
 
         self.horizontalLayout.addWidget(self.select_all_button)
 
-        self.deselect_all_button = QPushButton(self.groupBox)
-        self.deselect_all_button.setObjectName(u"deselect_all_button")
-
-        self.horizontalLayout.addWidget(self.deselect_all_button)
-
         self.select_data_items_button = QPushButton(self.groupBox)
         self.select_data_items_button.setObjectName(u"select_data_items_button")
 
         self.horizontalLayout.addWidget(self.select_data_items_button)
+
+        self.select_scenario_items_button = QPushButton(self.groupBox)
+        self.select_scenario_items_button.setObjectName(u"select_scenario_items_button")
+
+        self.horizontalLayout.addWidget(self.select_scenario_items_button)
 
         self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
@@ -68,6 +68,20 @@ class Ui_Form(object):
 
 
         self.verticalLayout_2.addLayout(self.horizontalLayout)
+
+        self.horizontalLayout_2 = QHBoxLayout()
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.deselect_all_button = QPushButton(self.groupBox)
+        self.deselect_all_button.setObjectName(u"deselect_all_button")
+
+        self.horizontalLayout_2.addWidget(self.deselect_all_button)
+
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout_2.addItem(self.horizontalSpacer_2)
+
+
+        self.verticalLayout_2.addLayout(self.horizontalLayout_2)
 
 
         self.verticalLayout.addWidget(self.groupBox)
@@ -82,16 +96,20 @@ class Ui_Form(object):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
         self.groupBox.setTitle(QCoreApplication.translate("Form", u"Items", None))
 #if QT_CONFIG(tooltip)
-        self.select_all_button.setToolTip(QCoreApplication.translate("Form", u"Select all items.", None))
+        self.select_all_button.setToolTip(QCoreApplication.translate("Form", u"Selects all items.", None))
 #endif // QT_CONFIG(tooltip)
         self.select_all_button.setText(QCoreApplication.translate("Form", u"Select all", None))
 #if QT_CONFIG(tooltip)
-        self.deselect_all_button.setToolTip(QCoreApplication.translate("Form", u"Deselect all items.", None))
+        self.select_data_items_button.setToolTip(QCoreApplication.translate("Form", u"Selects the entity and parameter value items.", None))
+#endif // QT_CONFIG(tooltip)
+        self.select_data_items_button.setText(QCoreApplication.translate("Form", u"Select entity and value items", None))
+#if QT_CONFIG(tooltip)
+        self.select_scenario_items_button.setToolTip(QCoreApplication.translate("Form", u"Selects the scenario and alternative items.", None))
+#endif // QT_CONFIG(tooltip)
+        self.select_scenario_items_button.setText(QCoreApplication.translate("Form", u"Select scenario items", None))
+#if QT_CONFIG(tooltip)
+        self.deselect_all_button.setToolTip(QCoreApplication.translate("Form", u"Deselects all items.", None))
 #endif // QT_CONFIG(tooltip)
         self.deselect_all_button.setText(QCoreApplication.translate("Form", u"Deselect all", None))
-#if QT_CONFIG(tooltip)
-        self.select_data_items_button.setToolTip(QCoreApplication.translate("Form", u"Selects entity and parameter data items.", None))
-#endif // QT_CONFIG(tooltip)
-        self.select_data_items_button.setText(QCoreApplication.translate("Form", u"Select data items", None))
     # retranslateUi
 

--- a/spinetoolbox/ui/select_database_items.ui
+++ b/spinetoolbox/ui/select_database_items.ui
@@ -18,7 +18,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>409</width>
     <height>300</height>
    </rect>
   </property>
@@ -40,7 +40,7 @@
         <item>
          <widget class="QPushButton" name="select_all_button">
           <property name="toolTip">
-           <string>Select all items.</string>
+           <string>Selects all items.</string>
           </property>
           <property name="text">
            <string>Select all</string>
@@ -48,9 +48,46 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="select_data_items_button">
+          <property name="toolTip">
+           <string>Selects the entity and parameter value items.</string>
+          </property>
+          <property name="text">
+           <string>Select entity and value items</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="select_scenario_items_button">
+          <property name="toolTip">
+           <string>Selects the scenario and alternative items.</string>
+          </property>
+          <property name="text">
+           <string>Select scenario items</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
          <widget class="QPushButton" name="deselect_all_button">
           <property name="toolTip">
-           <string>Deselect all items.</string>
+           <string>Deselects all items.</string>
           </property>
           <property name="text">
            <string>Deselect all</string>
@@ -58,17 +95,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="select_data_items_button">
-          <property name="toolTip">
-           <string>Selects entity and parameter data items.</string>
-          </property>
-          <property name="text">
-           <string>Select data items</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/spinetoolbox/ui/select_database_items_dialog.py
+++ b/spinetoolbox/ui/select_database_items_dialog.py
@@ -11,7 +11,7 @@
 ######################################################################################################################
 
 ################################################################################
-## Form generated from reading UI file 'purge_settings_dialog.ui'
+## Form generated from reading UI file 'select_database_items_dialog.ui'
 ##
 ## Created by: Qt User Interface Compiler version 6.4.1
 ##
@@ -26,18 +26,25 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
-    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
+    QLabel, QSizePolicy, QSpacerItem, QVBoxLayout,
+    QWidget)
 
 class Ui_Dialog(object):
     def setupUi(self, Dialog):
         if not Dialog.objectName():
             Dialog.setObjectName(u"Dialog")
-        Dialog.resize(400, 300)
+        Dialog.resize(400, 307)
         self.root_layout = QVBoxLayout(Dialog)
         self.root_layout.setObjectName(u"root_layout")
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
         self.root_layout.addItem(self.verticalSpacer)
+
+        self.warning_label = QLabel(Dialog)
+        self.warning_label.setObjectName(u"warning_label")
+        self.warning_label.setStyleSheet(u"QLabel  { color : red; }")
+
+        self.root_layout.addWidget(self.warning_label)
 
         self.button_box = QDialogButtonBox(Dialog)
         self.button_box.setObjectName(u"button_box")
@@ -56,5 +63,6 @@ class Ui_Dialog(object):
 
     def retranslateUi(self, Dialog):
         Dialog.setWindowTitle(QCoreApplication.translate("Dialog", u"Dialog", None))
+        self.warning_label.setText("")
     # retranslateUi
 

--- a/spinetoolbox/ui/select_database_items_dialog.ui
+++ b/spinetoolbox/ui/select_database_items_dialog.ui
@@ -2,8 +2,8 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
-# This file is part of Spine Items.
-# Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
 # any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 # without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
@@ -19,7 +19,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>307</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -38,6 +38,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="warning_label">
+     <property name="styleSheet">
+      <string notr="true">QLabel  { color : red; }</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="button_box">

--- a/spinetoolbox/widgets/link_properties_widget.py
+++ b/spinetoolbox/widgets/link_properties_widget.py
@@ -163,7 +163,8 @@ class LinkPropertiesWidget(PropertiesWidgetBase):
         if self._purge_settings_dialog is not None:
             self._purge_settings_dialog.raise_()
             return
-        self._purge_settings_dialog = PurgeSettingsDialog(self._connection.purge_settings, self._toolbox)
+        self._purge_settings_dialog = PurgeSettingsDialog(self._connection.purge_settings, parent=self._toolbox)
+        self._purge_settings_dialog.setWindowTitle(f"Purge settings for connection {self._connection.link.name}")
         self._purge_settings_dialog.accepted.connect(self._handle_purge_settings_changed)
         self._purge_settings_dialog.destroyed.connect(self._clean_up_purge_settings_dialog)
         self._purge_settings_dialog.show()
@@ -171,7 +172,7 @@ class LinkPropertiesWidget(PropertiesWidgetBase):
     @Slot()
     def _handle_purge_settings_changed(self):
         """Pushes a command that sets new purge settings onto undo stack."""
-        purge_settings = self._purge_settings_dialog.get_purge_settings()
+        purge_settings = self._purge_settings_dialog.get_checked_states()
         if self._connection.purge_settings == purge_settings:
             return
         options = {"purge_settings": purge_settings}

--- a/spinetoolbox/widgets/select_database_items.py
+++ b/spinetoolbox/widgets/select_database_items.py
@@ -63,6 +63,7 @@ class SelectDatabaseItems(QWidget):
         "entity_metadata",
         "parameter_value_metadata",
     )
+    _SCENARIO_ITEMS = ("alternative", "scenario", "scenario_alternative")
 
     def __init__(self, checked_states=None, parent=None):
         """
@@ -76,6 +77,7 @@ class SelectDatabaseItems(QWidget):
         self._ui = Ui_Form()
         self._ui.setupUi(self)
         self._ui.select_data_items_button.clicked.connect(self._select_data_items)
+        self._ui.select_scenario_items_button.clicked.connect(self._select_scenario_items)
         checked_states = (
             checked_states if checked_states is not None else {item: False for item in DatabaseMappingBase.ITEM_TYPES}
         )
@@ -98,15 +100,31 @@ class SelectDatabaseItems(QWidget):
         return {item: box.isChecked() for item, box in self._item_check_boxes.items()}
 
     def any_checked(self):
-        """Checks if any of the check boxes is checked.
+        """Checks if any of the checkboxes is checked.
 
         Returns:
             bool: True if any check box is checked, False otherwise
         """
         return any(box.isChecked() for box in self._item_check_boxes.values())
 
+    def any_structural_item_checked(self):
+        non_structural_items = set(self._DATA_ITEMS + self._SCENARIO_ITEMS)
+        structural_item_check_boxes = (
+            widget for item_type, widget in self._item_check_boxes.items() if item_type not in non_structural_items
+        )
+        for check_box in structural_item_check_boxes:
+            if check_box.isChecked():
+                return True
+        return False
+
     @Slot(bool)
     def _select_data_items(self, _=False):
         """Checks all data items."""
         for item_name in self._DATA_ITEMS:
+            self._item_check_boxes[item_name].setChecked(True)
+
+    @Slot(bool)
+    def _select_scenario_items(self, _=False):
+        """Checks all scenario items."""
+        for item_name in self._SCENARIO_ITEMS:
             self._item_check_boxes[item_name].setChecked(True)

--- a/tests/widgets/test_custom_qwidgets.py
+++ b/tests/widgets/test_custom_qwidgets.py
@@ -17,9 +17,10 @@ Unit tests for the models in ``custom_qwidgets`` module.
 """
 
 import unittest
+from contextlib import contextmanager
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QApplication
-from spinetoolbox.widgets.custom_qwidgets import FilterWidget
+from PySide6.QtWidgets import QApplication, QDialogButtonBox
+from spinetoolbox.widgets.custom_qwidgets import FilterWidget, SelectDatabaseItemsDialog
 from spinetoolbox.mvcmodels.filter_checkbox_list_model import DataToValueFilterCheckboxListModel
 
 
@@ -77,6 +78,33 @@ class TestFilterWidget(unittest.TestCase):
         self._widget.save_state()
         self.assertEqual(self._widget._filter_state, {"bii", "cii"})
         self.assertTrue(self._widget._filter_empty_state)
+
+
+class TestSelectDatabaseItemsDialog(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def test_ok_button_text(self):
+        text = "Do it!"
+        with _select_database_items_dialog(None, text) as dialog:
+            self.assertEqual(dialog._ui.button_box.button(QDialogButtonBox.StandardButton.Ok).text(), text)
+
+    def test_warning_label(self):
+        with _select_database_items_dialog(None, None) as dialog:
+            self.assertEqual(dialog._ui.warning_label.text(), "")
+            dialog._item_check_boxes_widget._item_check_boxes["metadata"].setChecked(True)
+            self.assertEqual(dialog._ui.warning_label.text(), "Warning! Structural data items selected.")
+
+
+@contextmanager
+def _select_database_items_dialog(checked_states, ok_button_text):
+    dialog = SelectDatabaseItemsDialog(checked_states, ok_button_text)
+    try:
+        yield dialog
+    finally:
+        dialog.deleteLater()
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_select_database_items.py
+++ b/tests/widgets/test_select_database_items.py
@@ -1,0 +1,87 @@
+######################################################################################################################
+# Copyright (C) 2017-2023 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for ``select_database_items`` module."""
+import unittest
+from contextlib import contextmanager
+
+from PySide6.QtWidgets import QApplication
+from spinetoolbox.widgets.select_database_items import SelectDatabaseItems
+
+
+class TestSelectDatabaseItems(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def test_restore_previously_checked_states(self):
+        stored_states = {"feature": True, "object": True}
+        with _select_database_items(stored_states) as widget:
+            self.assertEqual(
+                widget.checked_states(),
+                {
+                    "alternative": False,
+                    "entity_group": False,
+                    "entity_metadata": False,
+                    "feature": True,
+                    "list_value": False,
+                    "metadata": False,
+                    "object": True,
+                    "object_class": False,
+                    "parameter_definition": False,
+                    "parameter_value": False,
+                    "parameter_value_list": False,
+                    "parameter_value_metadata": False,
+                    "relationship": False,
+                    "relationship_class": False,
+                    "scenario": False,
+                    "scenario_alternative": False,
+                    "tool": False,
+                    "tool_feature": False,
+                    "tool_feature_method": False,
+                },
+            )
+
+    def test_any_checked(self):
+        with _select_database_items(None) as widget:
+            self.assertFalse(widget.any_checked())
+            widget._item_check_boxes["parameter_value_metadata"].click()
+            self.assertTrue(widget.any_checked())
+
+    def test_any_structural_item_checked(self):
+        stored_states = {
+            "object": True,
+            "relationship": True,
+            "entity_group": True,
+            "parameter_value": True,
+            "entity_metadata": True,
+            "parameter_value_metadata": True,
+            "scenario": True,
+            "alternative": True,
+            "scenario_alternative": True,
+        }
+        with _select_database_items(stored_states) as widget:
+            self.assertFalse(widget.any_structural_item_checked())
+            widget._item_check_boxes["list_value"].click()
+            self.assertTrue(widget.any_structural_item_checked())
+
+
+@contextmanager
+def _select_database_items(checked_states):
+    widget = SelectDatabaseItems(checked_states)
+    try:
+        yield widget
+    finally:
+        widget.deleteLater()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There is now a new button to select scenarios and alternatives in the different purge database dialogs as well as in the export database dialog. The dialog also shows a warning when any "dangerous" items have been selected.

Some code has been refactored to as we had multiple implementations of the same dialog doing almost the same thing.

Resolves #1905

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
