### PR TITLE
Fix blank db editor opening when can't open db url

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
@@ -44,8 +44,10 @@ class MultiSpineDBEditor(MultiTabWindow):
         self.setWindowIcon(QIcon(":/symbols/app.ico"))
         self.setStatusBar(_CustomStatusBar(self))
         self.statusBar().hide()
+        self.tab_load_success = True
         if db_url_codenames is not None:
-            self.add_new_tab(db_url_codenames)
+            if not self.add_new_tab(db_url_codenames):
+                self.tab_load_success = False
 
     def _make_other(self):
         return MultiSpineDBEditor(self.db_mngr)
@@ -86,8 +88,10 @@ class MultiSpineDBEditor(MultiTabWindow):
         return True
 
     def _make_new_tab(self, db_url_codenames=None):  # pylint: disable=arguments-differ
+        """Makes a new tab, if successful return the tab, returns None otherwise"""
         tab = SpineDBEditor(self.db_mngr)
-        tab.load_db_urls(db_url_codenames, create=True)
+        if not tab.load_db_urls(db_url_codenames, create=True):
+            return
         return tab
 
     def show_plus_button_context_menu(self, global_pos):

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -154,9 +154,9 @@ class SpineDBEditorBase(QMainWindow):
         self.ui.actionVacuum.setEnabled(False)
         self.url_toolbar.reload_action.setEnabled(False)
         if not db_url_codenames:
-            return
+            return False
         if not self.tear_down():
-            return
+            return False
         if self.db_maps:
             self.save_window_state()
         self.db_maps = []
@@ -167,7 +167,7 @@ class SpineDBEditorBase(QMainWindow):
             if db_map is not None:
                 self.db_maps.append(db_map)
         if not self.db_maps:
-            return
+            return False
         self.db_urls = [db_map.db_url for db_map in self.db_maps]
         self.ui.actionImport.setEnabled(True)
         self.ui.actionExport.setEnabled(True)
@@ -186,6 +186,7 @@ class SpineDBEditorBase(QMainWindow):
         if update_history:
             self.url_toolbar.add_urls_to_history(self.db_urls)
         self.restore_ui()
+        return True
 
     def init_add_undo_redo_actions(self):
         new_undo_action = self.db_mngr.undo_action[self.first_db_map]

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -1592,7 +1592,8 @@ class SpineDBManager(QObject):
         multi_db_editor = next(self.get_all_multi_spine_db_editors(), None)
         if multi_db_editor is None:
             multi_db_editor = MultiSpineDBEditor(self, db_url_codenames)
-            multi_db_editor.show()
+            if multi_db_editor.tab_load_success:  # don't open an editor if tabs were not loaded successfully
+                multi_db_editor.show()
             return
         existing = self._get_existing_spine_db_editor(db_url_codenames)
         if existing is None:

--- a/spinetoolbox/widgets/multi_tab_window.py
+++ b/spinetoolbox/widgets/multi_tab_window.py
@@ -125,11 +125,17 @@ class MultiTabWindow(QMainWindow):
         Args:
             *args: parameters forwarded to :func:`MutliTabWindow._make_new_tab`
             **kwargs: parameters forwarded to :func:`MultiTabwindow._make_new_tab`
+
+        Returns:
+            bool: True if successful, False otherwise
         """
         if not self._accepting_new_tabs:
-            return
+            return False
         tab = self._make_new_tab(*args, **kwargs)
+        if not tab:
+            return False
         self._add_connect_tab(tab, self.new_tab_title)
+        return True
 
     def insert_new_tab(self, index, *args, **kwargs):
         """Creates a new tab and inserts it at the given index.


### PR DESCRIPTION
Now when the version of a db is not up-to-date and the opening of the editor is cancelled, a blank DB editor no longer pops up.

Fixes #2280

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass (PySide6 6.5.2)
