### PR TITLE
Fix error while opening project allows to overwrite project

### DIFF
--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -294,6 +294,7 @@ class SpineToolboxProject(MetaObject):
         if not ProjectUpgrader(self._toolbox).is_valid(LATEST_PROJECT_VERSION, project_info):
             self._logger.msg_error.emit(f"Opening project in directory {self.project_dir} failed")
             return False
+        self._toolbox.ui.textBrowser_eventlog.clear()
         local_data_dict = load_local_project_data(self.config_dir, self._logger)
         self._merge_local_data_to_project_info(local_data_dict, project_info)
         # Parse project info

--- a/spinetoolbox/project_upgrader.py
+++ b/spinetoolbox/project_upgrader.py
@@ -59,12 +59,12 @@ class ProjectUpgrader:
         if v < LATEST_PROJECT_VERSION:
             # Back up project.json file before upgrading
             if not self.backup_project_file(project_dir, v):
-                self._toolbox.msg_error.emit("Upgrading project failed")
+                self._toolbox.msg_error.emit(f"Upgrading project <b>{project_dir}</b> failed")
                 return False
             upgraded_dict = self.upgrade_to_latest(v, project_dict, project_dir)
             # Force save project dict to project.json
             if not self.force_save(upgraded_dict, project_dir):
-                self._toolbox.msg_error.emit("Upgrading project failed")
+                self._toolbox.msg_error.emit(f"Upgrading project <b>{project_dir}</b> failed")
                 return False
             return upgraded_dict
         return project_dict


### PR DESCRIPTION
Now if the user tries to open a project that has a version number that is too low for the Toolbox version, the project will automatically close, so that the project can't be messed with. After the project is closed a message is emitted to the Event Log stating that the project couldn't be opened due to some error.

Fixes #2279

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
