### PR TITLE
Issue 2134 db editor filter behavior

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -150,10 +150,6 @@ class EntityTreeView(ResizableTreeView):
         """Classifies selection by item type and emits signal."""
         self._spine_db_editor.refresh_copy_paste_actions()
         self._refresh_selected_indexes()
-        # if not self.selectionModel().hasSelection():
-        #     return
-        # print(selected)
-        # print(self._selected_indexes)
         self.tree_selection_changed.emit(self._selected_indexes)
 
     def _refresh_selected_indexes(self):

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -150,6 +150,8 @@ class EntityTreeView(ResizableTreeView):
         """Classifies selection by item type and emits signal."""
         self._spine_db_editor.refresh_copy_paste_actions()
         self._refresh_selected_indexes()
+        if not self.selectionModel().hasSelection():
+            return
         self.tree_selection_changed.emit(self._selected_indexes)
 
     def _refresh_selected_indexes(self):

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -15,7 +15,7 @@ Classes for custom QTreeView.
 import pickle
 
 from PySide6.QtWidgets import QApplication, QMenu, QAbstractItemView
-from PySide6.QtCore import Signal, Slot, Qt, QEvent, QTimer, QModelIndex, QItemSelection
+from PySide6.QtCore import Signal, Slot, Qt, QEvent, QTimer, QModelIndex, QItemSelection, QSignalBlocker
 from PySide6.QtGui import QMouseEvent, QIcon
 
 from spinetoolbox.widgets.custom_qtreeview import CopyPasteTreeView
@@ -150,8 +150,6 @@ class EntityTreeView(ResizableTreeView):
         """Classifies selection by item type and emits signal."""
         self._spine_db_editor.refresh_copy_paste_actions()
         self._refresh_selected_indexes()
-        if not self.selectionModel().hasSelection():
-            return
         self.tree_selection_changed.emit(self._selected_indexes)
 
     def _refresh_selected_indexes(self):
@@ -168,7 +166,8 @@ class EntityTreeView(ResizableTreeView):
         """Clears the selection if any."""
         selection_model = self.selectionModel()
         if selection_model.hasSelection():
-            selection_model.clearSelection()
+            with QSignalBlocker(selection_model) as _:
+                selection_model.clearSelection()
 
     @busy_effect
     def fully_expand(self):

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -150,8 +150,10 @@ class EntityTreeView(ResizableTreeView):
         """Classifies selection by item type and emits signal."""
         self._spine_db_editor.refresh_copy_paste_actions()
         self._refresh_selected_indexes()
-        if not self.selectionModel().hasSelection():
-            return
+        # if not self.selectionModel().hasSelection():
+        #     return
+        # print(selected)
+        # print(self._selected_indexes)
         self.tree_selection_changed.emit(self._selected_indexes)
 
     def _refresh_selected_indexes(self):
@@ -671,7 +673,7 @@ class AlternativeTreeView(ItemTreeView):
 class ScenarioTreeView(ItemTreeView):
     """Custom QTreeView for the scenario tree in SpineDBEditor."""
 
-    alternative_selection_changed = Signal(dict)
+    scenario_selection_changed = Signal(dict)
 
     def __init__(self, parent):
         """
@@ -729,7 +731,7 @@ class ScenarioTreeView(ItemTreeView):
 
     @Slot(QItemSelection, QItemSelection)
     def _handle_selection_changed(self, selected, deselected):
-        """Emits alternative_selection_changed with the current selection."""
+        """Emits scenario_selection_changed with the current selection."""
         self._selected_alternative_ids.clear()
         for index in self.selectionModel().selectedRows(column=0):
             item = self.model().item_from_index(index)
@@ -737,7 +739,7 @@ class ScenarioTreeView(ItemTreeView):
                 self._selected_alternative_ids.setdefault(item.db_map, set()).update(item.alternative_id_list)
             elif isinstance(item, ScenarioAlternativeItem) and item.alternative_id is not None:
                 self._selected_alternative_ids.setdefault(item.db_map, set()).add(item.alternative_id)
-        self.alternative_selection_changed.emit(self._selected_alternative_ids)
+        self.scenario_selection_changed.emit(self._selected_alternative_ids)
 
     def remove_selected(self):
         """See base class."""

--- a/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
@@ -205,7 +205,6 @@ class ParameterViewMixin:
             self._filter_entity_ids.setdefault((db_map, class_id), set()).update(ids)
         if Qt.KeyboardModifier.ControlModifier not in QGuiApplication.keyboardModifiers():
             self._clear_all_other_selections(self.ui.treeView_object)
-            self._filter_entity_ids.clear()
             self._filter_alternative_ids.clear()
         self._reset_filters()
         self._set_default_parameter_data(self.ui.treeView_object.selectionModel().currentIndex())
@@ -217,7 +216,7 @@ class ParameterViewMixin:
         active_rel_inds = set(selected_indexes.get("relationship", {}).keys())
         active_rel_cls_inds = rel_cls_inds | {ind.parent() for ind in active_rel_inds}
         if Qt.KeyboardModifier.ControlModifier not in QGuiApplication.keyboardModifiers():
-            pass
+            self._clear_all_other_selections(self.ui.treeView_relationship)
         self._filter_class_ids = self._db_map_ids(active_rel_cls_inds)
         self._filter_entity_ids = self._db_map_class_ids(active_rel_inds)
         self._reset_filters()
@@ -245,7 +244,6 @@ class ParameterViewMixin:
             other_tree_view (AlternativeTreeView or ScenarioTreeView): tree view whose selection didn't change
         """
         if Qt.KeyboardModifier.ControlModifier in QGuiApplication.keyboardModifiers():
-            print(QGuiApplication.keyboardModifiers())
             alternative_ids = {
                 db_map: alt_ids.copy() for db_map, alt_ids in other_tree_view.selected_alternative_ids.items()
             }
@@ -255,7 +253,6 @@ class ParameterViewMixin:
             self._filter_class_ids.clear()
         for db_map, alt_ids in selected_db_map_alt_ids.items():
             alternative_ids.setdefault(db_map, set()).update(alt_ids)
-        # self.clear_all_filters()
         self._filter_alternative_ids = alternative_ids
         self._reset_filters()
 
@@ -265,7 +262,12 @@ class ParameterViewMixin:
         Args:
             current: the selection that was just made
         """
-        trees = [self.ui.treeView_object, self.ui.scenario_tree_view, self.ui.alternative_tree_view]
+        trees = [
+            self.ui.treeView_object,
+            self.ui.scenario_tree_view,
+            self.ui.alternative_tree_view,
+            self.ui.treeView_relationship,
+        ]
         for tree in trees:
             if tree != current:
                 with QSignalBlocker(tree) as _:

--- a/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
@@ -24,7 +24,6 @@ from ..mvcmodels.compound_parameter_models import (
     CompoundRelationshipParameterValueModel,
 )
 from ...helpers import preferred_row_height, DB_ITEM_SEPARATOR
-from spinetoolbox.spine_db_editor.widgets.custom_qtreeview import AlternativeTreeView, ScenarioTreeView
 
 
 class ParameterViewMixin:
@@ -242,6 +241,7 @@ class ParameterViewMixin:
         Args:
             selected_db_map_alt_ids (dict): mapping from database map to set of alternative ids
             other_tree_view (AlternativeTreeView or ScenarioTreeView): tree view whose selection didn't change
+            this_tree_view (AlternativeTreeView or ScenarioTreeView): tree view whose selection changed
         """
         if Qt.KeyboardModifier.ControlModifier in QGuiApplication.keyboardModifiers():
             alternative_ids = {

--- a/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
@@ -203,14 +203,10 @@ class ParameterViewMixin:
             self._filter_class_ids.setdefault(db_map, set()).update(ids)
         for (db_map, class_id), ids in self.db_mngr.db_map_class_ids(cascading_rels).items():
             self._filter_entity_ids.setdefault((db_map, class_id), set()).update(ids)
-        if QGuiApplication.keyboardModifiers() != Qt.KeyboardModifier.ControlModifier:
+        if Qt.KeyboardModifier.ControlModifier not in QGuiApplication.keyboardModifiers():
             self._clear_all_other_selections(self.ui.treeView_object)
-            #if self.ui.scenario_tree_view.selectionModel().hasSelection():
-            #        self.ui.scenario_tree_view.selectionModel().clearSelection()
-            #if self.ui.alternative_tree_view.selectionModel().hasSelection():
-            #        self.ui.alternative_tree_view.selectionModel().clearSelection()
-            #if self.ui.treeView_relationship.selectionModel().hasSelection():
-            #        self.ui.treeView_relationship.selectionModel().clearSelection()
+            self._filter_entity_ids.clear()
+            self._filter_alternative_ids.clear()
         self._reset_filters()
         self._set_default_parameter_data(self.ui.treeView_object.selectionModel().currentIndex())
 
@@ -220,6 +216,8 @@ class ParameterViewMixin:
         rel_cls_inds = set(selected_indexes.get("relationship_class", {}).keys())
         active_rel_inds = set(selected_indexes.get("relationship", {}).keys())
         active_rel_cls_inds = rel_cls_inds | {ind.parent() for ind in active_rel_inds}
+        if Qt.KeyboardModifier.ControlModifier not in QGuiApplication.keyboardModifiers():
+            pass
         self._filter_class_ids = self._db_map_ids(active_rel_cls_inds)
         self._filter_entity_ids = self._db_map_class_ids(active_rel_inds)
         self._reset_filters()
@@ -236,7 +234,7 @@ class ParameterViewMixin:
     def _handle_scenario_alternative_selection_changed(self, selected_db_map_alt_ids):
         """Resets filter according to selection in scenario tree view."""
         self._update_alternative_selection(
-            selected_db_map_alt_ids, self.ui.alternative_tree_view,self.ui.scenario_tree_view
+            selected_db_map_alt_ids, self.ui.alternative_tree_view, self.ui.scenario_tree_view
         )
 
     def _update_alternative_selection(self, selected_db_map_alt_ids, other_tree_view, this_tree_view):
@@ -246,21 +244,18 @@ class ParameterViewMixin:
             selected_db_map_alt_ids (dict): mapping from database map to set of alternative ids
             other_tree_view (AlternativeTreeView or ScenarioTreeView): tree view whose selection didn't change
         """
-        if QGuiApplication.keyboardModifiers() == Qt.KeyboardModifier.ControlModifier:
+        if Qt.KeyboardModifier.ControlModifier in QGuiApplication.keyboardModifiers():
+            print(QGuiApplication.keyboardModifiers())
             alternative_ids = {
                 db_map: alt_ids.copy() for db_map, alt_ids in other_tree_view.selected_alternative_ids.items()
             }
         else:
             alternative_ids = {}
             self._clear_all_other_selections(this_tree_view)
-        #    with QSignalBlocker(other_tree_view) as _:
-        #        other_tree_view.selectionModel().clearSelection()
-        #    if self.ui.treeView_object.selectionModel().hasSelection():
-        #        self.ui.treeView_object.selectionModel().clearSelection()
-        #    if self.ui.treeView_relationship.selectionModel().hasSelection():
-        #        self.ui.treeView_relationship.selectionModel().clearSelection()
+            self._filter_class_ids.clear()
         for db_map, alt_ids in selected_db_map_alt_ids.items():
             alternative_ids.setdefault(db_map, set()).update(alt_ids)
+        # self.clear_all_filters()
         self._filter_alternative_ids = alternative_ids
         self._reset_filters()
 

--- a/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
@@ -251,6 +251,7 @@ class ParameterViewMixin:
             alternative_ids = {}
             self._clear_all_other_selections(this_tree_view)
             self._filter_class_ids.clear()
+            self._filter_entity_ids.clear()
         for db_map, alt_ids in selected_db_map_alt_ids.items():
             alternative_ids.setdefault(db_map, set()).update(alt_ids)
         self._filter_alternative_ids = alternative_ids

--- a/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/parameter_view_mixin.py
@@ -13,9 +13,9 @@
 Contains the ParameterViewMixin class.
 """
 
-from PySide6.QtCore import Qt, Slot, QModelIndex
+from PySide6.QtCore import Qt, Slot, QModelIndex, QSignalBlocker
 from PySide6.QtWidgets import QHeaderView
-from PySide6.QtGui import QGuiApplication, QFocusEvent
+from PySide6.QtGui import QGuiApplication
 from .object_name_list_editor import ObjectNameListEditor
 from ..mvcmodels.compound_parameter_models import (
     CompoundObjectParameterDefinitionModel,
@@ -67,7 +67,7 @@ class ParameterViewMixin:
         """Connects signals to slots."""
         super().connect_signals()
         self.ui.alternative_tree_view.alternative_selection_changed.connect(self._handle_alternative_selection_changed)
-        self.ui.scenario_tree_view.alternative_selection_changed.connect(
+        self.ui.scenario_tree_view.scenario_selection_changed.connect(
             self._handle_scenario_alternative_selection_changed
         )
         self.ui.treeView_object.tree_selection_changed.connect(self._handle_object_tree_selection_changed)
@@ -203,6 +203,14 @@ class ParameterViewMixin:
             self._filter_class_ids.setdefault(db_map, set()).update(ids)
         for (db_map, class_id), ids in self.db_mngr.db_map_class_ids(cascading_rels).items():
             self._filter_entity_ids.setdefault((db_map, class_id), set()).update(ids)
+        if QGuiApplication.keyboardModifiers() != Qt.KeyboardModifier.ControlModifier:
+            self._clear_all_other_selections(self.ui.treeView_object)
+            #if self.ui.scenario_tree_view.selectionModel().hasSelection():
+            #        self.ui.scenario_tree_view.selectionModel().clearSelection()
+            #if self.ui.alternative_tree_view.selectionModel().hasSelection():
+            #        self.ui.alternative_tree_view.selectionModel().clearSelection()
+            #if self.ui.treeView_relationship.selectionModel().hasSelection():
+            #        self.ui.treeView_relationship.selectionModel().clearSelection()
         self._reset_filters()
         self._set_default_parameter_data(self.ui.treeView_object.selectionModel().currentIndex())
 
@@ -220,13 +228,16 @@ class ParameterViewMixin:
     @Slot(dict)
     def _handle_alternative_selection_changed(self, selected_db_map_alt_ids):
         """Resets filter according to selection in alternative tree view."""
-        self._update_alternative_selection(selected_db_map_alt_ids, self.ui.scenario_tree_view, self.ui.alternative_tree_view)
+        self._update_alternative_selection(
+            selected_db_map_alt_ids, self.ui.scenario_tree_view, self.ui.alternative_tree_view
+        )
 
     @Slot(dict)
     def _handle_scenario_alternative_selection_changed(self, selected_db_map_alt_ids):
         """Resets filter according to selection in scenario tree view."""
-
-        self._update_alternative_selection(selected_db_map_alt_ids, self.ui.alternative_tree_view, self.ui.scenario_tree_view)
+        self._update_alternative_selection(
+            selected_db_map_alt_ids, self.ui.alternative_tree_view,self.ui.scenario_tree_view
+        )
 
     def _update_alternative_selection(self, selected_db_map_alt_ids, other_tree_view, this_tree_view):
         """Combines alternative selections from alternative and scenario tree views.
@@ -235,15 +246,32 @@ class ParameterViewMixin:
             selected_db_map_alt_ids (dict): mapping from database map to set of alternative ids
             other_tree_view (AlternativeTreeView or ScenarioTreeView): tree view whose selection didn't change
         """
-        # print(isinstance(other_tree_view, AlternativeTreeView), isinstance(this_tree_view, AlternativeTreeView))
         if QGuiApplication.keyboardModifiers() == Qt.KeyboardModifier.ControlModifier:
             alternative_ids = {
                 db_map: alt_ids.copy() for db_map, alt_ids in other_tree_view.selected_alternative_ids.items()
             }
         else:
             alternative_ids = {}
-            other_tree_view.selectionModel().clearSelection()
+            self._clear_all_other_selections(this_tree_view)
+        #    with QSignalBlocker(other_tree_view) as _:
+        #        other_tree_view.selectionModel().clearSelection()
+        #    if self.ui.treeView_object.selectionModel().hasSelection():
+        #        self.ui.treeView_object.selectionModel().clearSelection()
+        #    if self.ui.treeView_relationship.selectionModel().hasSelection():
+        #        self.ui.treeView_relationship.selectionModel().clearSelection()
         for db_map, alt_ids in selected_db_map_alt_ids.items():
             alternative_ids.setdefault(db_map, set()).update(alt_ids)
         self._filter_alternative_ids = alternative_ids
         self._reset_filters()
+
+    def _clear_all_other_selections(self, current):
+        """Clears all the other selections besides the one that was just made.
+
+        Args:
+            current: the selection that was just made
+        """
+        trees = [self.ui.treeView_object, self.ui.scenario_tree_view, self.ui.alternative_tree_view]
+        for tree in trees:
+            if tree != current:
+                with QSignalBlocker(tree) as _:
+                    tree.selectionModel().clearSelection()


### PR DESCRIPTION
The filter has now been updated between Alternative tree, Scenario tree and Object tree. The user can select multiple elements across these three trees by holding down ctrl. If ctrl is not pressed all other previous selections will be deselected and only the new selection will be active. Selecting with ctrl+shift also works across different trees.

Fixes #2134

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
