### PR TITLE
Workaround to hide a rogue widget in Database editor

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -13,7 +13,7 @@
 ################################################################################
 ## Form generated from reading UI file 'spine_db_editor_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.1
+## Created by: Qt User Interface Compiler version 6.4.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -655,7 +655,7 @@ class TabularViewMixin:
     def _make_all_frozen_headers(self):
         """Turns the first row of columns in the frozen table into TabularViewHeaderWidgets."""
         if self.frozen_table_model.rowCount() > 0:
-            self._make_frozen_headers(0, self.frozen_table_model.columnCount())
+            self._make_frozen_headers(0, self.frozen_table_model.columnCount() - 1)
 
     def _make_frozen_headers(self, first_column, last_column):
         horizontal_header = self.ui.frozen_table.horizontalHeader()


### PR DESCRIPTION
We now hide all unneeded `QTabBar` widgets when changing between views in Database editor. The mystery of the rogue widget remains unsolved, however.

Fixes #2091

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
