### PR TITLE
update unique_name() to append a number in brackets

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1029,18 +1029,26 @@ def unique_name(prefix, existing):
     Returns:
         str: unique name
     """
-    pattern = re.compile(fr"^{prefix} [0-9]+$")
     reserved = set()
+
+    # check if `prefix` is already a duplicate and adjust if needed
+    match = re.fullmatch(r"^(.*) \(([0-9]+)\)$", prefix)
+    if match:
+        prefix = match[1]
+        reserved.add(int(match[2]))
+
+    pattern = re.compile(fr"^{prefix} \(([0-9]+)\)$")
     for name in existing:
-        if pattern.fullmatch(name) is not None:
-            _, _, number = name.rpartition(" ")
-            reserved.add(int(number))
+        match = pattern.fullmatch(name)
+        if match:
+            reserved.add(int(match[1]))
+
     free = len(reserved) + 1
-    for i in range(len(reserved)):
-        if i + 1 not in reserved:
-            free = i + 1
+    for i in range(1, len(reserved) + 1):
+        if i not in reserved:
+            free = i
             break
-    return f"{prefix} {free}"
+    return f"{prefix} ({free})"
 
 
 def get_upgrade_db_promt_text(url, current, expected):

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -409,7 +409,7 @@ class TestScenarioModel(_TestBase):
                         ],
                         [
                             {
-                                "my_scenario 1": [
+                                "my_scenario (1)": [
                                     ["alternative_1", ""],
                                     ["Base", "Base alternative"],
                                     ["Type scenario alternative name here...", ""],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -270,11 +270,17 @@ class TestHelpers(unittest.TestCase):
                 self.assertTrue(dir_is_valid(None, temp_dir, "Message title"))
 
     def test_unique_name(self):
-        self.assertEqual(unique_name("Prefix", []), "Prefix 1")
-        self.assertEqual(unique_name("Prefix", ["aaa"]), "Prefix 1")
-        self.assertEqual(unique_name("Prefix", ["Prefix 1"]), "Prefix 2")
-        self.assertEqual(unique_name("Prefix", ["Prefix 2"]), "Prefix 1")
-        self.assertEqual(unique_name("Prefix 1", {"Prefix", "Prefix 1", "Prefix 1 1"}), "Prefix 1 2")
+        self.assertEqual(unique_name("Prefix", []), "Prefix (1)")
+        self.assertEqual(unique_name("Prefix", ["aaa"]), "Prefix (1)")
+        self.assertEqual(unique_name("Prefix", ["Prefix (1)"]), "Prefix (2)")
+        self.assertEqual(unique_name("Prefix", ["Prefix (2)"]), "Prefix (1)")
+        self.assertEqual(unique_name("Prefix (1)", []), "Prefix (2)")
+        self.assertEqual(unique_name("Prefix (1)", ["Prefix"]), "Prefix (2)")
+        self.assertEqual(unique_name("Prefix (1)", {"Prefix", "Prefix (1)", "Prefix (2)"}), "Prefix (3)")
+        self.assertEqual(unique_name("p (9)", {"p", "p (1)", "p (2)", "p (3)", "p (4)",
+                                               "p (5)", "p (6)", "p (7)", "p (8)", "p (9)"}), "p (10)")
+        self.assertEqual(unique_name("p (9)", {"p", "p (1)", "p (2)", "p (3)", "p (4)",
+                                               "p (5)", "p (6)", "p (7)", "p (8)", "p (9)", "p (10)"}), "p (11)")
 
     def test_load_tool_specification_from_file(self):
         """Tests creating a PythonTool (specification) instance from a valid tool specification file."""


### PR DESCRIPTION
Updated `helpers.unique_name()`, updated associated tests and added a few new test cases to illustrate current behavior.

I feel like this is too small to mention in the release notes, but please correct me if you disagree.

Fixes #2085

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
