### PR TITLE
Fix undo/redo in Database editor

### DIFF
--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -272,6 +272,7 @@ class AddItemsCommand(SpineDBCommand):
             self.redo_db_map_data,
             self.item_type,
             readd=self._readd,
+            cascade=False,
             check=self._check,
             callback=self.handle_redo_complete,
         )
@@ -285,7 +286,7 @@ class AddItemsCommand(SpineDBCommand):
         if self.db_map not in db_map_data:
             self.setObsolete(True)
             return
-        self.redo_db_map_data = db_map_data
+        self.redo_db_map_data = {db_map: [x.deepcopy() for x in data] for db_map, data in db_map_data.items()}
         self.undo_db_map_ids = {db_map: {x["id"] for x in data} for db_map, data in db_map_data.items()}
 
 

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -999,7 +999,7 @@ class SpineDBManager(QObject):
             if to_add:
                 yield AddItemsCommand(self, db_map, to_add, item_type, check=False)
 
-    def add_items(self, db_map_data, item_type, readd=False, check=True, callback=None):
+    def add_items(self, db_map_data, item_type, readd=False, cascade=True, check=True, callback=None):
         for db_map, data in db_map_data.items():
             try:
                 worker = self._get_worker(db_map)
@@ -1007,7 +1007,7 @@ class SpineDBManager(QObject):
                 # We're closing the kiosk.
                 continue
             cache = self.get_db_map_cache(db_map)
-            worker.add_items(data, item_type, readd, check, cache, callback)
+            worker.add_items(data, item_type, readd, cascade, check, cache, callback)
 
     def update_items(self, db_map_data, item_type, check=True, callback=None):
         for db_map, data in db_map_data.items():

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -405,13 +405,14 @@ class SpineDBWorker(QObject):
             yield item_type, items
 
     @busy_effect
-    def add_items(self, orig_items, item_type, readd, check, cache, callback):
+    def add_items(self, orig_items, item_type, readd, cascade, check, cache, callback):
         """Adds items to db.
 
         Args:
             orig_items (dict): lists of items to add or update
             item_type (str): item type
             readd (bool) : Whether to re-add items that were previously removed
+            cascade (bool): Whether to add items in cascade or just the root items
             check (bool): Whether to check integrity
             cache (dict): Cache
             callback (None or function): something to call with the result
@@ -468,7 +469,10 @@ class SpineDBWorker(QObject):
                         # Item may have been unbound on commit.
                         # We need to rebind it so cascade_readd() notifies fetch parents properly.
                         self._rebind_recursively(item_in_cache)
-                    item_in_cache.cascade_readd()
+                    if cascade:
+                        item_in_cache.cascade_readd()
+                    else:
+                        item_in_cache.readd()
                     data.append(item_in_cache)
             db_map_data = {self._db_map: data}
             if item_type == actual_item_type and callback is not None:


### PR DESCRIPTION
This PR fixes undoing item removal after committing to a database.

For `spinedb_api` side changes, see spine-tools/Spine-Database-API#256

Fixes #2228

@manuelma Hopefully this will not be as bad to merge to the entity branch as it looks.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
