### PR TITLE
fix selecting objects and object classes in db editor

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/single_parameter_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_parameter_models.py
@@ -418,21 +418,22 @@ class SingleParameterValueMixin(
 
     def filter_accepts_item(self, item):
         """Reimplemented to also account for the entity and alternative filter."""
-        # return (
-        #     super().filter_accepts_item(item)
-        #     and self._entity_filter_accepts_item(item)
-        #     and self._alternative_filter_accepts_item(item)
-        # )
-
-        a = super().filter_accepts_item(item)
-        b = self._entity_filter_accepts_item(item)
-        c = self._alternative_filter_accepts_item(item)
-        # print(a, b, c)
-        return a and b and c
+        return (
+            super().filter_accepts_item(item)
+            and self._entity_filter_accepts_item(item)
+            and self._alternative_filter_accepts_item(item)
+        )
 
     def _entity_filter_accepts_item(self, item):
         """Returns the result of the entity filter."""
+        object_class_id = item["object_class_id"]
         if not self._filter_db_map_class_entity_ids:
+            return True
+        try:
+            active_class_ids = [i[1] for i in self._filter_db_map_class_entity_ids.keys()]
+        except TypeError:
+            active_class_ids = []
+        if object_class_id and object_class_id not in active_class_ids:
             return True
         entity_id = item["entity_id"]
         return entity_id in self._filter_entity_ids


### PR DESCRIPTION
Again enables object class and object selection simultaneously.

Re #2134

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
