### PR TITLE
Fix fully collapsable widgets

### DIFF
--- a/spinetoolbox/ui/array_editor.py
+++ b/spinetoolbox/ui/array_editor.py
@@ -42,6 +42,7 @@ class Ui_Form(object):
         self.splitter = QSplitter(Form)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
         self.verticalLayoutWidget = QWidget(self.splitter)
         self.verticalLayoutWidget.setObjectName(u"verticalLayoutWidget")
         self.verticalLayout_3 = QVBoxLayout(self.verticalLayoutWidget)

--- a/spinetoolbox/ui/array_editor.ui
+++ b/spinetoolbox/ui/array_editor.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QWidget" name="verticalLayoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>

--- a/spinetoolbox/ui/mini_kernel_editor_dialog.py
+++ b/spinetoolbox/ui/mini_kernel_editor_dialog.py
@@ -41,6 +41,7 @@ class Ui_Dialog(object):
         self.splitter = QSplitter(Dialog)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Vertical)
+        self.splitter.setChildrenCollapsible(False)
         self.widget = QWidget(self.splitter)
         self.widget.setObjectName(u"widget")
         self.verticalLayout = QVBoxLayout(self.widget)

--- a/spinetoolbox/ui/mini_kernel_editor_dialog.ui
+++ b/spinetoolbox/ui/mini_kernel_editor_dialog.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QWidget" name="">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>

--- a/spinetoolbox/ui/settings.py
+++ b/spinetoolbox/ui/settings.py
@@ -59,6 +59,7 @@ class Ui_SettingsForm(object):
         self.splitter = QSplitter(SettingsForm)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
         self.listWidget = QListWidget(self.splitter)
         icon = QIcon()
         icon.addFile(u":/icons/sliders-h.svg", QSize(), QIcon.Normal, QIcon.Off)

--- a/spinetoolbox/ui/settings.ui
+++ b/spinetoolbox/ui/settings.ui
@@ -64,6 +64,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QListWidget" name="listWidget">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">

--- a/spinetoolbox/ui/time_series_fixed_resolution_editor.py
+++ b/spinetoolbox/ui/time_series_fixed_resolution_editor.py
@@ -41,6 +41,7 @@ class Ui_TimeSeriesFixedResolutionEditor(object):
         self.verticalLayout = QVBoxLayout(TimeSeriesFixedResolutionEditor)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.splitter = QSplitter(TimeSeriesFixedResolutionEditor)
+        self.splitter.setChildrenCollapsible(False)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Horizontal)
         self.verticalLayoutWidget = QWidget(self.splitter)

--- a/spinetoolbox/ui/time_series_fixed_resolution_editor.ui
+++ b/spinetoolbox/ui/time_series_fixed_resolution_editor.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QWidget" name="verticalLayoutWidget">
       <layout class="QVBoxLayout" name="left_layout">
        <item>

--- a/spinetoolbox/ui/time_series_variable_resolution_editor.py
+++ b/spinetoolbox/ui/time_series_variable_resolution_editor.py
@@ -42,6 +42,7 @@ class Ui_TimeSeriesVariableResolutionEditor(object):
         self.splitter = QSplitter(TimeSeriesVariableResolutionEditor)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
         self.verticalLayoutWidget = QWidget(self.splitter)
         self.verticalLayoutWidget.setObjectName(u"verticalLayoutWidget")
         self.left_layout = QVBoxLayout(self.verticalLayoutWidget)

--- a/spinetoolbox/ui/time_series_variable_resolution_editor.ui
+++ b/spinetoolbox/ui/time_series_variable_resolution_editor.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QWidget" name="verticalLayoutWidget">
       <layout class="QVBoxLayout" name="left_layout">
        <item>


### PR DESCRIPTION
Disabled fully collapsing widgets by setting every QSplitters childrenCollapsible property to false.

Fixes #2167

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
