### PR TITLE
Fix Traceback after loading new database in Database editor tab

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -174,6 +174,9 @@ class TabularViewMixin:
     def init_models(self):
         """Initializes models."""
         super().init_models()
+        self.current_class_id.clear()
+        self.current_class_type = None
+        self.current_class_name = None
         self.clear_pivot_table()
 
     @Slot(QModelIndex, object)

--- a/spinetoolbox/widgets/multi_tab_window.py
+++ b/spinetoolbox/widgets/multi_tab_window.py
@@ -474,7 +474,7 @@ class TabBarPlus(QTabBar):
         self._plus_button.setIcon(QIcon(CharIconEngine("\uf067")))
         self._plus_button.clicked.connect(lambda _=False: self.plus_clicked.emit())
         self._move_plus_button()
-        self.setShape(QTabBar.RoundedNorth)
+        self.setShape(QTabBar.Shape.RoundedNorth)
         self.setTabsClosable(True)
         self.setMovable(True)
         self.setElideMode(Qt.ElideLeft)


### PR DESCRIPTION
This fixes a Traceback that could happen after opening a new database or adding a database into a tab in Database editor if an entity class was selected in one of the tree views before the operation.

Fixes #1981

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
