### PR TITLE
Fix default text color in Tool Specification Code Editor

### DIFF
--- a/spinetoolbox/widgets/code_text_edit.py
+++ b/spinetoolbox/widgets/code_text_edit.py
@@ -38,7 +38,7 @@ class CodeTextEdit(QPlainTextEdit):
         self._right_margin = 16
         font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
         self.setFont(font)
-        foreground_color = self._style.styles[Token.Text]
+        foreground_color = self._style.styles[Token]
         self.setStyleSheet(
             f"QPlainTextEdit {{background-color: {self._style.background_color}; color: {foreground_color};}}"
         )


### PR DESCRIPTION
Token.Text is an empty string which resulted in the foreground (text) color being black.

Fixes #1966

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
