### PR TITLE
Fix shutting down Jupyter Consoles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
--e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
+-e git+https://github.com/spine-tools/spine-engine.git@fix_shutting_down_kms#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
 -e .

--- a/spinetoolbox/spine_engine_manager.py
+++ b/spinetoolbox/spine_engine_manager.py
@@ -171,11 +171,15 @@ class LocalSpineEngineManager(SpineEngineManagerBase):
 
     def shutdown_kernel(self, connection_file):
         # pylint: disable=import-outside-toplevel
-        from spine_engine.execution_managers.kernel_execution_manager import pop_kernel_manager
+        from spine_engine.execution_managers.kernel_execution_manager import shutdown_kernel_manager
 
-        km = pop_kernel_manager(connection_file)
-        if km is not None:
-            km.shutdown_kernel(now=True)
+        shutdown_kernel_manager(connection_file)
+
+    def kernel_managers(self):
+        # pylint: disable=import-outside-toplevel
+        from spine_engine.execution_managers.kernel_execution_manager import n_kernel_managers
+
+        return n_kernel_managers()
 
     def issue_persistent_command(self, persistent_key, command):
         # pylint: disable=import-outside-toplevel

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -2488,7 +2488,7 @@ class ToolboxUI(QMainWindow):
         while self._persistent_consoles:
             self._persistent_consoles.popitem()[1].close()
         while self._jupyter_consoles:
-            self._jupyter_consoles.popitem()[1].close()
+            self._jupyter_consoles.popitem()[1].kernel_client.stop_channels()
 
     def restore_and_activate(self):
         if self.isMinimized():


### PR DESCRIPTION
Fixes shutting down kernel managers running in Spine Engine and a repeating 'Warning: kernel died...' message when switching projects.


Fixes #2013

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
