### PR TITLE
Fix overwriting existing database

### DIFF
--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -359,10 +359,13 @@ class SpineDBManager(QObject):
                 msg.setWindowTitle("Database not empty")
                 msg.setText(f"The URL <b>{url}</b> points to an existing database.")
                 msg.setInformativeText("Do you want to overwrite it?")
-                msg.addButton("Overwrite", QMessageBox.ButtonRole.AcceptRole)
+                overwrite_button = msg.addButton("Overwrite", QMessageBox.ButtonRole.AcceptRole)
                 msg.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
-                ret = msg.exec()  # Show message box
-                if ret != QMessageBox.ButtonRole.AcceptRole:
+                msg.exec()
+                # We have custom buttons, exec() returns an opaque value.
+                # Let's check the clicked button explicitly instead.
+                clicked_button = msg.clickedButton()
+                if clicked_button is not overwrite_button:
                     return
             do_create_new_spine_database(url)
             logger.msg_success.emit(f"New Spine db successfully created at '{url}'.")


### PR DESCRIPTION
This PR makes the "Overwrite" button work properly in the confirmation dialog.

Fixes #2015
## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
