### PR TITLE
Fix overlapping xticks

### DIFF
--- a/spinetoolbox/plotting.py
+++ b/spinetoolbox/plotting.py
@@ -298,6 +298,10 @@ def plot_data(data_list, plot_widget=None, plot_type=None):
     plot_widget.canvas.axes.set_xlabel(squeezed_data[0].x_label.label)
     plot_title = " | ".join(map(str, common_indexes))
     plot_widget.canvas.axes.set_title(plot_title)
+    for data in data_list:
+        print(type(data.x[0]))
+        if type(data.x[0]) not in (float, np.float_, int):
+            plot_widget.canvas.axes.tick_params(axis='x', labelrotation=30)
     if len(squeezed_data) > 1:
         plot_widget.add_legend(legend_handles)
     if needs_redraw:

--- a/spinetoolbox/plotting.py
+++ b/spinetoolbox/plotting.py
@@ -299,7 +299,6 @@ def plot_data(data_list, plot_widget=None, plot_type=None):
     plot_title = " | ".join(map(str, common_indexes))
     plot_widget.canvas.axes.set_title(plot_title)
     for data in data_list:
-        print(type(data.x[0]))
         if type(data.x[0]) not in (float, np.float_, int):
             plot_widget.canvas.axes.tick_params(axis='x', labelrotation=30)
     if len(squeezed_data) > 1:

--- a/spinetoolbox/widgets/time_series_fixed_resolution_editor.py
+++ b/spinetoolbox/widgets/time_series_fixed_resolution_editor.py
@@ -159,6 +159,7 @@ class TimeSeriesFixedResolutionEditor(QWidget):
         """Updated the plot."""
         self._ui.plot_widget.canvas.axes.cla()
         add_time_series_plot(self._ui.plot_widget, self._model.value)
+        self._ui.plot_widget.canvas.axes.tick_params(axis='x', labelrotation=30)
         self._ui.plot_widget.canvas.draw()
 
     def value(self):

--- a/spinetoolbox/widgets/time_series_variable_resolution_editor.py
+++ b/spinetoolbox/widgets/time_series_variable_resolution_editor.py
@@ -82,6 +82,7 @@ class TimeSeriesVariableResolutionEditor(QWidget):
         """Updates the plot widget."""
         self._ui.plot_widget.canvas.axes.cla()
         add_time_series_plot(self._ui.plot_widget, self._model.value)
+        self._ui.plot_widget.canvas.axes.tick_params(axis='x', labelrotation=30)
         self._ui.plot_widget.canvas.draw()
 
     def value(self):


### PR DESCRIPTION
In plots the x-tick labels don't overlap anymore.

Fixes #2213

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
