### PR TITLE
Keep Frozen table sorted

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -13,7 +13,7 @@
 ################################################################################
 ## Form generated from reading UI file 'spine_db_editor_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.1
+## Created by: Qt User Interface Compiler version 6.4.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -217,7 +217,8 @@ class TabularViewMixin:
     @Slot(QAction)
     def _handle_pivot_action_triggered(self, action):
         self.current_input_type = action.text()
-        # NOTE: Changing the action also triggers a call to `_handle_pivot_table_visibility_changed` with `visible = True`
+        # NOTE: Changing the action also triggers a call to `_handle_pivot_table_visibility_changed`
+        # with `visible = True`
         # See `SpineDBEditor` class.
         self.do_reload_pivot_table()
 


### PR DESCRIPTION
The table is now always sorted. Sorting priority can be changed by dragging and dropping the columns around.

Resolves #2087

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
