### PR TITLE
Simplify project saving settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ projects/
 work/
 .coverage
 htmlcov/
+src/

--- a/spinetoolbox/ui/settings.py
+++ b/spinetoolbox/ui/settings.py
@@ -129,12 +129,6 @@ class Ui_SettingsForm(object):
         self.gridLayout = QGridLayout(self.groupBox_general)
         self.gridLayout.setSpacing(6)
         self.gridLayout.setObjectName(u"gridLayout")
-        self.checkBox_exit_prompt = QCheckBox(self.groupBox_general)
-        self.checkBox_exit_prompt.setObjectName(u"checkBox_exit_prompt")
-        self.checkBox_exit_prompt.setTristate(False)
-
-        self.gridLayout.addWidget(self.checkBox_exit_prompt, 1, 0, 1, 1)
-
         self.horizontalLayout_6 = QHBoxLayout()
         self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
         self.label = QLabel(self.groupBox_general)
@@ -165,6 +159,40 @@ class Ui_SettingsForm(object):
 
         self.gridLayout.addLayout(self.horizontalLayout_6, 13, 0, 1, 1)
 
+        self.formLayout_2 = QFormLayout()
+        self.formLayout_2.setObjectName(u"formLayout_2")
+        self.label_2 = QLabel(self.groupBox_general)
+        self.label_2.setObjectName(u"label_2")
+
+        self.formLayout_2.setWidget(0, QFormLayout.LabelRole, self.label_2)
+
+        self.project_save_options_combo_box = QComboBox(self.groupBox_general)
+        self.project_save_options_combo_box.addItem("")
+        self.project_save_options_combo_box.addItem("")
+        self.project_save_options_combo_box.setObjectName(u"project_save_options_combo_box")
+
+        self.formLayout_2.setWidget(0, QFormLayout.FieldRole, self.project_save_options_combo_box)
+
+
+        self.gridLayout.addLayout(self.formLayout_2, 5, 0, 1, 1)
+
+        self.checkBox_custom_open_project_dialog = QCheckBox(self.groupBox_general)
+        self.checkBox_custom_open_project_dialog.setObjectName(u"checkBox_custom_open_project_dialog")
+        self.checkBox_custom_open_project_dialog.setChecked(False)
+
+        self.gridLayout.addWidget(self.checkBox_custom_open_project_dialog, 1, 0, 1, 1)
+
+        self.checkBox_delete_data = QCheckBox(self.groupBox_general)
+        self.checkBox_delete_data.setObjectName(u"checkBox_delete_data")
+
+        self.gridLayout.addWidget(self.checkBox_delete_data, 2, 0, 1, 1)
+
+        self.checkBox_exit_prompt = QCheckBox(self.groupBox_general)
+        self.checkBox_exit_prompt.setObjectName(u"checkBox_exit_prompt")
+        self.checkBox_exit_prompt.setTristate(False)
+
+        self.gridLayout.addWidget(self.checkBox_exit_prompt, 4, 0, 1, 1)
+
         self.checkBox_open_previous_project = QCheckBox(self.groupBox_general)
         self.checkBox_open_previous_project.setObjectName(u"checkBox_open_previous_project")
         sizePolicy5 = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
@@ -173,24 +201,7 @@ class Ui_SettingsForm(object):
         sizePolicy5.setHeightForWidth(self.checkBox_open_previous_project.sizePolicy().hasHeightForWidth())
         self.checkBox_open_previous_project.setSizePolicy(sizePolicy5)
 
-        self.gridLayout.addWidget(self.checkBox_open_previous_project, 4, 0, 1, 1)
-
-        self.checkBox_delete_data = QCheckBox(self.groupBox_general)
-        self.checkBox_delete_data.setObjectName(u"checkBox_delete_data")
-
-        self.gridLayout.addWidget(self.checkBox_delete_data, 3, 0, 1, 1)
-
-        self.checkBox_custom_open_project_dialog = QCheckBox(self.groupBox_general)
-        self.checkBox_custom_open_project_dialog.setObjectName(u"checkBox_custom_open_project_dialog")
-        self.checkBox_custom_open_project_dialog.setChecked(False)
-
-        self.gridLayout.addWidget(self.checkBox_custom_open_project_dialog, 2, 0, 1, 1)
-
-        self.checkBox_save_project_before_closing = QCheckBox(self.groupBox_general)
-        self.checkBox_save_project_before_closing.setObjectName(u"checkBox_save_project_before_closing")
-        self.checkBox_save_project_before_closing.setTristate(True)
-
-        self.gridLayout.addWidget(self.checkBox_save_project_before_closing, 5, 0, 1, 1)
+        self.gridLayout.addWidget(self.checkBox_open_previous_project, 3, 0, 1, 1)
 
 
         self.verticalLayout_6.addWidget(self.groupBox_general)
@@ -884,11 +895,9 @@ class Ui_SettingsForm(object):
 
         self.verticalLayout_7.addWidget(self.buttonBox)
 
-        QWidget.setTabOrder(self.checkBox_exit_prompt, self.checkBox_custom_open_project_dialog)
         QWidget.setTabOrder(self.checkBox_custom_open_project_dialog, self.checkBox_delete_data)
         QWidget.setTabOrder(self.checkBox_delete_data, self.checkBox_open_previous_project)
-        QWidget.setTabOrder(self.checkBox_open_previous_project, self.checkBox_save_project_before_closing)
-        QWidget.setTabOrder(self.checkBox_save_project_before_closing, self.checkBox_datetime)
+        QWidget.setTabOrder(self.checkBox_open_previous_project, self.checkBox_datetime)
         QWidget.setTabOrder(self.checkBox_datetime, self.checkBox_color_toolbar_icons)
         QWidget.setTabOrder(self.checkBox_color_toolbar_icons, self.checkBox_use_smooth_zoom)
         QWidget.setTabOrder(self.checkBox_use_smooth_zoom, self.checkBox_use_curved_links)
@@ -975,10 +984,6 @@ class Ui_SettingsForm(object):
         self.listWidget.setSortingEnabled(__sortingEnabled)
 
         self.groupBox_general.setTitle(QCoreApplication.translate("SettingsForm", u"Main", None))
-#if QT_CONFIG(tooltip)
-        self.checkBox_exit_prompt.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Checking this shows the 'confirm exit' question box when quitting the app</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.checkBox_exit_prompt.setText(QCoreApplication.translate("SettingsForm", u"Confirm exit", None))
         self.label.setText(QCoreApplication.translate("SettingsForm", u"Work directory", None))
 #if QT_CONFIG(tooltip)
         self.lineEdit_work_dir.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Work directory location. Leave empty to use default (\\work).</p></body></html>", None))
@@ -987,22 +992,26 @@ class Ui_SettingsForm(object):
 #if QT_CONFIG(tooltip)
         self.toolButton_browse_work.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Pick Work directory with file browser</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(tooltip)
-        self.checkBox_open_previous_project.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>If checked, application opens the project at startup that was open the last time the application was quit</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.checkBox_open_previous_project.setText(QCoreApplication.translate("SettingsForm", u"Open previous project at startup", None))
-#if QT_CONFIG(tooltip)
-        self.checkBox_delete_data.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Check this box to delete project item's data when a project item is removed from project. This means, that the project item directory and its contens will be deleted from your HD.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.checkBox_delete_data.setText(QCoreApplication.translate("SettingsForm", u"Delete data when project item is removed from project", None))
+        self.label_2.setText(QCoreApplication.translate("SettingsForm", u"When there are unsaved changes:", None))
+        self.project_save_options_combo_box.setItemText(0, QCoreApplication.translate("SettingsForm", u"Ask what to do", None))
+        self.project_save_options_combo_box.setItemText(1, QCoreApplication.translate("SettingsForm", u"Automatically save project", None))
+
 #if QT_CONFIG(tooltip)
         self.checkBox_custom_open_project_dialog.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Select the type of dialog used in File-&gt;Open project...</p><p>Checking this box shows a custom dialog. Unchecking this box shows the OS provided 'select folder' dialog.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.checkBox_custom_open_project_dialog.setText(QCoreApplication.translate("SettingsForm", u"Custom open project dialog", None))
 #if QT_CONFIG(tooltip)
-        self.checkBox_save_project_before_closing.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Select what to do if there are unsaved changes when closing a project or when quitting the app.</p><p>Unchecked: Don't save project and don't show question box</p><p>Partially checked: Show question box</p><p>Checked: Save project and don't show question box</p><p><br/></p></body></html>", None))
+        self.checkBox_delete_data.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Check this box to delete project item's data when a project item is removed from project. This means, that the project item directory and its contens will be deleted from your HD.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.checkBox_save_project_before_closing.setText(QCoreApplication.translate("SettingsForm", u"Save project before closing", None))
+        self.checkBox_delete_data.setText(QCoreApplication.translate("SettingsForm", u"Delete data when project item is removed from project", None))
+#if QT_CONFIG(tooltip)
+        self.checkBox_exit_prompt.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Checking this shows the 'confirm exit' question box when quitting the app</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.checkBox_exit_prompt.setText(QCoreApplication.translate("SettingsForm", u"Always confirm exit", None))
+#if QT_CONFIG(tooltip)
+        self.checkBox_open_previous_project.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>If checked, application opens the project at startup that was open the last time the application was quit</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.checkBox_open_previous_project.setText(QCoreApplication.translate("SettingsForm", u"Open previous project at startup", None))
         self.groupBox_ui.setTitle(QCoreApplication.translate("SettingsForm", u"UI", None))
 #if QT_CONFIG(tooltip)
         self.checkBox_use_smooth_zoom.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Controls whether smooth or discete zoom is used in Design and Graph Views.</p></body></html>", None))

--- a/spinetoolbox/ui/settings.ui
+++ b/spinetoolbox/ui/settings.ui
@@ -216,19 +216,6 @@
            <property name="spacing">
             <number>6</number>
            </property>
-           <item row="1" column="0">
-            <widget class="QCheckBox" name="checkBox_exit_prompt">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Checking this shows the 'confirm exit' question box when quitting the app&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Confirm exit</string>
-             </property>
-             <property name="tristate">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
            <item row="13" column="0">
             <layout class="QHBoxLayout" name="horizontalLayout_6">
              <item>
@@ -276,33 +263,32 @@
              </item>
             </layout>
            </item>
-           <item row="4" column="0">
-            <widget class="QCheckBox" name="checkBox_open_previous_project">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, application opens the project at startup that was open the last time the application was quit&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Open previous project at startup</string>
-             </property>
-            </widget>
+           <item row="5" column="0">
+            <layout class="QFormLayout" name="formLayout_2">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>When there are unsaved changes:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="project_save_options_combo_box">
+               <item>
+                <property name="text">
+                 <string>Ask what to do</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Automatically save project</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
            </item>
-           <item row="3" column="0">
-            <widget class="QCheckBox" name="checkBox_delete_data">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this box to delete project item's data when a project item is removed from project. This means, that the project item directory and its contens will be deleted from your HD.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Delete data when project item is removed from project</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
+           <item row="1" column="0">
             <widget class="QCheckBox" name="checkBox_custom_open_project_dialog">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the type of dialog used in File-&amp;gt;Open project...&lt;/p&gt;&lt;p&gt;Checking this box shows a custom dialog. Unchecking this box shows the OS provided 'select folder' dialog.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -315,16 +301,42 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
-            <widget class="QCheckBox" name="checkBox_save_project_before_closing">
+           <item row="2" column="0">
+            <widget class="QCheckBox" name="checkBox_delete_data">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select what to do if there are unsaved changes when closing a project or when quitting the app.&lt;/p&gt;&lt;p&gt;Unchecked: Don't save project and don't show question box&lt;/p&gt;&lt;p&gt;Partially checked: Show question box&lt;/p&gt;&lt;p&gt;Checked: Save project and don't show question box&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this box to delete project item's data when a project item is removed from project. This means, that the project item directory and its contens will be deleted from your HD.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
-              <string>Save project before closing</string>
+              <string>Delete data when project item is removed from project</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QCheckBox" name="checkBox_exit_prompt">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Checking this shows the 'confirm exit' question box when quitting the app&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Always confirm exit</string>
              </property>
              <property name="tristate">
-              <bool>true</bool>
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QCheckBox" name="checkBox_open_previous_project">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, application opens the project at startup that was open the last time the application was quit&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Open previous project at startup</string>
              </property>
             </widget>
            </item>
@@ -1519,11 +1531,9 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>checkBox_exit_prompt</tabstop>
   <tabstop>checkBox_custom_open_project_dialog</tabstop>
   <tabstop>checkBox_delete_data</tabstop>
   <tabstop>checkBox_open_previous_project</tabstop>
-  <tabstop>checkBox_save_project_before_closing</tabstop>
   <tabstop>checkBox_datetime</tabstop>
   <tabstop>checkBox_color_toolbar_icons</tabstop>
   <tabstop>checkBox_use_smooth_zoom</tabstop>
@@ -1605,7 +1615,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="engine_processes_button_group"/>
   <buttongroup name="persistent_processes_button_group"/>
+  <buttongroup name="engine_processes_button_group"/>
  </buttongroups>
 </ui>

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -257,8 +257,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         self.ui.stackedWidget.setCurrentIndex(0)
         self.ui.listWidget.setFocus()
         self.ui.listWidget.setCurrentRow(0)
-        self._toolbox = toolbox  # QWidget parent
-        self._project = self._toolbox.project()
+        self._toolbox = toolbox
         self.orig_work_dir = ""  # Work dir when this widget was opened
         self._kernel_editor = None
         self._remote_host = ""
@@ -532,7 +531,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         super().read_settings()
         open_previous_project = int(self._qsettings.value("appSettings/openPreviousProject", defaultValue="0"))
         show_exit_prompt = int(self._qsettings.value("appSettings/showExitPrompt", defaultValue="2"))
-        save_at_exit = int(self._qsettings.value("appSettings/saveAtExit", defaultValue="1"))  # tri-state
+        save_at_exit = self._qsettings.value("appSettings/saveAtExit", defaultValue="prompt")
         datetime = int(self._qsettings.value("appSettings/dateTime", defaultValue="2"))
         delete_data = int(self._qsettings.value("appSettings/deleteData", defaultValue="0"))
         custom_open_project_dialog = self._qsettings.value("appSettings/customOpenProjectDialog", defaultValue="true")
@@ -562,12 +561,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
             self.ui.checkBox_open_previous_project.setCheckState(Qt.CheckState.Checked)
         if show_exit_prompt == 2:
             self.ui.checkBox_exit_prompt.setCheckState(Qt.CheckState.Checked)
-        if save_at_exit == 0:  # Not needed but makes the code more readable.
-            self.ui.checkBox_save_project_before_closing.setCheckState(Qt.CheckState.Unchecked)
-        elif save_at_exit == 1:
-            self.ui.checkBox_save_project_before_closing.setCheckState(Qt.PartiallyChecked)
-        else:  # save_at_exit == 2:
-            self.ui.checkBox_save_project_before_closing.setCheckState(Qt.CheckState.Checked)
+        self.ui.project_save_options_combo_box.setCurrentIndex({"prompt": 0, "automatic": 1}[save_at_exit])
         if datetime == 2:
             self.ui.checkBox_datetime.setCheckState(Qt.CheckState.Checked)
         if delete_data == 2:
@@ -701,7 +695,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         self._qsettings.setValue("appSettings/openPreviousProject", open_prev_proj)
         exit_prompt = str(self.ui.checkBox_exit_prompt.checkState().value)
         self._qsettings.setValue("appSettings/showExitPrompt", exit_prompt)
-        save_at_exit = str(self.ui.checkBox_save_project_before_closing.checkState().value)
+        save_at_exit = {0: "prompt", 1: "automatic"}[self.ui.project_save_options_combo_box.currentIndex()]
         self._qsettings.setValue("appSettings/saveAtExit", save_at_exit)
         datetime = str(self.ui.checkBox_datetime.checkState().value)
         self._qsettings.setValue("appSettings/dateTime", datetime)

--- a/tests/widgets/test_settings_widget.py
+++ b/tests/widgets/test_settings_widget.py
@@ -1,0 +1,88 @@
+######################################################################################################################
+# Copyright (C) 2017-2023 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""Unit tests for the ``settings_widget`` module."""
+import os
+import unittest
+
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication
+
+from spinetoolbox.widgets.settings_widget import SettingsWidget
+from tests.mock_helpers import create_toolboxui
+
+
+class TestSettingsWidget(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._settings = QSettings("SpineProject", "Spine Toolbox tests")
+        self._toolbox = create_toolboxui()
+        self._toolbox._qsettings = self._settings
+
+    def tearDown(self):
+        self._settings.clear()
+
+    def test_defaults_for_initially_empty_app_settings(self):
+        widget = SettingsWidget(self._toolbox)
+        widget.save_and_close()
+        widget.deleteLater()
+        self._settings.beginGroup("appSettings")
+        try:
+            self.assertEqual(self._settings.value("openPreviousProject"), "0")
+            self.assertEqual(self._settings.value("showExitPrompt"), "2")
+            self.assertEqual(self._settings.value("saveAtExit"), "prompt")
+            self.assertEqual(self._settings.value("dateTime"), "2")
+            self.assertEqual(self._settings.value("deleteData"), "0")
+            self.assertEqual(self._settings.value("customOpenProjectDialog"), "true")
+            self.assertEqual(self._settings.value("smoothZoom"), "false")
+            self.assertEqual(self._settings.value("colorToolbarIcons"), "false")
+            self.assertEqual(self._settings.value("colorPropertiesWidgets"), "false")
+            self.assertEqual(self._settings.value("curvedLinks"), "false")
+            self.assertEqual(self._settings.value("dragToDrawLinks"), "false")
+            self.assertEqual(self._settings.value("roundedItems"), "false")
+            self.assertEqual(self._settings.value("preventOverlapping"), "false")
+            self.assertEqual(self._settings.value("dataFlowAnimationDuration"), "100")
+            self.assertEqual(self._settings.value("bgChoice"), "solid")
+            self.assertEqual(self._settings.value("bgColor"), widget.bg_color)
+            self.assertEqual(self._settings.value("saveSpecBeforeClosing"), "1")
+            self.assertEqual(self._settings.value("specShowUndo"), "2")
+            self.assertEqual(self._settings.value("gamsPath"), "")
+            self.assertEqual(self._settings.value("useJuliaKernel"), "0")
+            self.assertEqual(self._settings.value("juliaPath"), "")
+            self.assertEqual(self._settings.value("juliaProjectPath"), "")
+            self.assertEqual(self._settings.value("juliaKernel"), "")
+            self.assertEqual(self._settings.value("usePythonKernel"), "0")
+            self.assertEqual(self._settings.value("pythonPath"), "")
+            self.assertEqual(self._settings.value("pythonKernel"), "")
+            self.assertEqual(self._settings.value("condaPath"), "")
+        finally:
+            self._settings.endGroup()
+        self._settings.beginGroup("engineSettings")
+        try:
+            self.assertEqual(self._settings.value("remoteExecutionEnabled"), "false")
+            self.assertEqual(self._settings.value("remoteHost"), "")
+            self.assertEqual(self._settings.value("remotePort"), 49152)
+            self.assertEqual(self._settings.value("remoteSecurityModel"), "")
+            self.assertEqual(self._settings.value("remoteSecurityFolder"), "")
+            self.assertEqual(self._settings.value("processLimiter"), "unlimited")
+            self.assertEqual(self._settings.value("maxProcesses"), str(os.cpu_count()))
+            self.assertEqual(self._settings.value("persistentLimiter"), "unlimited")
+            self.assertEqual(self._settings.value("maxPersistentProcesses"), str(os.cpu_count()))
+        finally:
+            self._settings.endGroup()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This removes the setting to close a project (or exit Toolbox) and quietly discarding any changes. The only options available now are "prompt to save" and "save automatically".

Fixes #1110

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
