### PR TITLE
Bind items to fetch parent in entity graph so it reacts to changes

### DIFF
--- a/spinetoolbox/fetch_parent.py
+++ b/spinetoolbox/fetch_parent.py
@@ -13,7 +13,7 @@
 The FetchParent and FlexibleFetchParent classes.
 """
 
-from PySide6.QtCore import QTimer, Signal, QObject
+from PySide6.QtCore import QTimer, Signal, QObject, Qt
 from .helpers import busy_effect
 
 
@@ -52,6 +52,9 @@ class FetchParent(QObject):
         if isinstance(self._owner, QObject):
             self._owner.destroyed.connect(lambda obj=None: self.set_obsolete(True))
         self.chunk_size = chunk_size
+
+    def apply_changes_immediately(self):
+        self._changes_pending.connect(self._apply_pending_changes, Qt.UniqueConnection)
 
     @property
     def index(self):
@@ -120,7 +123,7 @@ class FetchParent(QObject):
         return self._remove_item_callbacks[db_map]
 
     def _is_valid(self, version):
-        return version in (None, self._version) and not self.is_obsolete
+        return (version is None or version == self._version) and not self.is_obsolete
 
     def add_item(self, item, db_map, version=None):
         if not self._is_valid(version):

--- a/spinetoolbox/fetch_parent.py
+++ b/spinetoolbox/fetch_parent.py
@@ -18,11 +18,6 @@ from .helpers import busy_effect
 
 
 class FetchParent(QObject):
-    """
-    Attrs:
-        fetch_token (int or None)
-        None means we don't know yet. Set to a boolean value whenever we find out.
-    """
 
     _changes_pending = Signal()
 
@@ -36,7 +31,10 @@ class FetchParent(QObject):
                 If None, then no limit is imposed and the parent should fetch the entire contents of the DB.
         """
         super().__init__()
-        self._timer = QTimer()
+        self._version = 0
+        self._restore_item_callbacks = {}
+        self._update_item_callbacks = {}
+        self._remove_item_callbacks = {}
         self._items_to_add = {}
         self._items_to_update = {}
         self._items_to_remove = {}
@@ -44,7 +42,7 @@ class FetchParent(QObject):
         self._fetched = False
         self._busy = False
         self._position = {}
-        self.fetch_token = None
+        self._timer = QTimer()
         self._timer.setSingleShot(True)
         self._timer.setInterval(0)
         self._timer.timeout.connect(self._apply_pending_changes)
@@ -59,14 +57,14 @@ class FetchParent(QObject):
     def index(self):
         return self._index
 
-    def reset(self, fetch_token):
-        """Resets fetch parent as if nothing was ever fetched.
-
-        Args:
-            fetch_token (object): current fetch token
-        """
+    def reset(self):
+        """Resets fetch parent as if nothing was ever fetched."""
         if self.is_obsolete:
             return
+        self._version += 1
+        self._restore_item_callbacks.clear()
+        self._update_item_callbacks.clear()
+        self._remove_item_callbacks.clear()
         self._timer.stop()
         self._items_to_add.clear()
         self._items_to_update.clear()
@@ -76,7 +74,6 @@ class FetchParent(QObject):
         self._position.clear()
         if self.index is not None:
             self.index.reset()
-        self.fetch_token = fetch_token
 
     def position(self, db_map):
         return self._position.setdefault(db_map, 0)
@@ -99,17 +96,52 @@ class FetchParent(QObject):
             self.handle_items_removed({db_map: data})
         QTimer.singleShot(0, lambda: self.set_busy(False))
 
-    def add_item(self, item, db_map):
+    def bind_item(self, item, db_map):
+        # NOTE: If `item` is in the process of calling callbacks in another thread,
+        # the ones added below won't be called.
+        # So, it is important to call this function before self.add_item()
+        item.restore_callbacks.add(self._make_restore_item_callback(db_map))
+        item.update_callbacks.add(self._make_update_item_callback(db_map))
+        item.remove_callbacks.add(self._make_remove_item_callback(db_map))
+
+    def _make_restore_item_callback(self, db_map):
+        if db_map not in self._restore_item_callbacks:
+            self._restore_item_callbacks[db_map] = _ItemCallback(self.add_item, db_map, self._version)
+        return self._restore_item_callbacks[db_map]
+
+    def _make_update_item_callback(self, db_map):
+        if db_map not in self._update_item_callbacks:
+            self._update_item_callbacks[db_map] = _ItemCallback(self.update_item, db_map, self._version)
+        return self._update_item_callbacks[db_map]
+
+    def _make_remove_item_callback(self, db_map):
+        if db_map not in self._remove_item_callbacks:
+            self._remove_item_callbacks[db_map] = _ItemCallback(self.remove_item, db_map, self._version)
+        return self._remove_item_callbacks[db_map]
+
+    def _is_valid(self, version):
+        return version in (None, self._version) and not self.is_obsolete
+
+    def add_item(self, item, db_map, version=None):
+        if not self._is_valid(version):
+            return False
         self._items_to_add.setdefault(db_map, []).append(item)
         self._changes_pending.emit()
+        return True
 
-    def update_item(self, item, db_map):
+    def update_item(self, item, db_map, version=None):
+        if not self._is_valid(version):
+            return False
         self._items_to_update.setdefault(db_map, []).append(item)
         self._changes_pending.emit()
+        return True
 
-    def remove_item(self, item, db_map):
+    def remove_item(self, item, db_map, version=None):
+        if not self._is_valid(version):
+            return False
         self._items_to_remove.setdefault(db_map, []).append(item)
         self._changes_pending.emit()
+        return True
 
     @property
     def fetch_item_type(self):
@@ -332,3 +364,15 @@ class FetchIndex(dict):
 
     def get_items(self, key, db_map):
         return self.get(db_map, {}).get(key, [])
+
+
+class _ItemCallback:
+    def __init__(self, fn, *args):
+        self._fn = fn
+        self._args = args
+
+    def __call__(self, item):
+        return self._fn(item, *self._args)
+
+    def __str__(self):
+        return str(self._fn) + " with " + str(self._args)

--- a/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
@@ -130,7 +130,7 @@ class ItemMetadataTableModel(MetadataTableModelBase):
 
     def _reset_fetch_parents(self):
         for parent in self._fetch_parents():
-            parent.reset(None)
+            parent.reset()
         if self.canFetchMore(None):
             self.fetchMore(None)
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -352,7 +352,7 @@ class PivotTableModelBase(QAbstractTableModel):
 
     def reset_fetch_parents(self):
         for parent in self._fetch_parents():
-            parent.reset(None)
+            parent.reset()
 
     def _fetch_parents(self):
         """Yields fetch parents for this model.

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -484,8 +484,8 @@ class GraphViewMixin:
             self._owes_graph = True
             return
         self._owes_graph = False
-        self._entity_fetch_parent.reset(None)
-        self._parameter_value_fetch_parent.reset(None)
+        self._entity_fetch_parent.reset()
+        self._parameter_value_fetch_parent.reset()
         self._graph_fetch_more_later()
 
     def _do_build_graph(self):
@@ -572,7 +572,7 @@ class GraphViewMixin:
                 if (db_map, entity_id) not in db_map_entity_ids:
                     db_map_entity_ids.add((db_map, entity_id))
                     item = self.db_mngr.get_item(db_map, "entity", entity_id)
-                    self.db_mngr.bind_fetch_parent_item(db_map, self._entity_fetch_parent, item)
+                    self._entity_fetch_parent.bind_item(item, db_map)
         db_map_entity_ids_by_key = {}
         for db_map_entity_id in db_map_entity_ids:
             key = self.get_entity_key(db_map_entity_id)
@@ -829,7 +829,7 @@ class GraphViewMixin:
         }
         for db_map, items in added_db_map_data.items():
             for item in items:
-                self.db_mngr.bind_fetch_parent_item(db_map, self._entity_fetch_parent, item)
+                self._entity_fetch_parent.bind_item(item, db_map)
         return added_db_map_data
 
     def get_save_file_path(self, group, caption, filters):

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -153,6 +153,15 @@ class SpineDBManager(QObject):
         """
         return self._workers[db_map]
 
+    def bind_fetch_parent_item(self, db_map, parent, item):
+        if db_map.closed:
+            return
+        try:
+            worker = self._get_worker(db_map)
+        except KeyError:
+            return
+        worker.bind_item(parent, item)
+
     def register_fetch_parent(self, db_map, parent):
         """Registers a fetch parent.
 
@@ -166,7 +175,7 @@ class SpineDBManager(QObject):
             worker = self._get_worker(db_map)
         except KeyError:
             return
-        return worker.register_fetch_parent(parent)
+        worker.register_fetch_parent(parent)
 
     def can_fetch_more(self, db_map, parent):
         """Whether or not we can fetch more items of given type from given db.

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -153,15 +153,6 @@ class SpineDBManager(QObject):
         """
         return self._workers[db_map]
 
-    def bind_fetch_parent_item(self, db_map, parent, item):
-        if db_map.closed:
-            return
-        try:
-            worker = self._get_worker(db_map)
-        except KeyError:
-            return
-        worker.bind_item(parent, item)
-
     def register_fetch_parent(self, db_map, parent):
         """Registers a fetch parent.
 

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -114,7 +114,7 @@ class SpineDBWorker(QObject):
             if not item:
                 continue
             if index is not None or parent.accepts_item(item, self._db_map):
-                self._bind_item(parent, item)
+                self.bind_item(parent, item)
                 if item.is_valid():
                     parent.add_item(item, self._db_map)
                     if parent.shows_item(item, self._db_map):
@@ -125,7 +125,7 @@ class SpineDBWorker(QObject):
             return False
         return added_count > 0
 
-    def _bind_item(self, parent, item):
+    def bind_item(self, parent, item):
         # NOTE: If `item` is in the process of calling callbacks in another thread,
         # the ones added below won't be called.
         # So, it is important to call this function before parent.add_item(item)

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -286,43 +286,12 @@ class MockInstantQProcess(mock.Mock):
 
 
 class TestSpineDBManager(SpineDBManager):
-    # FIXME: Needed?
-    def fetch_all(self, db_map):
-        worker = self._get_worker(db_map)
-        for item_type in db_map.ITEM_TYPES:
-            parent = FlexibleFetchParent(item_type)
-            if worker.can_fetch_more(parent):
-                worker.fetch_more(parent)
-            qApp.processEvents()
-
-    def get_db_map(self, *args, **kwargs):
-        with mock.patch("spinetoolbox.spine_db_worker.QtBasedThreadPoolExecutor") as mock_executor:
-            mock_executor.return_value = _MockExecutor()
-            return super().get_db_map(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, synchronous=True)
 
     def can_fetch_more(self, db_map, parent):
-        parent.add_item = lambda item, db_map: parent.handle_items_added({db_map: [item]})
-        parent.update_item = lambda item, db_map: parent.handle_items_updated({db_map: [item]})
-        parent.remove_item = lambda item, db_map: parent.handle_items_removed({db_map: [item]})
+        parent.apply_changes_immediately()
         return super().can_fetch_more(db_map, parent)
-
-
-class _MockExecutor:
-    class _MockFuture:
-        def __init__(self, result):
-            self._result = result
-
-        def result(self):
-            return self._result
-
-        def add_done_callback(self, callback):
-            callback(self)
-
-    def submit(self, fn, *args, **kwargs):
-        return self._MockFuture(result=fn(*args, **kwargs))
-
-    def shutdown(self):
-        pass
 
 
 @contextmanager

--- a/tests/spine_db_editor/mvcmodels/test_compound_parameter_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_compound_parameter_models.py
@@ -123,7 +123,7 @@ class TestCompoundRelationshipParameterDefinitionModel(unittest.TestCase):
         self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc", "id": 1}]})
         self._db_mngr.add_entity_classes({self._db_map: [{"name": "rc", "dimension_id_list": [1], "id": 2}]})
         self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "entity_class_id": 2, "id": 1}]})
-        self._db_mngr.fetch_all(self._db_map)
+        self._db_map.fetch_all()
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.columnCount(), 6)
         row = [model.index(0, column).data() for column in range(model.columnCount())]
@@ -142,7 +142,7 @@ class TestCompoundObjectParameterValueModel(unittest.TestCase):
         logger = MagicMock()
         self._db_mngr = TestSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, codename="test_db", create=True)
-        self._db_mngr.fetch_all(self._db_map)
+        self._db_map.fetch_all()
         with patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"):
             self._db_editor = SpineDBEditor(self._db_mngr, {"sqlite://": "test_db"})
 
@@ -212,7 +212,7 @@ class TestCompoundRelationshipParameterValueModel(unittest.TestCase):
         logger = MagicMock()
         self._db_mngr = TestSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, codename="test_db", create=True)
-        self._db_mngr.fetch_all(self._db_map)
+        self._db_map.fetch_all()
         with patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"):
             self._db_editor = SpineDBEditor(self._db_mngr, {"sqlite://": "test_db"})
 

--- a/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
+++ b/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
@@ -53,7 +53,7 @@ class TestEmptyParameterModel(unittest.TestCase):
         import_relationship_parameters(self._db_map, (("dog__fish", "relative_speed"),))
         import_relationships(self._db_map, (("dog__fish", ("pluto", "nemo")),))
         self._db_map.commit_session("Add test data")
-        self._db_mngr.fetch_all(self._db_map)
+        self._db_map.fetch_all()
         self.object_table_header = [
             "entity_class_name",
             "entity_byname",


### PR DESCRIPTION
The graph was built in a combination of lazy and non-lazy techniques, making it unresponsive to certain actions.

For the graph to receive signals, the DB items need to be bound to the fetch parent that communicates the signals.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
