### PR TITLE
Fix Traceback when entering invalid values in Time series editors

### DIFF
--- a/spinetoolbox/mvcmodels/time_series_model_fixed_resolution.py
+++ b/spinetoolbox/mvcmodels/time_series_model_fixed_resolution.py
@@ -125,7 +125,10 @@ class TimeSeriesModelFixedResolution(IndexedValueTableModel):
         row = index.row()
         if row == len(self._value):
             self.insertRow(row)
-        self._value.values[row] = value
+        try:
+            self._value.values[row] = value
+        except ValueError:
+            self._value.values[row] = np.nan
         self.dataChanged.emit(index, index, [Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole])
         return True
 

--- a/spinetoolbox/mvcmodels/time_series_model_variable_resolution.py
+++ b/spinetoolbox/mvcmodels/time_series_model_variable_resolution.py
@@ -150,9 +150,15 @@ class TimeSeriesModelVariableResolution(IndexedValueTableModel):
         if row == len(self._value):
             self.insertRow(row)
         if index.column() == 0:
-            self._value.indexes[row] = value
+            try:
+                self._value.indexes[row] = value
+            except ValueError:
+                self._value.indexes[row] = np.datetime64()
         else:
-            self._value.values[row] = value
+            try:
+                self._value.values[row] = value
+            except ValueError:
+                self._value.values[row] = np.nan
         self.dataChanged.emit(index, index, [Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole])
         return True
 

--- a/tests/mvcmodels/test_TimeSeriesModelFixedResolution.py
+++ b/tests/mvcmodels/test_TimeSeriesModelFixedResolution.py
@@ -188,6 +188,17 @@ class TestTimeSeriesModelFixedStep(unittest.TestCase):
         )
         model.deleteLater()
 
+    def test_setData_sets_value_to_nan_if_conversion_to_float_fails(self):
+        model = TimeSeriesModelFixedResolution(
+            TimeSeriesFixedResolution("2019-07-05T12:00", "2 hours", [2.3, -5.0], True, False), None
+        )
+        model_index = model.index(0, 1)
+        model.setData(model_index, "1,1")
+        self.assertEqual(
+            model.value, TimeSeriesFixedResolution("2019-07-05T12:00", "2 hours", [np.nan, -5.0], True, False)
+        )
+        model.deleteLater()
+
     def test_set_resolution_updates_indexes(self):
         model = TimeSeriesModelFixedResolution(
             TimeSeriesFixedResolution("2019-07-05T12:00", "2 hours", [2.3, -5.0], True, False), None


### PR DESCRIPTION
Invalid input is now converted to NaNs or not-a-datetimes.

Fixes #1890

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
