### PR TITLE
upgrade pyside to fix Windows 11 crash

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 packages = find:
 zip_safe = False
 install_requires =
-    pyside6 >=6.4.0, !=6.4.2, < 6.5.0
+    pyside6 >=6.5.0
     psutil <5.9.2  # As of 2022-09-05 psutil 5.9.2 requires extra Microsoft Visual Build Tools installation
     jupyter-client >=6.0
     qtconsole >=5.1


### PR DESCRIPTION
Update PySide6 requirements to >= 6.5.0

Fixes issues #2121 and #2161

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
