### PR TITLE
Add tooltip warning about long scenario names in db editor

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/alternative_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/alternative_item.py
@@ -47,7 +47,8 @@ class AlternativeItem(GrayIfLastMixin, EditableMixin, LeafItem):
 
     @property
     def tool_tip(self):
-        return "<p>Drag this item it onto a <b>scenario</b> item in Scenario tree to add it to that scenario.</p>"
+        if self.id:
+            return "<p>Drag this item it onto a <b>scenario</b> item in Scenario tree to add it to that scenario.</p>"
 
     def add_item_to_db(self, db_item):
         self.db_mngr.add_alternatives({self.db_map: [db_item]})

--- a/spinetoolbox/spine_db_editor/mvcmodels/scenario_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/scenario_item.py
@@ -58,6 +58,11 @@ class ScenarioItem(GrayIfLastMixin, EditableMixin, EmptyChildMixin, FetchMoreMix
     def icon_code(self):
         return _SCENARIO_ICON
 
+    @property
+    def tool_tip(self):
+        if not self.id:
+            return "<p><b>Note</b>: Scenario names longer than 20 characters might appear shortened in generated files.</p>"
+
     def _do_set_up(self):
         """Doesn't add children to the last row."""
         if not self.id:


### PR DESCRIPTION
Added a note about scenario names getting shortened down to 20 characters when files with scenario names are generated as a tooltip in the scenario tree. Increased the amount of scenario names' characters in generated subdirectories from 15 to 20. Also removed incorrect tooltip from the last item in the alternative tree. issue 

Fixes #2081

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
