### PR TITLE
Fix segfault and empty output file when exporting from Database editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
@@ -135,7 +135,7 @@ class MassExportItemsDialog(MassSelectItemsDialog):
     """A dialog to let users chose items for JSON export."""
 
     _warn_checked_non_data_items = False
-    data_submitted = Signal(dict)
+    data_submitted = Signal(object)
 
     def __init__(self, parent, db_mngr, *db_maps, stored_state=None):
         """

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -530,7 +530,7 @@ class SpineDBEditorBase(QMainWindow):
             self, self.db_mngr, *self.db_maps, stored_state=self._export_items_dialog_state
         )
         self._export_items_dialog.state_storing_requested.connect(self._store_export_settings)
-        self._export_items_dialog.data_submitted.connect(self.mass_export_items)
+        self._export_items_dialog.data_submitted.connect(self.mass_export_items, Qt.ConnectionType.QueuedConnection)
         self._export_items_dialog.destroyed.connect(self._clean_up_export_items_dialog)
         self._export_items_dialog.show()
 
@@ -571,6 +571,7 @@ class SpineDBEditorBase(QMainWindow):
         parcel.push_object_group_ids(db_map_ent_group_ids)
         self.export_data(parcel.data)
 
+    @Slot(object)
     def mass_export_items(self, db_map_item_types):
         def _ids(t, types):
             return Asterisk if t in types else ()
@@ -924,6 +925,10 @@ class SpineDBEditorBase(QMainWindow):
         self.save_window_state()
         super().closeEvent(event)
 
+    @staticmethod
+    def _get_base_dir():
+        return APPLICATION_PATH
+
 
 class SpineDBEditor(TabularViewMixin, GraphViewMixin, ParameterViewMixin, TreeViewMixin, SpineDBEditorBase):
     """A widget to visualize Spine dbs."""
@@ -1192,7 +1197,3 @@ class SpineDBEditor(TabularViewMixin, GraphViewMixin, ParameterViewMixin, TreeVi
         for model in self._parameter_models:
             model.stop_invalidating_filter()
         return True
-
-    @staticmethod
-    def _get_base_dir():
-        return APPLICATION_PATH


### PR DESCRIPTION
This PR fixes two issues with exporting data from Database editor.

- The output file contained empty data due to bug in PySide6 (https://bugreports.qt.io/browse/PYSIDE-2406)
- The operation lead to segmentation fault due to some change in how signals were processed in PySide6

Fixes #2280

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
