### PR TITLE
Fix segfaults in Database editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -986,7 +986,6 @@ class SpineDBEditor(TabularViewMixin, GraphViewMixin, ParameterViewMixin, TreeVi
         self._timer_refresh_tab_order.timeout.connect(self._refresh_tab_order, Qt.UniqueConnection)
         self._timer_refresh_tab_order.start(100)
 
-    @Slot()
     def _refresh_tab_order(self):
         if self._torn_down:
             return


### PR DESCRIPTION
This PR fixes two segfaults in Database editor:

- when adding new tabs to the editor using the '+' button
- when switching between tabbed Object/Relationship parameter value and default value docs in a freshly created tab

Fixes #2262

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
