### PR TITLE
Fix importer spec menu anonymous mode when opened from properties tab

### DIFF
--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -60,6 +60,7 @@ from .project_item_icon import ProjectItemIcon
 from .load_project_items import load_project_items
 from .mvcmodels.project_tree_item import CategoryProjectTreeItem, RootProjectTreeItem
 from .mvcmodels.project_item_model import ProjectItemModel
+from .mvcmodels.project_tree_item import LeafProjectTreeItem
 from .mvcmodels.project_item_specification_models import ProjectItemSpecificationModel, FilteredSpecificationModel
 from .mvcmodels.filter_execution_model import FilterExecutionModel
 from .widgets.set_description_dialog import SetDescriptionDialog
@@ -1219,7 +1220,10 @@ class ToolboxUI(QMainWindow):
             return
         specification = self.specification_model.specification(index.row())
         # Open spec in Tool specification edit widget
-        self.show_specification_form(specification.item_type, specification, item)
+        if item.item_type() == "Importer":
+            item.edit_specification()
+        else:
+            self.show_specification_form(specification.item_type, specification, item)
 
     @Slot(QModelIndex)
     def remove_specification(self, index):


### PR DESCRIPTION
When importer specification menu is opened from the properties tab, it no more opens in anonymous mode. Instead, the spec menu opens in the same way as when opened by double-clicking the item such that available files are shown.

Fixes #1528

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
