### PR TITLE
Fix array editor indices starting point different from plot's

### DIFF
--- a/spinetoolbox/mvcmodels/array_model.py
+++ b/spinetoolbox/mvcmodels/array_model.py
@@ -130,7 +130,7 @@ class ArrayModel(QAbstractTableModel):
         column = index.column()
         if column == 0:
             if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
-                return row + 1
+                return row
             else:
                 return None
         if role == Qt.ItemDataRole.DisplayRole:

--- a/tests/mvcmodels/test_ArrayModel.py
+++ b/tests/mvcmodels/test_ArrayModel.py
@@ -38,7 +38,7 @@ class TestArrayModel(unittest.TestCase):
     def test_data_for_first_row_returns_none_with_empty_array(self):
         model = ArrayModel(self._parent)
         roles = [Qt.ItemDataRole.DisplayRole, Qt.ToolTip]
-        self.assertEqual(model.index(0, 0).data(), 1)
+        self.assertEqual(model.index(0, 0).data(), 0)
         index = model.index(0, 1)
         self.assertTrue(index.isValid())
         for role in roles:
@@ -54,7 +54,7 @@ class TestArrayModel(unittest.TestCase):
         model = ArrayModel(self._parent)
         self.assertTrue(model.insertRows(0, 2))
         self.assertEqual(model.rowCount(), 3)
-        expected_index = [1, 2, 3]
+        expected_index = [0, 1, 2]
         expected_data = ["0.0", "0.0", None]
         for row, (index, data) in enumerate(zip(expected_index, expected_data)):
             self.assertEqual(model.index(row, 0).data(), index)
@@ -77,7 +77,7 @@ class TestArrayModel(unittest.TestCase):
         model.reset(Array([5.0]))
         model.batch_set_data([model.index(0, 0)], ["2.3"])
         self.assertEqual(model.rowCount(), 2)
-        self.assertEqual(model.index(0, 0).data(), 1)
+        self.assertEqual(model.index(0, 0).data(), 0)
         self.assertEqual(model.index(0, 1).data(), "2.3")
 
     def test_batch_set_data_on_last_row_extends_table(self):

--- a/tests/widgets/test_ArrayTableView.py
+++ b/tests/widgets/test_ArrayTableView.py
@@ -84,7 +84,7 @@ class TestArrayTableView(unittest.TestCase):
         clip = StringIO(QApplication.clipboard().text())
         array = [row for row in csv.reader(clip, delimiter='\t')]
         with system_lc_numeric():
-            self.assertEqual(array, [["1", locale.str(5.5)]])
+            self.assertEqual(array, [["0", locale.str(5.5)]])
         table_view.deleteLater()
 
     def test_paste_non_numeric_to_empty_table(self):


### PR DESCRIPTION
Array editors indexing now also starts from zero so that it is consistent with the data that is saved.

Fixes #2217)

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
