### PR TITLE
Fix undo after rollback

### DIFF
--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -273,7 +273,7 @@ class SpineDBWorker(QObject):
         """Rollbacks session."""
         try:
             self._db_map.rollback_session()
-            self._db_mngr.undo_stack[self._db_map].setClean()
+            self._db_mngr.undo_stack[self._db_map].clear()
             self._db_mngr.receive_session_rolled_back({self._db_map})
         except SpineDBAPIError as err:
             self._db_mngr.error_msg.emit({self._db_map: [err.msg]})


### PR DESCRIPTION
Now when a db is rolled back, the undo/redo stack is cleared instead of just being set clean.

Fixes #2310

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
