### PR TITLE
Fix modifying map indexes

### DIFF
--- a/spinetoolbox/mvcmodels/map_model.py
+++ b/spinetoolbox/mvcmodels/map_model.py
@@ -509,6 +509,8 @@ def _reconstruct_map(tree):
         values.append(value)
     if len(indexes) > 1:
         first_type = type(indexes[0])
+        if first_type == numpy.float_:
+            first_type = float
         if any(not isinstance(i, first_type) for i in indexes[1:]):
             raise ParameterValueFormatError(f"Index type mismatch.")
     map_ = Map(indexes, values)

--- a/tests/widgets/test_custom_qwidgets.py
+++ b/tests/widgets/test_custom_qwidgets.py
@@ -40,7 +40,7 @@ class TestFilterWidget(unittest.TestCase):
         model = self._widget._ui_list.model()
         data = [model.index(row, 0).data() for row in range(model.rowCount())]
         self.assertEqual(data, ["(Select all)", "(Empty)", "ei", "bii", "cii"])
-        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) for row in range(model.rowCount())]
+        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole).value for row in range(model.rowCount())]
         self.assertEqual(checked, 5 * [Qt.CheckState.Checked.value])
         self.assertEqual(self._widget._filter_state, ["ei", "bii", "cii"])
         self.assertIsNone(self._widget._filter_empty_state)
@@ -49,7 +49,7 @@ class TestFilterWidget(unittest.TestCase):
         model = self._widget._ui_list.model()
         self._widget._ui_list.clicked.emit(model.index(1, 0))
         model = self._widget._ui_list.model()
-        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) for row in range(model.rowCount())]
+        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole).value for row in range(model.rowCount())]
         self.assertEqual(
             checked,
             [
@@ -66,7 +66,7 @@ class TestFilterWidget(unittest.TestCase):
         model = self._widget._ui_list.model()
         self._widget._ui_list.clicked.emit(model.index(2, 0))
         model = self._widget._ui_list.model()
-        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) for row in range(model.rowCount())]
+        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole).value for row in range(model.rowCount())]
         self.assertEqual(
             checked,
             [
@@ -83,7 +83,7 @@ class TestFilterWidget(unittest.TestCase):
         model = self._widget._ui_list.model()
         self._widget._ui_list.clicked.emit(model.index(0, 0))
         model = self._widget._ui_list.model()
-        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) for row in range(model.rowCount())]
+        checked = [model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole).value for row in range(model.rowCount())]
         self.assertEqual(checked, 5 * [Qt.CheckState.Unchecked.value])
         self.assertTrue(self._widget.has_filter())
 


### PR DESCRIPTION
Index type mismatch error doesn't happen between floats anymore in the map editor.

Fixes #2208

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
