### PR TITLE
Fix select new file in Tool Spec Editor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
+-e git+https://github.com/spine-tools/spine-items.git@issue_2099_tool_spec_select_new_file#egg=spine_items
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git@issue_2099_tool_spec_select_new_file#egg=spine_items
+-e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
 -e .

--- a/spinetoolbox/widgets/code_text_edit.py
+++ b/spinetoolbox/widgets/code_text_edit.py
@@ -44,10 +44,14 @@ class CodeTextEdit(QPlainTextEdit):
         self._cursor_block = None
         self.cursorPositionChanged.connect(self._update_line_number_area_cursor_position)
         self._update_line_number_area_width()
+        self._file_selected = False
 
     def insertFromMimeData(self, source):
         if source.hasText():
             self.insertPlainText(source.text())
+
+    def file_selected(self, status):
+        self._file_selected = status
 
     def set_lexer_name(self, lexer_name):
         try:
@@ -121,11 +125,12 @@ class CodeTextEdit(QPlainTextEdit):
         bottom = top + round(self.blockBoundingRect(block).height())
         width = self._line_number_area.width()
         while block.isValid() and top <= ev.rect().bottom():
-            if block.isVisible() and bottom >= ev.rect().top():
-                if block_number == self.textCursor().blockNumber():
-                    painter.fillRect(0, top, width, bottom - top, foreground_color.darker())
-                number = str(block_number + 1)
-                painter.drawText(0, top, width - self._right_margin, bottom - top, Qt.AlignRight, number)
+            if self._file_selected:
+                if block.isVisible() and bottom >= ev.rect().top():
+                    if block_number == self.textCursor().blockNumber():
+                        painter.fillRect(0, top, width, bottom - top, foreground_color.darker())
+                    number = str(block_number + 1)
+                    painter.drawText(0, top, width - self._right_margin, bottom - top, Qt.AlignRight, number)
             block = block.next()
             top = bottom
             bottom = top + round(self.blockBoundingRect(block).height())


### PR DESCRIPTION
If the spec editor of a tool that has no specification is opened, the text editor widget is completely empty and the header is changed into "No file selected". When a main program file is created, it is automatically selected and the text editor is ready for use. +fixed a bug that sometimes when creating a new main program file, the file would be created, but it would not appear in the spec editor.

Re spine-tools/Spine-Toolbox#2099

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
