### PR TITLE
Fix Manage elements -dialog for 0D entity classes

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -613,7 +613,7 @@ class ManageElementsDialog(AddEntitiesOrManageElementsDialog):
     @Slot(str)
     def reset_entity_class_combo_box(self, database, relationship_class_key=None):
         self.db_map = self.keyed_db_maps[database]
-        self.entity_class_keys = list(self.db_map_ent_cls_lookup[self.db_map])
+        self.entity_class_keys = [i for i in self.db_map_ent_cls_lookup[self.db_map] if i[1]]
         self.ent_cls_combo_box.addItems([f"{name}" for name, _ in self.entity_class_keys])
         try:
             current_index = self.entity_class_keys.index(relationship_class_key)

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -281,8 +281,7 @@ class EntityTreeView(ResizableTreeView):
         )
         self._manage_members_action.setEnabled(item.item_type == "entity" and item.is_group)
         self._manage_elements_action.setEnabled(
-            item.item_type == "root"
-            or (item.item_type == "entity_class" and bool(item.display_id[1]))
+            item.item_type == "root" or (item.item_type == "entity_class" and bool(item.display_id[1]))
         )
         read_only = item.item_type in ("root", "members")
         self._export_action.setEnabled(not read_only)

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -280,7 +280,10 @@ class EntityTreeView(ResizableTreeView):
             item.item_type == "entity" and not item.is_group and not item.element_name_list
         )
         self._manage_members_action.setEnabled(item.item_type == "entity" and item.is_group)
-        self._manage_elements_action.setEnabled(item.item_type in ("root", "entity_class"))
+        self._manage_elements_action.setEnabled(
+            item.item_type == "root"
+            or (item.item_type == "entity_class" and bool(item.display_id[1]))
+        )
         read_only = item.item_type in ("root", "members")
         self._export_action.setEnabled(not read_only)
         self._edit_action.setEnabled(not read_only)

--- a/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
@@ -120,6 +120,8 @@ class TreeViewMixin:
         dialog.show()
 
     def show_manage_elements_form(self, parent_item):
+        if not parent_item.display_id[1]:  # Don't show for 0-dimensional entity classes
+            return
         dialog = ManageElementsDialog(self, parent_item, self.db_mngr, *self.db_maps)
         dialog.show()
 


### PR DESCRIPTION
The Manage elements dialog is no longer available
for zero dimensional entity classes.

Fixes #2321

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
