### PR TITLE
Don't allow widgets to collapse in Console Dockwidget

### DIFF
--- a/spinetoolbox/ui/mainwindow.py
+++ b/spinetoolbox/ui/mainwindow.py
@@ -13,7 +13,7 @@
 ################################################################################
 ## Form generated from reading UI file 'mainwindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.1
+## Created by: Qt User Interface Compiler version 6.4.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -338,6 +338,7 @@ class Ui_MainWindow(object):
         self.splitter_console = QSplitter(self.dockWidgetContents_console)
         self.splitter_console.setObjectName(u"splitter_console")
         self.splitter_console.setOrientation(Qt.Vertical)
+        self.splitter_console.setChildrenCollapsible(False)
         self.listView_console_executions = QTreeView(self.splitter_console)
         self.listView_console_executions.setObjectName(u"listView_console_executions")
         sizePolicy1.setHeightForWidth(self.listView_console_executions.sizePolicy().hasHeightForWidth())

--- a/spinetoolbox/ui/mainwindow.ui
+++ b/spinetoolbox/ui/mainwindow.ui
@@ -400,6 +400,9 @@
        <property name="orientation">
         <enum>Qt::Vertical</enum>
        </property>
+       <property name="childrenCollapsible">
+        <bool>false</bool>
+       </property>
        <widget class="QTreeView" name="listView_console_executions">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -233,9 +233,9 @@ class ToolboxUI(QMainWindow):
         # Save/restore splitter states when hiding/showing execution lists
         if obj == self.ui.listView_console_executions:
             if ev.type() == QEvent.Hide:
-                self._qsettings.setValue("mainWindow/consoleSplitterState", self.ui.splitter_console.saveState())
+                self._qsettings.setValue("mainWindow/consoleSplitterPosition", self.ui.splitter_console.saveState())
             elif ev.type() == QEvent.Show:
-                splitter_state = self._qsettings.value("mainWindow/consoleSplitterState", defaultValue="false")
+                splitter_state = self._qsettings.value("mainWindow/consoleSplitterPosition", defaultValue="false")
                 if splitter_state != "false":
                     self.ui.splitter_console.restoreState(splitter_state)
         return super().eventFilter(obj, ev)


### PR DESCRIPTION
This PR hopefully fixes an issue where users were unable to see the Scenario Executions list after execution because the QTreeView had collapsed. This is fixed by not allowing the widgets to collapse in the first place. Also, the key where the splitter_console state is stored had to be changed to accommodate current users. 

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [x] Unit tests pass
