### PR TITLE
remove duplicate scenario dialog, copy with number after name instead

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -59,6 +59,7 @@ from ...helpers import (
     busy_effect,
     CharIconEngine,
     preferred_row_height,
+    unique_name,
 )
 from ...spine_db_parcel import SpineDBParcel
 from ...config import APPLICATION_PATH
@@ -639,13 +640,10 @@ class SpineDBEditorBase(QMainWindow):
             scen_id (int)
         """
         orig_name = self.db_mngr.get_item(db_map, "scenario", scen_id)["name"]
-        dup_name, ok = QInputDialog.getText(
-            self, "Duplicate object", "Enter a name for the duplicate object:", text=orig_name + "_copy"
-        )
-        if not ok:
-            return
         parcel = SpineDBParcel(self.db_mngr)
         parcel.full_push_scenario_ids({db_map: {scen_id}})
+        existing_names = {i.name for i in self.db_mngr.get_items(db_map, "scenario", only_visible=False)}
+        dup_name = unique_name(orig_name, existing_names)
         self.db_mngr.duplicate_scenario(parcel.data, dup_name, db_map)
 
     @Slot(object)


### PR DESCRIPTION
The dialog box (with wrong labels) has been removed, and instead the duplication is performed with a duplicate name similar to [line 222 of `spine_db_editor/mvcmodels/scenario_model.py`](https://github.com/spine-tools/Spine-Toolbox/blob/4cc129da76b9629db10b059c27958718429494f2/spinetoolbox/spine_db_editor/mvcmodels/scenario_model.py#L222)

Fixes #2021 

## Questions
- How does this dialog box get triggered? I was unable to find it, so haven't actually been able to confirm the functionality 😅 🙈 
- Should the dialog box for duplicate object also be removed?

## Checklist before merging
- [x] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] ~Unit tests have been added/updated accordingly~ N/A
- [x] Code has been formatted by black
- [x] Unit tests pass
