### PR TITLE
Fix links loop python script erased

### DIFF
--- a/spinetoolbox/widgets/code_text_edit.py
+++ b/spinetoolbox/widgets/code_text_edit.py
@@ -35,9 +35,9 @@ class CodeTextEdit(QPlainTextEdit):
         self._right_margin = 16
         font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
         self.setFont(font)
-        foreground_color = self._style.styles[Token]
+        self.foreground_color = self._style.styles[Token]
         self.setStyleSheet(
-            f"QPlainTextEdit {{background-color: {self._style.background_color}; color: {foreground_color};}}"
+            f"QPlainTextEdit {{background-color: {self._style.background_color}; color: {self.foreground_color};}}"
         )
         self.blockCountChanged.connect(self._update_line_number_area_width)
         self.updateRequest.connect(self._update_line_number_area)
@@ -108,6 +108,14 @@ class CodeTextEdit(QPlainTextEdit):
         bottom = max(old_bottom, new_bottom)
         self._line_number_area.update(0, top, self._line_number_area.width(), bottom - top)
         self._cursor_block = new_cursor_block
+
+    def set_enabled_with_greyed(self, enabled):
+        super().setEnabled(enabled)
+        if enabled:
+            x = f"QPlainTextEdit {{background-color: {self._style.background_color}; color: {self.foreground_color};}}"
+        else:
+            x = f"QPlainTextEdit {{background-color: #737373; color: {self.foreground_color};}}"
+        self.setStyleSheet(x)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)

--- a/spinetoolbox/widgets/jump_properties_widget.py
+++ b/spinetoolbox/widgets/jump_properties_widget.py
@@ -57,25 +57,28 @@ class JumpPropertiesWidget(PropertiesWidgetBase):
     def _load_condition_into_ui(self, condition):
         self._track_changes = False
         self._ui.pushButton_save_script.setEnabled(False)
-        self._ui.condition_script_edit.setEnabled(condition["type"] == "python-script")
+        self._ui.condition_script_edit.set_enabled_with_greyed(condition["type"] == "python-script")
         self._ui.comboBox_tool_spec.setEnabled(condition["type"] == "tool-specification")
         self._ui.toolButton_edit_tool_spec.setEnabled(condition["type"] == "tool-specification")
-        if not condition["type"] == "python-script":
-            self._ui.condition_script_edit.clear()
+        self._ui.condition_script_edit.setPlainText(condition["script"])
+        self._ui.comboBox_tool_spec.setCurrentText(condition["specification"])
         if condition["type"] == "python-script":
             self._ui.radioButton_py_script.setChecked(True)
-            if not condition["script"] or condition["script"] != self._ui.condition_script_edit.toPlainText():
-                self._ui.condition_script_edit.setPlainText(condition["script"])
         elif condition["type"] == "tool-specification":
             self._ui.radioButton_tool_spec.setChecked(True)
-            self._ui.comboBox_tool_spec.setCurrentText(condition["specification"])
         self._track_changes = True
 
     def _make_condition_from_ui(self):
+        condition = {
+            "script": self._ui.condition_script_edit.toPlainText(),
+            "specification": self._ui.comboBox_tool_spec.currentText(),
+        }
         if self._ui.radioButton_py_script.isChecked():
-            return {"type": "python-script", "script": self._ui.condition_script_edit.toPlainText()}
+            condition["type"] = "python-script"
+            return condition
         if self._ui.radioButton_tool_spec.isChecked():
-            return {"type": "tool-specification", "specification": self._ui.comboBox_tool_spec.currentText()}
+            condition["type"] = "tool-specification"
+            return condition
         return {}
 
     def _change_condition(self):

--- a/tests/widgets/test_jump_properties_widget.py
+++ b/tests/widgets/test_jump_properties_widget.py
@@ -80,7 +80,7 @@ class TestJumpPropertiesWidget(unittest.TestCase):
                 "bottom",
                 "dc 1",
                 "bottom",
-                {"type": "python-script", "script": "exit(23)"},
+                {"type": "python-script", "script": "exit(23)", "specification": ""},
                 toolbox=self._toolbox,
             )
         )


### PR DESCRIPTION
Now when the condition type of Loop is changed from Python script to Tool spec, the script is saved. The Python script editor is also disabled, and it turns grey to indicate that.

Fixes #2174

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
