### PR TITLE
Fix alternative and scenario filtering

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -514,7 +514,7 @@ class ToolFeatureTreeView(ItemTreeView):
 class AlternativeTreeView(ItemTreeView):
     """Custom QTreeView for the alternative tree in SpineDBEditor."""
 
-    alternative_selection_changed = Signal(dict)
+    alternative_selection_changed = Signal(object)
 
     def __init__(self, parent):
         """
@@ -674,7 +674,7 @@ class AlternativeTreeView(ItemTreeView):
 class ScenarioTreeView(ItemTreeView):
     """Custom QTreeView for the scenario tree in SpineDBEditor."""
 
-    scenario_selection_changed = Signal(dict)
+    scenario_selection_changed = Signal(object)
 
     def __init__(self, parent):
         """


### PR DESCRIPTION
Somehow dict didn't work anymore on the signals that track alternative- and scenario tree selections, causing filtering by them to be broken.

Fixes #2225

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
