### PR TITLE
Fix text in close project dialog

### DIFF
--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -95,7 +95,8 @@ from .helpers import (
     format_log_message,
     color_from_index,
     load_specification_from_file,
-    load_specification_local_data, same_path,
+    load_specification_local_data,
+    same_path,
 )
 from .project_commands import (
     AddSpecificationCommand,
@@ -364,7 +365,6 @@ class ToolboxUI(QMainWindow):
                 new_value = {0: "prompt", 1: "prompt", 2: "automatic"}[old_value]
                 self._qsettings.setValue("appSettings/saveAtExit", new_value)
 
-
     def _update_execute_enabled(self):
         first_index = next(self.project_item_model.leaf_indexes(), None)
         self.ui.actionExecute_project.setEnabled(first_index is not None and not self.execution_in_progress)
@@ -453,7 +453,9 @@ class ToolboxUI(QMainWindow):
         )
         if not project_dir:
             open_previous_project = int(self._qsettings.value("appSettings/openPreviousProject", defaultValue="0"))
-            if open_previous_project != Qt.CheckState.Checked.value:  # 2: Qt.CheckState.Checked, ie. open_previous_project==True
+            if (
+                open_previous_project != Qt.CheckState.Checked.value
+            ):  # 2: Qt.CheckState.Checked, ie. open_previous_project==True
                 self.msg.emit(welcome_msg)
                 return
             # Get previous project (directory)
@@ -689,6 +691,9 @@ class ToolboxUI(QMainWindow):
     def close_project(self, ask_confirmation=True):
         """Closes the current project.
 
+        Args:
+            ask_confirmation (bool): if False, no confirmation whatsoever is asked from user
+
         Returns:
             bool: True when no project open or when it's closed successfully, False otherwise.
         """
@@ -696,7 +701,7 @@ class ToolboxUI(QMainWindow):
             return True
         if ask_confirmation and not self.undo_stack.isClean():
             save_at_exit = self._qsettings.value("appSettings/saveAtExit", defaultValue="prompt")
-            if save_at_exit == "prompt" and not self._confirm_save_and_exit():
+            if save_at_exit == "prompt" and not self._confirm_project_close():
                 return False
             elif save_at_exit == "automatic" and not self.save_project():
                 return False
@@ -862,7 +867,11 @@ class ToolboxUI(QMainWindow):
                     "Would you like to overwrite the existing project?".format(project_dir)
                 )
                 box1 = QMessageBox(
-                    QMessageBox.Icon.Question, "Overwrite?", msg1, buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel, parent=self
+                    QMessageBox.Icon.Question,
+                    "Overwrite?",
+                    msg1,
+                    buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+                    parent=self,
                 )
                 box1.button(QMessageBox.StandardButton.Ok).setText("Overwrite")
                 answer1 = box1.exec()
@@ -874,7 +883,11 @@ class ToolboxUI(QMainWindow):
                     "Would you like to make this directory into a Spine Toolbox project?".format(project_dir)
                 )
                 box2 = QMessageBox(
-                    QMessageBox.Icon.Question, "Not empty", msg2, buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel, parent=self
+                    QMessageBox.Icon.Question,
+                    "Not empty",
+                    msg2,
+                    buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+                    parent=self,
                 )
                 box2.button(QMessageBox.StandardButton.Ok).setText("Go ahead")
                 answer2 = box2.exec()
@@ -1096,7 +1109,7 @@ class ToolboxUI(QMainWindow):
             "Remove All Items",
             msg,
             buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
-            parent=self
+            parent=self,
         )
         message_box.button(QMessageBox.StandardButton.Ok).setText("Remove Items")
         answer = message_box.exec()
@@ -1610,12 +1623,15 @@ class ToolboxUI(QMainWindow):
         self.msg.emit(f"Retrieving project {job_id} from server and extracting to: {project_dir}")
         host, port, sec_model, sec_folder = self.engine_server_settings()
         if not host:
-            self.msg_error.emit("Spine Engine Server <b>host address</b> missing. "
-                                "Please enter host in <b>File->Settings->Engine</b>.")
+            self.msg_error.emit(
+                "Spine Engine Server <b>host address</b> missing. "
+                "Please enter host in <b>File->Settings->Engine</b>."
+            )
             return
         elif not port:
-            self.msg_error.emit("Spine Engine Server <b>port</b> missing. "
-                                "Please select port in <b>File->Settings->Engine</b>.")
+            self.msg_error.emit(
+                "Spine Engine Server <b>port</b> missing. " "Please select port in <b>File->Settings->Engine</b>."
+            )
             return
         self.msg.emit(f"Connecting to Spine Engine Server at <b>{host}:{port}</b>")
         try:
@@ -1732,7 +1748,10 @@ class ToolboxUI(QMainWindow):
         can_copy = any(isinstance(x, ProjectItemIcon) for x in selected_items)
         has_items = self.project_item_model.n_items() > 0
         selected_project_items = [x for x in selected_items if isinstance(x, ProjectItemIcon)]
-        _methods = [getattr(self.project_item_model.get_item(x.name()).project_item, "copy_local_data") for x in selected_project_items]
+        _methods = [
+            getattr(self.project_item_model.get_item(x.name()).project_item, "copy_local_data")
+            for x in selected_project_items
+        ]
         can_duplicate_files = any(m.__qualname__.partition(".")[0] != "ProjectItem" for m in _methods)
         self.ui.actionCopy.setEnabled(can_copy)
         self.ui.actionPaste.setEnabled(can_paste)
@@ -1801,7 +1820,7 @@ class ToolboxUI(QMainWindow):
                 if not self._confirm_exit():
                     return False
             elif task == "prompt save":
-                if not self._confirm_save_and_exit():
+                if not self._confirm_project_close():
                     return False
             elif task == "save":
                 self.save_project()
@@ -1834,7 +1853,7 @@ class ToolboxUI(QMainWindow):
             return True
         return False
 
-    def _confirm_save_and_exit(self):
+    def _confirm_project_close(self):
         """
         Confirms exit from user and saves the project if requested.
 
@@ -1843,11 +1862,11 @@ class ToolboxUI(QMainWindow):
         """
         msg = QMessageBox(parent=self)
         msg.setIcon(QMessageBox.Icon.Question)
-        msg.setWindowTitle("Save project before leaving")
-        msg.setText("The project has unsaved changes. Do you want to save them before closing?")
-        msg.setStandardButtons(QMessageBox.StandardButton.Save | QMessageBox.StandardButton.Discard | QMessageBox.StandardButton.Cancel)
-        msg.button(QMessageBox.StandardButton.Save).setText("Save and exit")
-        msg.button(QMessageBox.StandardButton.Discard).setText("Exit without saving")
+        msg.setWindowTitle("Confirm project close")
+        msg.setText("Current project has unsaved changes.")
+        msg.setStandardButtons(
+            QMessageBox.StandardButton.Save | QMessageBox.StandardButton.Discard | QMessageBox.StandardButton.Cancel
+        )
         answer = msg.exec()
         if answer == QMessageBox.StandardButton.Cancel:
             return False
@@ -1880,7 +1899,13 @@ class ToolboxUI(QMainWindow):
         """Clears recent projects list in File->Open recent menu."""
         msg = "Are you sure?"
         title = "Clear recent projects?"
-        message_box = QMessageBox(QMessageBox.Icon.Question, title, msg, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, parent=self)
+        message_box = QMessageBox(
+            QMessageBox.Icon.Question,
+            title,
+            msg,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            parent=self,
+        )
         answer = message_box.exec()
         if answer == QMessageBox.StandardButton.No:
             return
@@ -2245,7 +2270,11 @@ class ToolboxUI(QMainWindow):
                 msg += "<br><br><b>Warning: Item data will be permanently lost after this operation.</b>"
             # noinspection PyCallByClass, PyTypeChecker
             message_box = QMessageBox(
-                QMessageBox.Icon.Question, "Remove Item", msg, buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel, parent=self
+                QMessageBox.Icon.Question,
+                "Remove Item",
+                msg,
+                buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+                parent=self,
             )
             message_box.button(QMessageBox.StandardButton.Ok).setText("Remove Item")
             answer = message_box.exec()


### PR DESCRIPTION
The dialog title, message and button texts now make more sense when closing a project or opening another project as well.

Fixes #1317

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
