### PR TITLE
Introduce FetchParent.shows_item()

### DIFF
--- a/spinetoolbox/mvcmodels/compound_table_model.py
+++ b/spinetoolbox/mvcmodels/compound_table_model.py
@@ -114,6 +114,8 @@ class CompoundTableModel(MinimalTableModel):
         self.layoutAboutToBeChanged.emit()
         self._do_refresh()
         self.layoutChanged.emit()
+        if self.canFetchMore(QModelIndex()):
+            self.fetchMore(QModelIndex())
 
     def _do_refresh(self):
         """Recomputes the row and inverse row maps."""

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_parameter_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_parameter_models.py
@@ -63,6 +63,7 @@ class CompoundParameterModel(CompoundWithEmptyTableModel):
         self._fetch_parent = FlexibleFetchParent(
             self.item_type,
             accepts_item=self.accepts_item,
+            shows_item=self.shows_item,
             handle_items_added=self.handle_items_added,
             handle_items_removed=self.handle_items_removed,
             handle_items_updated=self.handle_items_updated,
@@ -81,6 +82,9 @@ class CompoundParameterModel(CompoundWithEmptyTableModel):
 
     def accepts_item(self, item, db_map):
         return item.get(self.entity_class_id_key) is not None
+
+    def shows_item(self, item, db_map):
+        return any(m.db_map == db_map and m.filter_accepts_item(item) for m in self.accepted_single_models())
 
     def _make_header(self):
         raise NotImplementedError()

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -271,8 +271,9 @@ class SpineDBWorker(QObject):
             if parent.accepts_item(item, self._db_map):
                 self._bind_item(parent, item)
                 if item.is_valid():
-                    parent.add_item(self._db_map, item)
-                    added_count += 1
+                    parent.add_item(item, self._db_map)
+                    if parent.shows_item(item, self._db_map):
+                        added_count += 1
                 if added_count == parent.chunk_size:
                     break
         if parent.chunk_size is None:
@@ -288,21 +289,21 @@ class SpineDBWorker(QObject):
         if parent.is_obsolete:
             self._add_item_callbacks.pop(parent, None)
             return False
-        parent.add_item(self._db_map, item)
+        parent.add_item(item, self._db_map)
         return True
 
     def _update_item(self, parent, item):
         if parent.is_obsolete:
             self._update_item_callbacks.pop(parent, None)
             return False
-        parent.update_item(self._db_map, item)
+        parent.update_item(item, self._db_map)
         return True
 
     def _remove_item(self, parent, item):
         if parent.is_obsolete:
             self._remove_item_callbacks.pop(parent, None)
             return False
-        parent.remove_item(self._db_map, item)
+        parent.remove_item(item, self._db_map)
         return True
 
     def _make_add_item_callback(self, parent):

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -286,9 +286,9 @@ class TestSpineDBManager(SpineDBManager):
             return super().get_db_map(*args, **kwargs)
 
     def can_fetch_more(self, db_map, parent):
-        parent.add_item = lambda db_map, item: parent.handle_items_added({db_map: [item]})
-        parent.update_item = lambda db_map, item: parent.handle_items_updated({db_map: [item]})
-        parent.remove_item = lambda db_map, item: parent.handle_items_removed({db_map: [item]})
+        parent.add_item = lambda item, db_map: parent.handle_items_added({db_map: [item]})
+        parent.update_item = lambda item, db_map: parent.handle_items_updated({db_map: [item]})
+        parent.remove_item = lambda item, db_map: parent.handle_items_removed({db_map: [item]})
         return super().can_fetch_more(db_map, parent)
 
 


### PR DESCRIPTION
To determine if a parent should continue fetching after fetching items that aren't shown in the corresponding view because of a filter.

Fixes #2051

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
