### PR TITLE
Fix fresh project item names

### DIFF
--- a/spinetoolbox/widgets/add_project_item_widget.py
+++ b/spinetoolbox/widgets/add_project_item_widget.py
@@ -59,7 +59,8 @@ class AddProjectItemWidget(QWidget):
         else:
             prefix = class_.item_type()
             self.ui.comboBox_specification.setEnabled(False)
-        self.name = unique_name(prefix, toolbox.project().all_item_names)
+        existing_item_names = toolbox.project().all_item_names
+        self.name = unique_name(prefix, existing_item_names) if prefix in existing_item_names else prefix
         self.ui.lineEdit_name.setText(self.name)
         self.ui.lineEdit_name.selectAll()
         self.description = ""

--- a/tests/widgets/test_AddProjectItemWidget.py
+++ b/tests/widgets/test_AddProjectItemWidget.py
@@ -49,11 +49,11 @@ class TestAddProjectItemWidget(unittest.TestCase):
 
     def test_name_field_initially_selected(self):
         widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=TestProjectItem)
-        self.assertEqual(widget.ui.lineEdit_name.selectedText(), "TestItemType (1)")
+        self.assertEqual(widget.ui.lineEdit_name.selectedText(), "TestItemType")
 
     def test_find_item_is_used_to_create_prefix(self):
         widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=TestProjectItem)
-        self.assertEqual(widget.ui.lineEdit_name.text(), "TestItemType (1)")
+        self.assertEqual(widget.ui.lineEdit_name.text(), "TestItemType")
 
 
 class TestAddProjectItemWidgetWithSpecifications(unittest.TestCase):


### PR DESCRIPTION
No need to append (1) or any other number to item name that is already unique in Add project item dialog.

Fixes #2111

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
