### PR TITLE
Prevent unit tests from modifying app settings

### DIFF
--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -38,8 +38,8 @@ def create_toolboxui():
 def create_project(toolbox, project_dir):
     """Creates a project for the given ToolboxUI."""
     with mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"), mock.patch(
-        "spinetoolbox.widgets.open_project_widget.OpenProjectDialog.update_recents"
-    ):
+        "spinetoolbox.ui_main.QSettings.setValue"
+    ), mock.patch("spinetoolbox.ui_main.QSettings.sync"):
         toolbox.create_project(project_dir)
 
 
@@ -47,9 +47,9 @@ def create_toolboxui_with_project(project_dir):
     """Returns ToolboxUI with a project instance where
     QSettings among others has been mocked."""
     with mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"), mock.patch(
-        "spinetoolbox.ui_main.ToolboxUI.update_recent_projects"
-    ), mock.patch("spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, mock.patch(
-        "spinetoolbox.widgets.open_project_widget.OpenProjectDialog.update_recents"
+        "spinetoolbox.ui_main.QSettings.value"
+    ) as mock_qsettings_value, mock.patch("spinetoolbox.ui_main.QSettings.setValue"), mock.patch(
+        "spinetoolbox.ui_main.QSettings.sync"
     ), mock.patch(
         "spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"
     ), mock.patch(

--- a/tests/mvcmodels/test_FilterCheckboxList.py
+++ b/tests/mvcmodels/test_FilterCheckboxList.py
@@ -148,7 +148,8 @@ class TestFilterCheckboxListModel(unittest.TestCase):
         self.model.set_filter('b')
         self.assertFalse(self.model._add_to_selection)
         self.assertEqual(
-            self.model.data(self.model.index(len(self.model._action_rows) - 1, 0), Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Unchecked
+            self.model.data(self.model.index(len(self.model._action_rows) - 1, 0), Qt.ItemDataRole.CheckStateRole),
+            Qt.CheckState.Unchecked,
         )
 
     def test_selected_when_filtered(self):

--- a/tests/test_toolboxUI.py
+++ b/tests/test_toolboxUI.py
@@ -242,8 +242,8 @@ class TestToolboxUI(unittest.TestCase):
 
     def test_new_project(self):
         self._temp_dir = TemporaryDirectory()
-        with mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"), mock.patch(
-            "spinetoolbox.widgets.open_project_widget.OpenProjectDialog.remove_directory_from_recents"
+        with mock.patch("spinetoolbox.ui_main.QSettings.setValue"), mock.patch(
+            "spinetoolbox.ui_main.QSettings.sync"
         ), mock.patch("PySide6.QtWidgets.QFileDialog.getExistingDirectory") as mock_dir_getter:
             mock_dir_getter.return_value = self._temp_dir.name
             self.toolbox.new_project()
@@ -252,8 +252,8 @@ class TestToolboxUI(unittest.TestCase):
 
     def test_save_project(self):
         self._temp_dir = TemporaryDirectory()
-        with mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"), mock.patch(
-            "spinetoolbox.widgets.open_project_widget.OpenProjectDialog.remove_directory_from_recents"
+        with mock.patch("spinetoolbox.ui_main.QSettings.setValue"), mock.patch(
+            "spinetoolbox.ui_main.QSettings.sync"
         ), mock.patch("PySide6.QtWidgets.QFileDialog.getExistingDirectory") as mock_dir_getter:
             mock_dir_getter.return_value = self._temp_dir.name
             self.toolbox.new_project()

--- a/tests/widgets/test_custom_qwidgets.py
+++ b/tests/widgets/test_custom_qwidgets.py
@@ -53,7 +53,16 @@ class TestFilterWidget(unittest.TestCase):
         self._widget._ui_list.clicked.emit(model.index(1, 0))
         model = self._widget._ui_list.model()
         checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) for row in range(model.rowCount())]
-        self.assertEqual(checked, [Qt.CheckState.Unchecked.value, Qt.CheckState.Unchecked.value, Qt.CheckState.Checked.value, Qt.CheckState.Checked.value, Qt.CheckState.Checked.value])
+        self.assertEqual(
+            checked,
+            [
+                Qt.CheckState.Unchecked.value,
+                Qt.CheckState.Unchecked.value,
+                Qt.CheckState.Checked.value,
+                Qt.CheckState.Checked.value,
+                Qt.CheckState.Checked.value,
+            ],
+        )
         self.assertTrue(self._widget.has_filter())
 
     def test_click_item(self):
@@ -61,7 +70,16 @@ class TestFilterWidget(unittest.TestCase):
         self._widget._ui_list.clicked.emit(model.index(2, 0))
         model = self._widget._ui_list.model()
         checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) for row in range(model.rowCount())]
-        self.assertEqual(checked, [Qt.CheckState.Unchecked.value, Qt.CheckState.Checked.value, Qt.CheckState.Unchecked.value, Qt.CheckState.Checked.value, Qt.CheckState.Checked.value])
+        self.assertEqual(
+            checked,
+            [
+                Qt.CheckState.Unchecked.value,
+                Qt.CheckState.Checked.value,
+                Qt.CheckState.Unchecked.value,
+                Qt.CheckState.Checked.value,
+                Qt.CheckState.Checked.value,
+            ],
+        )
         self.assertTrue(self._widget.has_filter())
 
     def test_click_Select_All_item(self):


### PR DESCRIPTION
We now mock the setValue() and sync() methods of QSettings in unit tests to prevent the tests from modifying Toolbox app settings. Most notably, the initial directory for the Open project dialog should now stay intact.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
