### PR TITLE
Issue 2206 plot data not visible

### DIFF
--- a/spinetoolbox/widgets/plot_widget.py
+++ b/spinetoolbox/widgets/plot_widget.py
@@ -79,7 +79,6 @@ class PlotWidget(QWidget):
         data_dicts = []
         for xy_data in self.original_xy_data:
             label = " | ".join(["None" if name is None else name for name in xy_data.data_index])
-            # label = " | ".join(xy_data.data_index)
             header.append(label)
             indexes.append(xy_data.x)
             data_dict = dict(zip(xy_data.x, xy_data.y))

--- a/spinetoolbox/widgets/plot_widget.py
+++ b/spinetoolbox/widgets/plot_widget.py
@@ -78,7 +78,8 @@ class PlotWidget(QWidget):
         indexes = []
         data_dicts = []
         for xy_data in self.original_xy_data:
-            label = " | ".join(xy_data.data_index)
+            label = " | ".join(["None" if name is None else name for name in xy_data.data_index])
+            # label = " | ".join(xy_data.data_index)
             header.append(label)
             indexes.append(xy_data.x)
             data_dict = dict(zip(xy_data.x, xy_data.y))


### PR DESCRIPTION
Now it is possible to view and copy plot data on plots that have some of the names in their label as None.

Fixes #2206

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
