### PR TITLE
Fix SpineOpt installer wizard

### DIFF
--- a/spinetoolbox/widgets/add_up_spine_opt_wizard.py
+++ b/spinetoolbox/widgets/add_up_spine_opt_wizard.py
@@ -53,10 +53,11 @@ class AddUpSpineOptWizard(QWizard):
     """A wizard to install & upgrade SpineOpt."""
 
     def __init__(self, parent, julia_exe, julia_project):
-        """Initialize class.
-
+        """
         Args:
             parent (QWidget): the parent widget (SettingsWidget)
+            julia_exe (str): path to Julia executable
+            julia_project (str): path to Julia project
         """
         super().__init__(parent)
         self.process_log = None
@@ -125,13 +126,15 @@ class SelectJuliaPage(QWizardPage):
         self._julia_exe_line_edit.setText(self._julia_exe)
         self._julia_project_line_edit.setText(self._julia_project)
 
-    def _select_julia_exe(self):
+    @Slot(bool)
+    def _select_julia_exe(self, _):
         julia_exe, _ = QFileDialog.getOpenFileName(self, "Select Julia executable", self.field("julia_exe"))
         if not julia_exe:
             return
         self.setField("julia_exe", julia_exe)
 
-    def _select_julia_project(self):
+    @Slot(bool)
+    def _select_julia_project(self, _):
         julia_project = QFileDialog.getExistingDirectory(
             self, "Select Julia project (directory)", self.field("julia_project")
         )
@@ -181,11 +184,10 @@ class CheckPreviousInstallPage(QWizardPage):
         qApp.setOverrideCursor(QCursor(Qt.BusyCursor))  # pylint: disable=undefined-variable
         self._exec_mngr.start_execution()
 
-    @Slot(int)
     def _handle_check_install_finished(self, ret):
         qApp.restoreOverrideCursor()  # pylint: disable=undefined-variable
         self._exec_mngr.execution_finished.disconnect(self._handle_check_install_finished)
-        if self.wizard().currentPage() != self:
+        if self.wizard().currentPage() is not self:
             return
         output_log = self._exec_mngr.process_output
         error_log = self._exec_mngr.process_error
@@ -258,11 +260,10 @@ class AddUpSpineOptPage(QWizardProcessPage):
         qApp.setOverrideCursor(QCursor(Qt.BusyCursor))  # pylint: disable=undefined-variable
         self._exec_mngr.start_execution()
 
-    @Slot(int)
     def _handle_spine_opt_add_up_finished(self, ret):
         qApp.restoreOverrideCursor()  # pylint: disable=undefined-variable
         self._exec_mngr.execution_finished.disconnect(self._handle_spine_opt_add_up_finished)
-        if self.wizard().currentPage() != self:
+        if self.wizard().currentPage() is not self:
             return
         self._exec_mngr = None
         self._successful = ret == 0
@@ -387,8 +388,8 @@ class TroubleshootProblemsPage(QWizardPage):
         layout.addStretch()
         self.registerField("problem1", self._button1)
         self.registerField("problem2", self._button2)
-        self._button1.toggled.connect(self.completeChanged)
-        self._button2.toggled.connect(self.completeChanged)
+        self._button1.toggled.connect(lambda _: self.completeChanged.emit())
+        self._button2.toggled.connect(lambda _: self.completeChanged.emit())
         button_view_log.clicked.connect(self._show_log)
 
     def isComplete(self):
@@ -480,11 +481,10 @@ class ResetRegistryPage(QWizardProcessPage):
         qApp.setOverrideCursor(QCursor(Qt.BusyCursor))  # pylint: disable=undefined-variable
         self._exec_mngr.start_execution()
 
-    @Slot(int)
     def _handle_registry_reset_finished(self, ret):
         qApp.restoreOverrideCursor()  # pylint: disable=undefined-variable
         self._exec_mngr.execution_finished.disconnect(self._handle_registry_reset_finished)
-        if self.wizard().currentPage() != self:
+        if self.wizard().currentPage() is not self:
             return
         self._exec_mngr = None
         self._successful = ret == 0

--- a/spinetoolbox/widgets/custom_qwidgets.py
+++ b/spinetoolbox/widgets/custom_qwidgets.py
@@ -551,7 +551,7 @@ class QWizardProcessPage(QWizardPage):
         def __set__(self, obj, value):
             setattr(obj, self.private_name, value)
             try:
-                value.execution_finished.connect(obj.widget_copy.show)
+                value.execution_finished.connect(lambda _: obj.widget_copy.show())
             except AttributeError:
                 pass
 
@@ -587,7 +587,7 @@ class QWizardProcessPage(QWizardPage):
         self.msg.connect(self._add_msg)
         self.msg_warning.connect(self._add_msg_warning)
         self.msg_error.connect(self._add_msg_error)
-        self.msg_success.connect(self._add_msg_succes)
+        self.msg_success.connect(self._add_msg_success)
         self.msg_proc.connect(self._add_msg)
         self.msg_proc_error.connect(self._add_msg_error)
         self._button_copy.clicked.connect(self._handle_copy_clicked)
@@ -597,16 +597,20 @@ class QWizardProcessPage(QWizardPage):
         self._label_copy.show()
         qApp.clipboard().setText(self._log.toPlainText())  # pylint: disable=undefined-variable
 
+    @Slot(str)
     def _add_msg(self, msg):
         self._log.append(format_log_message("msg", msg, show_datetime=False))
 
+    @Slot(str)
     def _add_msg_warning(self, msg):
         self._log.append(format_log_message("msg_warning", msg, show_datetime=False))
 
+    @Slot(str)
     def _add_msg_error(self, msg):
         self._log.append(format_log_message("msg_error", msg, show_datetime=False))
 
-    def _add_msg_succes(self, msg):
+    @Slot(str)
+    def _add_msg_success(self, msg):
         self._log.append(format_log_message("msg_success", msg, show_datetime=False))
 
     def isComplete(self):
@@ -672,6 +676,7 @@ class HorizontalSpinBox(QToolBar):
         except TypeError:
             pass
 
+    @Slot(str)
     def setValue(self, value, strict=False):
         try:
             value = int(value)

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -136,14 +136,14 @@ class SettingsWidgetBase(QWidget):
         """Gets selections and saves them to persistent memory."""
         return True
 
-    @Slot(bool)
-    def update_ui_and_close(self, checked=False):
+    @Slot()
+    def update_ui_and_close(self):
         """Updates UI to reflect current settings and close."""
         self.update_ui()
         self.close()
 
-    @Slot(bool)
-    def save_and_close(self, checked=False):
+    @Slot()
+    def save_and_close(self):
         """Saves settings and close."""
         if self.save_settings():
             self.close()

--- a/tests/mvcmodels/test_FileListModel.py
+++ b/tests/mvcmodels/test_FileListModel.py
@@ -51,7 +51,7 @@ class TestFileListModel(unittest.TestCase):
             dupe2,
             file_resource_in_pack("some name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file21")),
             file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file3")),
-            dupe2
+            dupe2,
         ]
         self._model.update(single_resources + pack_resources)
         results = self._model.duplicate_paths()

--- a/tests/widgets/test_AddUpSpineOptWizard.py
+++ b/tests/widgets/test_AddUpSpineOptWizard.py
@@ -42,6 +42,7 @@ class TestAddUpSpineOptWizard(unittest.TestCase):
     def tearDown(self):
         """Clean up."""
         clean_up_toolbox(self.toolbox)
+        self.settings_widget.deleteLater()
 
     def test_spine_opt_installation_succeeds(self):
         wizard = AddUpSpineOptWizard(self.settings_widget, "path/to/julia", "path/to/julia_project")


### PR DESCRIPTION
This fixes a crash that occurred after SpineOpt was installed in SpineOpt installer wizard.

Also fixes unit tests which crashed due to the same issue.

Fixes #2202

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
