### PR TITLE
Fix Text and icons overlapping in tool spec editor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
+-e git+https://github.com/spine-tools/spine-items.git@issue_2160_text_and_icons_overlapping#egg=spine_items
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git@issue_2160_text_and_icons_overlapping#egg=spine_items
+-e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
 -e .

--- a/spinetoolbox/widgets/custom_qwidgets.py
+++ b/spinetoolbox/widgets/custom_qwidgets.py
@@ -262,7 +262,7 @@ class ToolBarWidgetBase(QWidget):
         tool_bar (QToolBar)
     """
 
-    def __init__(self, text, parent=None):
+    def __init__(self, text, parent=None, io_files=None):
         """Class constructor.
 
         Args:
@@ -273,7 +273,10 @@ class ToolBarWidgetBase(QWidget):
         self._text = text
         self._parent = parent
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        if io_files:
+            layout.setContentsMargins(0, 0, 0, 0)
+        else:
+            layout.setContentsMargins(30, 0, 0, 0)
         layout.setSpacing(0)
         self.tool_bar = _MenuToolBar(self)
         layout.addStretch()
@@ -286,8 +289,8 @@ class ToolBarWidgetBase(QWidget):
 
 
 class ToolBarWidget(ToolBarWidgetBase):
-    def __init__(self, text, parent=None):
-        super().__init__(text, parent)
+    def __init__(self, text, parent=None, io_files=None):
+        super().__init__(text, parent, io_files)
         spacing = self.fontMetrics().horizontalAdvance(self._text)  # pylint: disable=undefined-variable
         self.layout().insertSpacing(0, spacing)
 


### PR DESCRIPTION
The icons in Program files and Input & output files -widgets don't overlap with the texts anymore.

Fixes #2160

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
