### PR TITLE
Speed up checking Tools' notifications

### DIFF
--- a/spinetoolbox/mvcmodels/file_list_models.py
+++ b/spinetoolbox/mvcmodels/file_list_models.py
@@ -180,14 +180,12 @@ class FileListModel(QAbstractItemModel):
         pack_paths = [Path(r.path) for item in self._pack_resources for r in item.resources if r.hasfilepath]
         paths = single_paths + pack_paths
         duplicates = set()
-        for p1, p2 in combinations(paths, 2):
-            try:
-                if p1 == p2:
-                    duplicates.add(str(p2))
-            except OSError:
-                # Sometimes file access fails e.g. in the middle of replacing
-                # resources when a connected DC is being renamed.
-                continue
+        seen = set()
+        for path in paths:
+            if str(path) in seen:
+                duplicates.add(str(path))
+            else:
+                seen.add(str(path))
         return duplicates
 
     def _pack_index(self, pack_label):

--- a/tests/mvcmodels/test_FileListModel.py
+++ b/tests/mvcmodels/test_FileListModel.py
@@ -1,0 +1,61 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Items.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""
+Unit tests for FileListModel class.
+"""
+
+import unittest
+from PySide6.QtWidgets import QApplication
+from pathlib import Path
+from spinetoolbox.mvcmodels.file_list_models import FileListModel
+from spine_engine.project_item.project_item_resource import file_resource, file_resource_in_pack
+
+
+class TestFileListModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._model = FileListModel()
+
+    def tearDown(self):
+        self._model.deleteLater()
+
+    def test_duplicate_files(self):
+        dupe1 = file_resource("item name", str(Path.cwd() / "path" / "to" / "other" / "file" / "A1"), "file label")
+        dupe2 = file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file"))
+        single_resources = [
+            dupe1,
+            dupe1,
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "A1"), "file label"),
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "Worcestershire"), "file label"),
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "Sriracha"), "file label"),
+            file_resource("some name", str(Path.cwd() / "path" / "to" / "other" / "file" / "B12"), "file label"),
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "other" / "file" / "Sriracha"), "some label"),
+        ]
+        pack_resources = [
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "other" / "pack_file")),
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "some" / "pack_file")),
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file2")),
+            dupe2,
+            file_resource_in_pack("some name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file21")),
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file3")),
+            dupe2
+        ]
+        self._model.update(single_resources + pack_resources)
+        results = self._model.duplicate_paths()
+        expected = set()
+        expected.add(str(dupe1.path))
+        expected.add(str(dupe2.path))
+        self.assertEqual(results, expected)


### PR DESCRIPTION
On large projects that have a large amount of files as possible resources for a Tool, checking the Tool's notifications took a long time. Now the checks for duplicate files in resource files and checking if the input file requirements are met are only conducted when either the requirements or resources have changed. The checking of file duplicates has also been made faster.

Re #2083

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
