### PR TITLE
Fix adding parameter values via Pivot table

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -1133,8 +1133,8 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
     def _object_parameter_value_to_add(self, db_map, header_ids, value_and_type):
         value, value_type = split_value_and_type(value_and_type)
         return dict(
-            entity_class_id=self._parent.current_class_id[db_map],
-            entity_id=header_ids[0],
+            object_class_id=self._parent.current_class_id[db_map],
+            object_id=header_ids[0],
             parameter_definition_id=header_ids[-2],
             value=value,
             type=value_type,
@@ -1143,11 +1143,10 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
 
     def _relationship_parameter_value_to_add(self, db_map, header_ids, value_and_type, rel_id_lookup):
         object_id_list = tuple(id_ for id_ in header_ids[:-2])
-        relationship_id = rel_id_lookup[db_map, object_id_list]
         value, value_type = split_value_and_type(value_and_type)
         return dict(
-            entity_class_id=self._parent.current_class_id[db_map],
-            entity_id=relationship_id,
+            relationship_class_id=self._parent.current_class_id[db_map],
+            relationship_id=rel_id_lookup[db_map, object_id_list],
             parameter_definition_id=header_ids[-2],
             value=value,
             type=value_type,

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -475,7 +475,7 @@ class TabularViewMixin:
         get_id = self._make_get_id(action)
         if self.current_class_type == "object_class":
             return {
-                ((db_map, x["entity_id"]), (db_map, x["parameter_id"]), (db_map, x["alternative_id"]), db_map): get_id(
+                ((db_map, x["object_id"]), (db_map, x["parameter_id"]), (db_map, x["alternative_id"]), db_map): get_id(
                     db_map, x
                 )
                 for db_map, items in db_map_parameter_values.items()


### PR DESCRIPTION
This fixes a bug where parameter values added using Pivot table did not show up in Object/Relationship parameter value tables.

Fixes #2094

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
