### PR TITLE
Black formatting

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-black == 23.3.0
+black == 21.12b0
 pre-commit == 2.0.1
 PyYAML >= 5.4
 pylint >= 2.3.0

--- a/spinetoolbox/widgets/custom_qgraphicsviews.py
+++ b/spinetoolbox/widgets/custom_qgraphicsviews.py
@@ -128,7 +128,7 @@ class CustomQGraphicsView(QGraphicsView):
             self.time_line.start()
         else:
             angle = event.angleDelta().y()
-            factor = self._zoom_factor_base**angle
+            factor = self._zoom_factor_base ** angle
             self.gentle_zoom(factor, event.position().toPoint())
             self._set_preferred_scene_rect()
 
@@ -212,12 +212,12 @@ class CustomQGraphicsView(QGraphicsView):
 
     def zoom_in(self):
         """Perform a zoom in with a fixed scaling."""
-        self.gentle_zoom(self._zoom_factor_base**self._angle)
+        self.gentle_zoom(self._zoom_factor_base ** self._angle)
         self._set_preferred_scene_rect()
 
     def zoom_out(self):
         """Perform a zoom out with a fixed scaling."""
-        self.gentle_zoom(self._zoom_factor_base**-self._angle)
+        self.gentle_zoom(self._zoom_factor_base ** -self._angle)
         self._set_preferred_scene_rect()
 
     def gentle_zoom(self, factor, zoom_focus=None):


### PR DESCRIPTION
We need to stick to black 21.12b0 due to dependency conflicts.

See also spine-tools/spine-items#122 and spine-tools/Spine-Database-API#247

Spine-engine repository was already compatible with the upgraded black, no changes there.

Fixes #2115
## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
