### PR TITLE
Fix entity group updates in Object tree

### DIFF
--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -53,7 +53,7 @@ class TreeItem:
     def children(self, children):
         bad_types = [type(child) for child in children if not isinstance(child, TreeItem)]
         if bad_types:
-            raise TypeError(f"Cand't set children of type {bad_types} for an item of type {type(self)}")
+            raise TypeError(f"Can't set children of type {bad_types} for an item of type {type(self)}")
         for child in children:
             child.parent_item = self
         self._children = children

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -163,6 +163,11 @@ class ObjectClassItem(EntityClassItem):
         super().tear_down()
         self._entity_group_fetch_parent.set_obsolete(True)
 
+    def revitalize(self):
+        """See base class"""
+        super().revitalize()
+        self._entity_group_fetch_parent.set_obsolete(False)
+
 
 class RelationshipClassItem(EntityClassItem):
     """A relationship_class item."""

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -353,9 +353,10 @@ class MultiDBTreeItem(TreeItem):
                 new_children.append(new_child)
             if child.display_id in display_ids[:row] + display_ids[row + 1 :] or child.should_be_merged():
                 # Take the child and put it in the list to be merged
-                new_children.append(child)
                 self.remove_children(row, 1)
                 display_ids.pop(row)
+                child.revitalize()
+                new_children.append(child)
         self._deep_refresh_children()
         self._merge_children(new_children)
         top_left = self.model.index(0, 0, self.index())
@@ -448,3 +449,9 @@ class MultiDBTreeItem(TreeItem):
     def tear_down(self):
         super().tear_down()
         self._fetch_parent.set_obsolete(True)
+
+    def revitalize(self):
+        """Reverts tear down operation"""
+        self._fetch_parent.set_obsolete(False)
+        for child in self._children:
+            child.revitalize()

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -877,11 +877,13 @@ class ObjectGroupDialogBase(QDialog):
         object_ids = self.db_map_object_ids[self.db_map]
         members = []
         non_members = []
+        initial_member_ids = self.initial_member_ids()
+        initial_entity_id = self.initial_entity_id()
         for obj_name in sorted(object_ids):
             obj_id = object_ids[obj_name]
-            if obj_id in self.initial_member_ids():
+            if obj_id in initial_member_ids:
                 members.append(obj_name)
-            elif obj_id != self.initial_entity_id():
+            elif obj_id != initial_entity_id:
                 non_members.append(obj_name)
         member_items = [QTreeWidgetItem([obj_name]) for obj_name in members]
         non_member_items = [QTreeWidgetItem([obj_name]) for obj_name in non_members]

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -1405,7 +1405,9 @@ class SpineDBManager(QObject):
         """Removes items from database.
 
         Args:
-            db_map_typed_ids (dict): mapping DiffDatabaseMapping to item type (str) to lists of items to remove
+            item_type (str): database item type
+            db_map_ids (dict): mapping DatabaseMapping to removable ids
+            callback (Callable): function to call after removal is finished
         """
         for db_map, ids in db_map_ids.items():
             try:

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -517,7 +517,9 @@ class SpineDBWorker(QObject):
         """Removes items from database.
 
         Args:
-            ids_per_type (dict): lists of items to remove keyed by item type (str)
+            item_type (str): item type
+            ids (Iterable of int): removable item ids
+            callback (Callable, optional): function to call after items have been removed
         """
         if self._committing:
             with self._db_map.override_committing(self._committing):


### PR DESCRIPTION
This PR fixes a bug where adding or removing objects from entity groups using Manage members dialog would not update the Object tree properly.

Fixes #2219

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
