### PR TITLE
Fix pivot table editor for Scenario and Relationship modes

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
@@ -35,7 +35,17 @@ from ...helpers import object_icon
 from ..mvcmodels.metadata_table_model_base import Column as MetadataColumn
 
 
-class RelationshipPivotTableDelegate(CheckBoxDelegate):
+class PivotTableDelegateMixin:
+    """A mixin that fixes Pivot table's header table editor position."""
+
+    def updateEditorGeometry(self, editor, option, index):
+        """Fixes position of header table editors."""
+        super().updateEditorGeometry(editor, option, index)
+        if isinstance(editor, PivotHeaderTableLineEditor):
+            editor.fix_geometry()
+
+
+class RelationshipPivotTableDelegate(PivotTableDelegateMixin, CheckBoxDelegate):
     data_committed = Signal(QModelIndex, object)
 
     def __init__(self, parent):
@@ -84,12 +94,12 @@ class RelationshipPivotTableDelegate(CheckBoxDelegate):
     def createEditor(self, parent, option, index):
         if self._is_relationship_index(index):
             return super().createEditor(parent, option, index)
-        editor = CustomLineEditor(parent)
+        editor = PivotHeaderTableLineEditor(parent)
         editor.set_data(index.data(Qt.ItemDataRole.EditRole))
         return editor
 
 
-class ScenarioAlternativeTableDelegate(RankDelegate):
+class ScenarioAlternativeTableDelegate(PivotTableDelegateMixin, RankDelegate):
     data_committed = Signal(QModelIndex, object)
 
     def __init__(self, parent):
@@ -135,12 +145,12 @@ class ScenarioAlternativeTableDelegate(RankDelegate):
     def createEditor(self, parent, option, index):
         if self._is_scenario_alternative_index(index):
             return super().createEditor(parent, option, index)
-        editor = CustomLineEditor(parent)
+        editor = PivotHeaderTableLineEditor(parent)
         editor.set_data(index.data(Qt.ItemDataRole.EditRole))
         return editor
 
 
-class ParameterPivotTableDelegate(QStyledItemDelegate):
+class ParameterPivotTableDelegate(PivotTableDelegateMixin, QStyledItemDelegate):
     parameter_value_editor_requested = Signal(QModelIndex)
     data_committed = Signal(QModelIndex, object)
 
@@ -175,12 +185,6 @@ class ParameterPivotTableDelegate(QStyledItemDelegate):
         editor = PivotHeaderTableLineEditor(parent)
         editor.set_data(index.data(Qt.ItemDataRole.EditRole))
         return editor
-
-    def updateEditorGeometry(self, editor, option, index):
-        """Fixes position of header table editors."""
-        super().updateEditorGeometry(editor, option, index)
-        if isinstance(editor, PivotHeaderTableLineEditor):
-            editor.fix_geometry()
 
 
 class ParameterValueElementDelegate(QStyledItemDelegate):


### PR DESCRIPTION
This PR makes Pivot table header editors visible in Scenario and Relationship mode.

Fixes #2062

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
~- [ ] Unit tests pass~ Unit tests pass on local machine but seem to be broken on master on certain systems
