### PR TITLE
Add options to kill persistent console processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   in Database editor.
 - Scenarios can now be copied and pasted between databases in Database editor.
 - Scenarios can now be duplicated in Database editor.
+- Tool project item's Python and Julia consoles can now be killed from the right-click context menu.
+  A killed console can be restored by restarting it.
+- A new option "Kill consoles at the end of execution" has been added to Tool properties
+  that kills Python and Julia console processes after execution saving some memory and computing resources.
 
 ### Changed
 - The console settings of Python tools as well as the command and shell settings of executable tools

--- a/spinetoolbox/server/engine_client.py
+++ b/spinetoolbox/server/engine_client.py
@@ -295,6 +295,15 @@ class EngineClient:
         data = persistent_key, "interrupt_persistent", ""
         return self.send_request_to_persistent(data)
 
+    def send_kill_persistent(self, persistent_key):
+        """Sends kill persistent cmd to persistent execution manager backend on server.
+
+        Args:
+            persistent_key (tuple): persistent manager identifier
+        """
+        data = persistent_key, "kill_persistent", ""
+        return self.send_request_to_persistent(data)
+
     def send_request_to_persistent(self, data):
         """Sends given data containing persistent_key, command, cmd_to_persistent to
         Spine Engine Server to be processed by a persistent execution manager backend.

--- a/spinetoolbox/spine_engine_manager.py
+++ b/spinetoolbox/spine_engine_manager.py
@@ -112,6 +112,14 @@ class SpineEngineManagerBase:
         """
         raise NotImplementedError()
 
+    def kill_persistent(self, persistent_key):
+        """Kills a persistent process.
+
+        Args:
+            persistent_key (tuple): persistent identifier
+        """
+        raise NotImplementedError()
+
     def get_persistent_completions(self, persistent_key, text):
         """Returns a list of auto-completion options from given text.
 
@@ -195,6 +203,12 @@ class LocalSpineEngineManager(SpineEngineManagerBase):
         from spine_engine.execution_managers.persistent_execution_manager import interrupt_persistent
 
         interrupt_persistent(persistent_key)
+
+    def kill_persistent(self, persistent_key):
+        # pylint: disable=import-outside-toplevel
+        from spine_engine.execution_managers.persistent_execution_manager import kill_persistent
+
+        kill_persistent(persistent_key)
 
     def get_persistent_completions(self, persistent_key, text):
         # pylint: disable=import-outside-toplevel
@@ -339,6 +353,10 @@ class RemoteSpineEngineManager(SpineEngineManagerBase):
     def interrupt_persistent(self, persistent_key):
         """See base class."""
         return self.engine_client.send_interrupt_persistent(persistent_key)
+
+    def kill_persistent(self, persistent_key):
+        """See base class."""
+        return self.engine_client.send_kill_persistent(persistent_key)
 
     def get_persistent_completions(self, persistent_key, text):
         """See base class."""

--- a/spinetoolbox/spine_engine_worker.py
+++ b/spinetoolbox/spine_engine_worker.py
@@ -288,6 +288,8 @@ class SpineEngineWorker(QObject):
                 "Please go to Settings->Tools and check your setup."
             )
             self._event_message_arrived.emit(item, msg["filter_id"], "msg_error", msg_text)
+        elif msg_type == "persistent_killed":
+            self._logger.persistent_killed(item, msg["filter_id"])
         elif msg_type == "stdin":
             self._logger.add_persistent_stdin(item, msg["filter_id"], msg["data"])
         elif msg_type == "stdout":
@@ -299,6 +301,8 @@ class SpineEngineWorker(QObject):
                 item, msg["filter_id"], "msg", f"*** Starting execution on persistent process <b>{msg['args']}</b> ***"
             )
             self._event_message_arrived.emit(item, msg["filter_id"], "msg_warning", "See Console for messages")
+        else:
+            raise RuntimeError(f"Logic error: unknown persistent execution msg_type '{msg_type}'")
 
     def _handle_kernel_execution_msg(self, msg):
         item = self._project_items[msg["item_name"]] or self._connections.get(msg["item_name"])

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -2426,6 +2426,9 @@ class ToolboxUI(QMainWindow):
             d[filter_id] = self._make_persistent_console(item, key, language)
         self.override_console_and_execution_list()
 
+    def persistent_killed(self, item, filter_id):
+        self._get_console(item, filter_id).set_killed(True)
+
     def add_persistent_stdin(self, item, filter_id, data):
         self._get_console(item, filter_id).add_stdin(data)
 

--- a/tests/server/test_EngineClient.py
+++ b/tests/server/test_EngineClient.py
@@ -122,7 +122,9 @@ class TestEngineClient(unittest.TestCase):
         client = EngineClient("localhost", 5601, ClientSecurityModel.NONE, "")
         logger = mock.MagicMock()
         logger.msg_warning = mock.MagicMock()
-        exec_mngr1 = PythonPersistentExecutionManager(logger, ["python"], [], "alias", group_id="SomeGroup")
+        exec_mngr1 = PythonPersistentExecutionManager(
+            logger, ["python"], [], "alias", kill_completed_processes=False, group_id="SomeGroup"
+        )
         # Make exec_mngr live on the server, then send command from client to server for processing and check output
         self.service.persistent_exec_mngrs["123"] = exec_mngr1
         gener = client.send_issue_persistent_command("123", "print('hi')")
@@ -144,7 +146,9 @@ class TestEngineClient(unittest.TestCase):
         client = EngineClient("localhost", 5601, ClientSecurityModel.NONE, "")
         logger = mock.MagicMock()
         logger.msg_warning = mock.MagicMock()
-        exec_mngr1 = PythonPersistentExecutionManager(logger, ["python"], [], "alias", group_id="SomeGroup")
+        exec_mngr1 = PythonPersistentExecutionManager(
+            logger, ["python"], [], "alias", kill_completed_processes=False, group_id="SomeGroup"
+        )
         self.service.persistent_exec_mngrs["123"] = exec_mngr1
         should_be_true = client.send_is_complete("123", "print('hi')")
         self.assertTrue(should_be_true)


### PR DESCRIPTION
This adds an action to the context menu of Julia and Python execution consoles that lets users to kill the underlying process to save computing resources.

Implements #1586

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
