### PR TITLE
Add unit test for ResourceFilterModel

### DIFF
--- a/spinetoolbox/mvcmodels/resource_filter_model.py
+++ b/spinetoolbox/mvcmodels/resource_filter_model.py
@@ -51,9 +51,8 @@ class ResourceFilterModel(QStandardItemModel):
         def append_filter_items(parent_item, filter_names, filter_type, online, online_default):
             for name in filter_names[filter_type]:
                 filter_item = QStandardItem(name)
-                filter_item.setData(
-                    Qt.CheckState.Checked if online.get(name, online_default) else Qt.CheckState.Unchecked,
-                    Qt.ItemDataRole.CheckStateRole,
+                filter_item.setCheckState(
+                    Qt.CheckState.Checked if online.get(name, online_default) else Qt.CheckState.Unchecked
                 )
                 filter_item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsUserCheckable)
                 parent_item.appendRow(filter_item)

--- a/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
@@ -94,7 +94,9 @@ class MassSelectItemsDialog(SelectDatabaseItemsDialog):
         """Enables or disables the OK button."""
         super()._handle_check_box_state_changed(_checked)
         if self._ui.button_box.button(QDialogButtonBox.StandardButton.Ok).isEnabled():
-            self._ui.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(self._database_check_boxes_widget.any_checked())
+            self._ui.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(
+                self._database_check_boxes_widget.any_checked()
+            )
 
     def accept(self):
         super().accept()

--- a/spinetoolbox/widgets/persistent_console_widget.py
+++ b/spinetoolbox/widgets/persistent_console_widget.py
@@ -125,7 +125,11 @@ class _CustomLineEdit(QPlainTextEdit):
             if cursor.position() == self.min_pos:
                 return
             if cursor.positionInBlock() == self.new_line_indent:
-                cursor.movePosition(QTextCursor.MoveOperation.PreviousCharacter, QTextCursor.MoveMode.KeepAnchor, n=self.new_line_indent + 1)
+                cursor.movePosition(
+                    QTextCursor.MoveOperation.PreviousCharacter,
+                    QTextCursor.MoveMode.KeepAnchor,
+                    n=self.new_line_indent + 1,
+                )
                 cursor.removeSelectedText()
                 return
         if ev.key() == Qt.Key_Left:
@@ -137,7 +141,9 @@ class _CustomLineEdit(QPlainTextEdit):
         if ev.key() == Qt.Key_Delete:
             cursor = self.textCursor()
             if cursor.atBlockEnd():
-                cursor.movePosition(QTextCursor.MoveOperation.NextCharacter, QTextCursor.MoveMode.KeepAnchor, n=self.new_line_indent + 1)
+                cursor.movePosition(
+                    QTextCursor.MoveOperation.NextCharacter, QTextCursor.MoveMode.KeepAnchor, n=self.new_line_indent + 1
+                )
                 cursor.removeSelectedText()
                 return
         if self._console.key_press_event(ev):

--- a/tests/mvcmodels/test_resource_filter_model.py
+++ b/tests/mvcmodels/test_resource_filter_model.py
@@ -1,0 +1,92 @@
+######################################################################################################################
+# Copyright (C) 2017-2023 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""Unit tests for the ``resource_filter_model`` module."""
+import unittest
+from unittest import mock
+from contextlib import contextmanager
+
+from PySide6.QtCore import QObject, Qt
+from PySide6.QtGui import QUndoStack
+from PySide6.QtWidgets import QApplication
+
+from spine_engine.project_item.project_item_resource import database_resource
+from spinedb_api.filters.scenario_filter import SCENARIO_FILTER_TYPE
+from spinedb_api.filters.tool_filter import TOOL_FILTER_TYPE
+from spinetoolbox.mvcmodels.resource_filter_model import ResourceFilterModel
+
+
+class TestResourceFilterModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._logger = mock.MagicMock()
+        self._parent = QObject()
+        self._undo_stack = QUndoStack(self._parent)
+
+    def tearDown(self):
+        self._parent.deleteLater()
+
+    def test_setData_changes_checked_state(self):
+        connection = mock.MagicMock()
+        connection.database_resources = [database_resource("Data Store", "sqlite:///db.sqlite", filterable=True)]
+
+        def online_filters(resource_label, resource_type):
+            return {SCENARIO_FILTER_TYPE: {}, TOOL_FILTER_TYPE: {}}[resource_type]
+
+        connection.online_filters.side_effect = online_filters
+        connection.get_scenario_names.return_value = ["my_scenario"]
+        connection.get_tool_names.return_value = ["my_tool"]
+        connection.is_filter_online_by_default = True
+        with resource_filter_model(connection, self._undo_stack, self._logger) as model:
+            model.build_tree()
+            root_index = model.index(0, 0)
+            self.assertEqual(model.rowCount(root_index), 2)
+            scenario_root_index = model.index(0, 0, root_index)
+            self.assertEqual(model.rowCount(scenario_root_index), 2)
+            my_scenario_index = model.index(1, 0, scenario_root_index)
+            self.assertEqual(my_scenario_index.data(), "my_scenario")
+            self.assertEqual(model.data(my_scenario_index, Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Checked.value)
+            self.assertTrue(
+                model.setData(my_scenario_index, Qt.CheckState.Unchecked.value, Qt.ItemDataRole.CheckStateRole)
+            )
+            self.assertEqual(
+                model.data(my_scenario_index, Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Unchecked.value
+            )
+            self.assertTrue(
+                model.setData(my_scenario_index, Qt.CheckState.Checked.value, Qt.ItemDataRole.CheckStateRole)
+            )
+            self.assertEqual(model.data(my_scenario_index, Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Checked.value)
+            tool_root_index = model.index(1, 0, root_index)
+            self.assertEqual(model.rowCount(tool_root_index), 2)
+            my_tool_index = model.index(1, 0, tool_root_index)
+            self.assertEqual(my_tool_index.data(), "my_tool")
+            self.assertEqual(model.data(my_tool_index, Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Checked.value)
+            self.assertTrue(model.setData(my_tool_index, Qt.CheckState.Unchecked.value, Qt.ItemDataRole.CheckStateRole))
+            self.assertEqual(model.data(my_tool_index, Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Unchecked.value)
+            self.assertTrue(model.setData(my_tool_index, Qt.CheckState.Checked.value, Qt.ItemDataRole.CheckStateRole))
+            self.assertEqual(model.data(my_tool_index, Qt.ItemDataRole.CheckStateRole), Qt.CheckState.Checked.value)
+
+
+@contextmanager
+def resource_filter_model(connection, undo_stack, logger):
+    model = ResourceFilterModel(connection, undo_stack, logger)
+    try:
+        yield model
+    finally:
+        model.deleteLater()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The new test should ensure that `ResourceFilterModel.setData()` won't break again as easily.

Fixes #1939 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
