### PR TITLE
Fix decimal separators in parameter value editor.

### DIFF
--- a/spinetoolbox/mvcmodels/array_model.py
+++ b/spinetoolbox/mvcmodels/array_model.py
@@ -131,27 +131,26 @@ class ArrayModel(QAbstractTableModel):
             return None
         row = index.row()
         column = index.column()
-        if role == Qt.ItemDataRole.DisplayRole:
-            if column == 0:
+        if column == 0:
+            if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
                 return row + 1
+            else:
+                return None
+        if role == Qt.ItemDataRole.DisplayRole:
+            if row == len(self._data):
+                return None
+            return str(self._data[row])
+        if role == Qt.ItemDataRole.EditRole:
+            if row == len(self._data):
+                return self._data_type()
+            return self._data[row]
+        if role == Qt.ItemDataRole.ToolTipRole:
             if row == len(self._data):
                 return None
             element = self._data[row]
-            if isinstance(element, (float, str)):
-                return element
             return str(element)
-        if column == 1:
-            if role == Qt.ItemDataRole.EditRole:
-                if row == len(self._data):
-                    return self._data_type()
-                return self._data[row]
-            if role == Qt.ItemDataRole.ToolTipRole:
-                if row == len(self._data):
-                    return None
-                element = self._data[row]
-                return str(element)
-            if role == Qt.ItemDataRole.BackgroundRole and row == len(self._data):
-                return EXPANSE_COLOR
+        if role == Qt.ItemDataRole.BackgroundRole and row == len(self._data):
+            return EXPANSE_COLOR
         return None
 
     def flags(self, index):

--- a/spinetoolbox/mvcmodels/indexed_value_table_model.py
+++ b/spinetoolbox/mvcmodels/indexed_value_table_model.py
@@ -46,7 +46,8 @@ class IndexedValueTableModel(QAbstractTableModel):
                 return None
             if index.column() == 0:
                 return str(self._value.indexes[index.row()])
-            return float(self._value.values[index.row()])
+            value = self._value.values[index.row()]
+            return str(value) if role == Qt.ItemDataRole.DisplayRole else value
         if role == Qt.ItemDataRole.BackgroundRole:
             if index.row() == len(self._value):
                 return EXPANSE_COLOR

--- a/spinetoolbox/mvcmodels/map_model.py
+++ b/spinetoolbox/mvcmodels/map_model.py
@@ -154,18 +154,16 @@ class MapModel(QAbstractTableModel):
             if self._is_in_expanse(row_index, column_index):
                 return ""
             data = self._rows[row_index][column_index]
+            if isinstance(data, (float, int, Duration)):
+                return str(data)
             if isinstance(data, DateTime):
                 return str(data.value)
-            if isinstance(data, Duration):
-                return str(data)
             if isinstance(data, TimeSeries):
                 return "Time series"
             if isinstance(data, TimePattern):
                 return "Time pattern"
             if isinstance(data, Array):
                 return "Array"
-            if isinstance(data, Number):
-                return float(data)
             if data is None:
                 return "None"
             if data is empty:

--- a/tests/mvcmodels/test_ArrayModel.py
+++ b/tests/mvcmodels/test_ArrayModel.py
@@ -58,7 +58,7 @@ class TestArrayModel(unittest.TestCase):
         self.assertTrue(model.insertRows(0, 2))
         self.assertEqual(model.rowCount(), 3)
         expected_index = [1, 2, 3]
-        expected_data = [0.0, 0.0, None]
+        expected_data = ["0.0", "0.0", None]
         for row, (index, data) in enumerate(zip(expected_index, expected_data)):
             self.assertEqual(model.index(row, 0).data(), index)
             self.assertEqual(model.index(row, 1).data(), data)
@@ -81,14 +81,14 @@ class TestArrayModel(unittest.TestCase):
         model.batch_set_data([model.index(0, 0)], ["2.3"])
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.index(0, 0).data(), 1)
-        self.assertEqual(model.index(0, 1).data(), 2.3)
+        self.assertEqual(model.index(0, 1).data(), "2.3")
 
     def test_batch_set_data_on_last_row_extends_table(self):
         model = ArrayModel(self._parent)
         model.reset(Array([5.0]))
         model.batch_set_data([model.index(1, 0)], ["2.3"])
         self.assertEqual(model.rowCount(), 3)
-        self.assertEqual(model.index(0, 1).data(), 5.0)
+        self.assertEqual(model.index(0, 1).data(), "5.0")
 
     def test_set_array_type_converts_existing_data(self):
         model = ArrayModel(self._parent)
@@ -102,15 +102,15 @@ class TestArrayModel(unittest.TestCase):
         model.reset(Array([5.0]))
         self.assertTrue(model.setData(model.index(0, 0), 2.3))
         self.assertEqual(model.rowCount(), 2)
-        self.assertEqual(model.index(0, 1).data(), 2.3)
+        self.assertEqual(model.index(0, 1).data(), "2.3")
 
     def test_setData_on_last_row_extends_array(self):
         model = ArrayModel(self._parent)
         model.reset(Array([5.0]))
         self.assertTrue(model.setData(model.index(1, 0), 2.3))
         self.assertEqual(model.rowCount(), 3)
-        self.assertEqual(model.index(0, 1).data(), 5.0)
-        self.assertEqual(model.index(1, 1).data(), 2.3)
+        self.assertEqual(model.index(0, 1).data(), "5.0")
+        self.assertEqual(model.index(1, 1).data(), "2.3")
 
     def test_index_type_is_in_header(self):
         model = ArrayModel(self._parent)

--- a/tests/mvcmodels/test_IndexedValueTableModel.py
+++ b/tests/mvcmodels/test_IndexedValueTableModel.py
@@ -44,7 +44,7 @@ class TestIndexedValueTableModel(unittest.TestCase):
             QApplication()
 
     def setUp(self):
-        self._value = MockValue(['a', 'b', 'c'], [7, 5, 3])
+        self._value = MockValue(["a", "b", "c"], [7, 5, 3])
         self._model = IndexedValueTableModel(self._value, None)
 
     def test_column_count_is_2(self):
@@ -52,34 +52,34 @@ class TestIndexedValueTableModel(unittest.TestCase):
 
     def test_data(self):
         model_index = self._model.index(0, 0)
-        self.assertEqual(self._model.data(model_index), 'a')
+        self.assertEqual(self._model.data(model_index), "a")
         model_index = self._model.index(2, 0)
-        self.assertEqual(self._model.data(model_index), 'c')
+        self.assertEqual(self._model.data(model_index), "c")
         model_index = self._model.index(0, 1)
-        self.assertEqual(self._model.data(model_index), 7)
+        self.assertEqual(self._model.data(model_index), "7")
         model_index = self._model.index(2, 1)
-        self.assertEqual(self._model.data(model_index), 3)
+        self.assertEqual(self._model.data(model_index), "3")
 
     def test_horizontal_header_data(self):
-        self.assertEqual(self._model.headerData(0), 'idx')
-        self.assertEqual(self._model.headerData(1), 'Value')
+        self.assertEqual(self._model.headerData(0), "idx")
+        self.assertEqual(self._model.headerData(1), "Value")
 
     def test_set_horizontal_header_data(self):
         self._model.setHeaderData(0, Qt.Orientation.Horizontal, "new idx")
-        self.assertEqual(self._model.headerData(0), 'new idx')
+        self.assertEqual(self._model.headerData(0), "new idx")
 
     def test_vertical_header_data_is_row_number(self):
         for row in range(3):
             self.assertEqual(self._model.headerData(row, orientation=Qt.Orientation.Vertical), row + 1)
 
     def test_reset(self):
-        new_value = MockValue(['d'], [1])
+        new_value = MockValue(["d"], [1])
         self._model.reset(new_value)
         self.assertEqual(self._model.rowCount(), 2)
         model_index = self._model.index(0, 0)
-        self.assertEqual(self._model.data(model_index), 'd')
+        self.assertEqual(self._model.data(model_index), "d")
         model_index = self._model.index(0, 1)
-        self.assertEqual(self._model.data(model_index), 1)
+        self.assertEqual(self._model.data(model_index), "1")
 
     def test_row_count(self):
         self.assertEqual(self._model.rowCount(), 4)

--- a/tests/mvcmodels/test_MapModel.py
+++ b/tests/mvcmodels/test_MapModel.py
@@ -37,9 +37,9 @@ class TestMapModel(unittest.TestCase):
         model.append_column()
         self.assertEqual(model.columnCount(), 5)
         expected_table = [
-            ["A", -1.1, "", "", ""],
-            ["B", "a", 1.1, "", ""],
-            ["B", "b", 2.2, "", ""],
+            ["A", "-1.1", "", "", ""],
+            ["B", "a", "1.1", "", ""],
+            ["B", "b", "2.2", "", ""],
             ["", "", "", "", ""],
         ]
         for y, row in enumerate(expected_table):
@@ -70,7 +70,7 @@ class TestMapModel(unittest.TestCase):
         model.convert_leaf_maps()
         self.assertEqual(model.columnCount(), 3)
         self.assertEqual(model.rowCount(), 2)
-        self.assertEqual(model.index(0, 0).data(), 1.0)
+        self.assertEqual(model.index(0, 0).data(), str(1.0))
         self.assertEqual(model.index(0, 1).data(), "Time series")
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 0).data(), "")
@@ -83,8 +83,8 @@ class TestMapModel(unittest.TestCase):
         self.assertEqual(model.index(0, 0).data(), "a")
         self.assertEqual(model.index(1, 0).data(), "b")
         self.assertEqual(model.index(2, 0).data(), "")
-        self.assertEqual(model.index(0, 1).data(), 1.1)
-        self.assertEqual(model.index(1, 1).data(), 2.2)
+        self.assertEqual(model.index(0, 1).data(), str(1.1))
+        self.assertEqual(model.index(1, 1).data(), str(2.2))
         self.assertEqual(model.index(2, 1).data(), "")
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 2).data(), "")
@@ -127,13 +127,13 @@ class TestMapModel(unittest.TestCase):
         self.assertEqual(model.index(1, 0).data(), "B")
         self.assertEqual(model.index(2, 0).data(), "B")
         self.assertEqual(model.index(3, 0).data(), "")
-        self.assertEqual(model.index(0, 1).data(), -1.1)
+        self.assertEqual(model.index(0, 1).data(), str(-1.1))
         self.assertEqual(model.index(1, 1).data(), "a")
         self.assertEqual(model.index(2, 1).data(), "b")
         self.assertEqual(model.index(3, 1).data(), "")
         self.assertEqual(model.index(0, 2).data(), "")
-        self.assertEqual(model.index(1, 2).data(), 1.1)
-        self.assertEqual(model.index(2, 2).data(), 2.2)
+        self.assertEqual(model.index(1, 2).data(), str(1.1))
+        self.assertEqual(model.index(2, 2).data(), str(2.2))
         self.assertEqual(model.index(3, 2).data(), "")
         self.assertEqual(model.index(0, 3).data(), "")
         self.assertEqual(model.index(1, 3).data(), "")
@@ -194,7 +194,7 @@ class TestMapModel(unittest.TestCase):
         nested_map = Map(["A"], [leaf_map])
         root_map = Map(["root"], [nested_map])
         model = MapModel(root_map, self._parent)
-        expected_data = [["root", "A", "a", 1.1], ["root", "A", "b", 2.2]]
+        expected_data = [["root", "A", "a", str(1.1)], ["root", "A", "b", str(2.2)]]
         for row in range(2):
             for column in range(4):
                 index = model.index(row, column)
@@ -248,7 +248,7 @@ class TestMapModel(unittest.TestCase):
         self.assertEqual(model.index(0, 1).data(), "")
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 0).data(), "a")
-        self.assertEqual(model.index(1, 1).data(), 1.1)
+        self.assertEqual(model.index(1, 1).data(), str(1.1))
         self.assertEqual(model.index(1, 2).data(), "")
         self.assertEqual(model.index(2, 0).data(), "")
         self.assertEqual(model.index(2, 1).data(), "")
@@ -260,10 +260,10 @@ class TestMapModel(unittest.TestCase):
         self.assertTrue(model.insertRows(1, 1))
         self.assertEqual(model.rowCount(), 3)
         self.assertEqual(model.index(0, 0).data(), "a")
-        self.assertEqual(model.index(0, 1).data(), 1.1)
+        self.assertEqual(model.index(0, 1).data(), str(1.1))
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 0).data(), "a")
-        self.assertEqual(model.index(1, 1).data(), 1.1)
+        self.assertEqual(model.index(1, 1).data(), str(1.1))
         self.assertEqual(model.index(1, 2).data(), "")
 
     def test_insertRows_to_middle_of_nested_map(self):
@@ -272,7 +272,12 @@ class TestMapModel(unittest.TestCase):
         model = MapModel(map_value, self._parent)
         self.assertTrue(model.insertRows(1, 1))
         self.assertEqual(model.rowCount(), 4)
-        expected_table = [["A", "a", 1.1, ""], ["A", "a", 1.1, ""], ["A", "b", 2.2, ""], ["", "", "", ""]]
+        expected_table = [
+            ["A", "a", str(1.1), ""],
+            ["A", "a", str(1.1), ""],
+            ["A", "b", str(2.2), ""],
+            ["", "", "", ""],
+        ]
         for y, row in enumerate(expected_table):
             for x, expected in enumerate(row):
                 self.assertEqual(model.index(y, x).data(), expected)
@@ -307,7 +312,7 @@ class TestMapModel(unittest.TestCase):
         self.assertTrue(model.removeRows(0, 1))
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.index(0, 0).data(), "b")
-        self.assertEqual(model.index(0, 1).data(), 2.2)
+        self.assertEqual(model.index(0, 1).data(), str(2.2))
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 0).data(), "")
         self.assertEqual(model.index(1, 1).data(), "")
@@ -319,7 +324,7 @@ class TestMapModel(unittest.TestCase):
         self.assertTrue(model.removeRows(0, 1))
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.index(0, 0).data(), "b")
-        self.assertEqual(model.index(0, 1).data(), 2.2)
+        self.assertEqual(model.index(0, 1).data(), str(2.2))
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 0).data(), "")
         self.assertEqual(model.index(1, 1).data(), "")
@@ -331,7 +336,7 @@ class TestMapModel(unittest.TestCase):
         model = MapModel(map_value, self._parent)
         self.assertTrue(model.removeRows(1, 1))
         self.assertEqual(model.rowCount(), 3)
-        expected_table = [["A", "a", 1.1, ""], ["A", "c", 3.3, ""], ["", "", "", ""]]
+        expected_table = [["A", "a", str(1.1), ""], ["A", "c", str(3.3), ""], ["", "", "", ""]]
         for y, row in enumerate(expected_table):
             for x, expected in enumerate(row):
                 self.assertEqual(model.index(y, x).data(), expected)
@@ -365,10 +370,10 @@ class TestMapModel(unittest.TestCase):
         self.assertEqual(model.rowCount(), 3)
         self.assertEqual(model.columnCount(), 3)
         self.assertEqual(model.index(0, 0).data(), "1M")
-        self.assertEqual(model.index(0, 1).data(), 1.1)
+        self.assertEqual(model.index(0, 1).data(), str(1.1))
         self.assertEqual(model.index(0, 2).data(), "")
         self.assertEqual(model.index(1, 0).data(), "1M")
-        self.assertEqual(model.index(1, 1).data(), 2.2)
+        self.assertEqual(model.index(1, 1).data(), str(2.2))
         self.assertEqual(model.index(1, 2).data(), "")
         self.assertEqual(model.index(2, 0).data(), "")
         self.assertEqual(model.index(2, 1).data(), "")
@@ -393,7 +398,7 @@ class TestMapModel(unittest.TestCase):
         self.assertEqual(model.rowCount(), 1 + 1)
         self.assertEqual(model.columnCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "idx")
-        self.assertEqual(model.index(0, 1).data(), 0.0)
+        self.assertEqual(model.index(0, 1).data(), str(0.0))
 
     def test_init_converts_numpy_strings_to_real_strings(self):
         map_value = Map(["a"], [1.1])
@@ -559,7 +564,7 @@ class TestMapModel(unittest.TestCase):
         self.assertEqual(model.headerData(3, Qt.Orientation.Horizontal), None)
         self.assertEqual(model.index(0, 0).data(), "")
         self.assertEqual(model.index(0, 1).data(), "A")
-        self.assertEqual(model.index(0, 2).data(), 1.0)
+        self.assertEqual(model.index(0, 2).data(), str(1.0))
         self.assertEqual(model.index(0, 3).data(), "")
         self.assertEqual(model.index(1, 0).data(), "")
         self.assertEqual(model.index(1, 1).data(), "")

--- a/tests/mvcmodels/test_TimeSeriesModelFixedResolution.py
+++ b/tests/mvcmodels/test_TimeSeriesModelFixedResolution.py
@@ -41,7 +41,8 @@ class TestTimeSeriesModelFixedStep(unittest.TestCase):
             model_index = model.index(0, 0)
             self.assertEqual(model.data(model_index, role), "2019-07-05T12:00:00")
             model_index = model.index(0, 1)
-            self.assertEqual(model.data(model_index, role), -5.0)
+            expected = str(-5.0) if role == Qt.ItemDataRole.DisplayRole else -5.0
+            self.assertEqual(model.data(model_index, role), expected)
         model.deleteLater()
 
     def test_flags(self):

--- a/tests/mvcmodels/test_TimeSeriesModelVariableResolution.py
+++ b/tests/mvcmodels/test_TimeSeriesModelVariableResolution.py
@@ -44,7 +44,8 @@ class TestTimeSeriesModelFixedStep(unittest.TestCase):
             model_index = model.index(0, 0)
             self.assertEqual(model.data(model_index, role), "2019-07-05T12:00:00")
             model_index = model.index(0, 1)
-            self.assertEqual(model.data(model_index, role), -5.0)
+            expected = str(-5.0) if role == Qt.ItemDataRole.DisplayRole else -5.0
+            self.assertEqual(model.data(model_index, role), expected)
 
     def test_flags(self):
         model = TimeSeriesModelVariableResolution(

--- a/tests/widgets/test_ArrayTableView.py
+++ b/tests/widgets/test_ArrayTableView.py
@@ -87,7 +87,7 @@ class TestArrayTableView(unittest.TestCase):
         clip = StringIO(QApplication.clipboard().text())
         array = [row for row in csv.reader(clip, delimiter='\t')]
         with system_lc_numeric():
-            self.assertEqual(array, [["1"], [locale.str(5.5)]])
+            self.assertEqual(array, [["1", locale.str(5.5)]])
         table_view.deleteLater()
 
     def test_paste_non_numeric_to_empty_table(self):

--- a/tests/widgets/test_indexed_value_table_context_menu.py
+++ b/tests/widgets/test_indexed_value_table_context_menu.py
@@ -50,8 +50,8 @@ class TestArrayTableContextMenu(unittest.TestCase):
         self.assertIsNotNone(insert_action)
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
-        self.assertEqual(model.index(0, 1).data(), -1.0)
-        self.assertEqual(model.index(1, 1).data(), 0.0)
+        self.assertEqual(model.index(0, 1).data(), str(-1.0))
+        self.assertEqual(model.index(1, 1).data(), str(0.0))
         editor.deleteLater()
 
     def test_insert_row_before(self):
@@ -66,8 +66,8 @@ class TestArrayTableContextMenu(unittest.TestCase):
         self.assertIsNotNone(insert_action)
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
-        self.assertEqual(model.index(0, 1).data(), 0.0)
-        self.assertEqual(model.index(1, 1).data(), -1.0)
+        self.assertEqual(model.index(0, 1).data(), str(0.0))
+        self.assertEqual(model.index(1, 1).data(), str(-1.0))
         editor.deleteLater()
 
     def test_remove_rows(self):
@@ -82,7 +82,7 @@ class TestArrayTableContextMenu(unittest.TestCase):
         self.assertIsNotNone(remove_action)
         remove_action.trigger()
         self.assertEqual(model.rowCount(), 1 + 1)
-        self.assertEqual(model.index(0, 1).data(), -2.0)
+        self.assertEqual(model.index(0, 1).data(), str(-2.0))
         editor.deleteLater()
 
     def test_show_value_editor(self):
@@ -119,9 +119,9 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "D1-2")
-        self.assertEqual(model.index(0, 1).data(), -1.1)
+        self.assertEqual(model.index(0, 1).data(), str(-1.1))
         self.assertEqual(model.index(1, 0).data(), "")
-        self.assertEqual(model.index(1, 1).data(), 0.0)
+        self.assertEqual(model.index(1, 1).data(), str(0.0))
         editor.deleteLater()
 
     def test_insert_row_after_with_time_series_fixed_resolution_editor(self):
@@ -137,9 +137,9 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "2020-11-11T14:25:00")
-        self.assertEqual(model.index(0, 1).data(), -1.1)
+        self.assertEqual(model.index(0, 1).data(), str(-1.1))
         self.assertEqual(model.index(1, 0).data(), "2020-11-12T14:25:00")
-        self.assertEqual(model.index(1, 1).data(), 0.0)
+        self.assertEqual(model.index(1, 1).data(), str(0.0))
         editor.deleteLater()
 
     def test_insert_row_after_with_time_series_variable_resolution_editor(self):
@@ -155,9 +155,9 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "2020-11-11T14:25:00")
-        self.assertEqual(model.index(0, 1).data(), -1.1)
+        self.assertEqual(model.index(0, 1).data(), str(-1.1))
         self.assertEqual(model.index(1, 0).data(), "2020-11-11T15:25:00")
-        self.assertEqual(model.index(1, 1).data(), 0.0)
+        self.assertEqual(model.index(1, 1).data(), str(0.0))
         editor.deleteLater()
 
     def test_insert_row_before_with_time_pattern_editor(self):
@@ -173,9 +173,9 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "")
-        self.assertEqual(model.index(0, 1).data(), 0.0)
+        self.assertEqual(model.index(0, 1).data(), str(0.0))
         self.assertEqual(model.index(1, 0).data(), "D1-2")
-        self.assertEqual(model.index(1, 1).data(), -1.1)
+        self.assertEqual(model.index(1, 1).data(), str(-1.1))
         editor.deleteLater()
 
     def test_insert_row_before_with_time_series_fixed_resolution_editor(self):
@@ -191,9 +191,9 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "2020-11-11T14:25:00")
-        self.assertEqual(model.index(0, 1).data(), 0.0)
+        self.assertEqual(model.index(0, 1).data(), str(0.0))
         self.assertEqual(model.index(1, 0).data(), "2020-11-12T14:25:00")
-        self.assertEqual(model.index(1, 1).data(), -1.1)
+        self.assertEqual(model.index(1, 1).data(), str(-1.1))
         editor.deleteLater()
 
     def test_insert_row_before_with_time_series_variable_resolution_editor(self):
@@ -209,9 +209,9 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "2020-11-11T13:25:00")
-        self.assertEqual(model.index(0, 1).data(), 0.0)
+        self.assertEqual(model.index(0, 1).data(), str(0.0))
         self.assertEqual(model.index(1, 0).data(), "2020-11-11T14:25:00")
-        self.assertEqual(model.index(1, 1).data(), -1.1)
+        self.assertEqual(model.index(1, 1).data(), str(-1.1))
         editor.deleteLater()
 
     def test_remove_rows_with_time_pattern_editor(self):
@@ -227,7 +227,7 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         remove_action.trigger()
         self.assertEqual(model.rowCount(), 1 + 1)
         self.assertEqual(model.index(0, 0).data(), "D3-4")
-        self.assertEqual(model.index(0, 1).data(), -2.2)
+        self.assertEqual(model.index(0, 1).data(), str(-2.2))
         editor.deleteLater()
 
     def test_remove_rows_with_time_series_fixed_resolution_editor(self):
@@ -243,7 +243,7 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         remove_action.trigger()
         self.assertEqual(model.rowCount(), 1 + 1)
         self.assertEqual(model.index(0, 0).data(), "2020-11-11T14:25:00")
-        self.assertEqual(model.index(0, 1).data(), -2.2)
+        self.assertEqual(model.index(0, 1).data(), str(-2.2))
         editor.deleteLater()
 
     def test_remove_rows_with_time_series_variable_resolution_editor(self):
@@ -261,7 +261,7 @@ class TestIndexedValueTableContextMenu(unittest.TestCase):
         remove_action.trigger()
         self.assertEqual(model.rowCount(), 1 + 1)
         self.assertEqual(model.index(0, 0).data(), "2020-11-12T14:25:00")
-        self.assertEqual(model.index(0, 1).data(), -2.2)
+        self.assertEqual(model.index(0, 1).data(), str(-2.2))
         editor.deleteLater()
 
 
@@ -285,7 +285,7 @@ class TestMapTableContextMenu(unittest.TestCase):
         self.assertEqual(model.columnCount(), 3 + 1)
         self.assertEqual(model.index(0, 0).data(), "a")
         self.assertEqual(model.index(0, 1).data(), "")
-        self.assertEqual(model.index(0, 2).data(), -1.0)
+        self.assertEqual(model.index(0, 2).data(), str(-1.0))
         editor.deleteLater()
 
     def test_insert_column_before(self):
@@ -302,7 +302,7 @@ class TestMapTableContextMenu(unittest.TestCase):
         self.assertEqual(model.columnCount(), 3 + 1)
         self.assertEqual(model.index(0, 0).data(), "")
         self.assertEqual(model.index(0, 1).data(), "a")
-        self.assertEqual(model.index(0, 2).data(), -1.0)
+        self.assertEqual(model.index(0, 2).data(), str(-1.0))
         editor.deleteLater()
 
     def test_insert_row_after(self):
@@ -318,9 +318,9 @@ class TestMapTableContextMenu(unittest.TestCase):
         insert_action.trigger()
         self.assertEqual(model.rowCount(), 2 + 1)
         self.assertEqual(model.index(0, 0).data(), "a")
-        self.assertEqual(model.index(0, 1).data(), -1.0)
+        self.assertEqual(model.index(0, 1).data(), str(-1.0))
         self.assertEqual(model.index(1, 0).data(), "a")
-        self.assertEqual(model.index(1, 1).data(), -1.0)
+        self.assertEqual(model.index(1, 1).data(), str(-1.0))
         editor.deleteLater()
 
     def test_insert_row_before(self):
@@ -338,7 +338,7 @@ class TestMapTableContextMenu(unittest.TestCase):
         self.assertEqual(model.index(0, 0).data(), "")
         self.assertEqual(model.index(0, 1).data(), "")
         self.assertEqual(model.index(1, 0).data(), "a")
-        self.assertEqual(model.index(1, 1).data(), -1.0)
+        self.assertEqual(model.index(1, 1).data(), str(-1.0))
         editor.deleteLater()
 
     def test_remove_columns(self):
@@ -353,7 +353,7 @@ class TestMapTableContextMenu(unittest.TestCase):
         self.assertIsNotNone(insert_action)
         insert_action.trigger()
         self.assertEqual(model.columnCount(), 1 + 1)
-        self.assertEqual(model.index(0, 0).data(), -1.0)
+        self.assertEqual(model.index(0, 0).data(), str(-1.0))
         editor.deleteLater()
 
     def test_remove_rows(self):


### PR DESCRIPTION
This makes parameter value editors always use dots as decimal separators.

Fixes #1765

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
