### PR TITLE
fix icons disappear when double-clicking an existing specification

### DIFF
--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -1241,7 +1241,7 @@ class ToolboxUI(QMainWindow):
             index (QModelIndex): Index of the item (from double-click or context menu signal)
             item (ProjectItem, optional)
         """
-        if not index.isValid():
+        if not index.isValid() or not item:
             return
         specification = self.specification_model.specification(index.row())
         # Open spec in Tool specification edit widget


### PR DESCRIPTION
Fixed bug where double-clicking an existing tool specification in the toolbar caused weird behavior like the icons disappearing. The bug was caused by the fix to issue #1528.

Re #1528

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
