### PR TITLE
Fix Cannot exit from specification editor without naming

### DIFF
--- a/tests/project_item/test_specification_editor_window.py
+++ b/tests/project_item/test_specification_editor_window.py
@@ -155,7 +155,7 @@ class TestSpecificationEditorWindowBase(unittest.TestCase):
             project_item.set_specification(specification)
             self._toolbox.project().add_item(project_item)
             window = SpecificationEditorWindowBase(self._toolbox, item=project_item)
-            mock_make_specification.side_effect = lambda name: ProjectItemSpecification(
+            mock_make_specification.side_effect = lambda name, exiting: ProjectItemSpecification(
                 name, window._spec_toolbar.description(), "Mock"
             )
             mock_save.return_value = {}


### PR DESCRIPTION
When trying to exit an items specification editor without naming the specification, users are now asked if they want to exit without saving or cancel the exit. For the Tool item the same applies when tool type or main program file is not selected.

Fixes #2123

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
