### PR TITLE
Fix Excel export in Database editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -649,9 +649,7 @@ class GraphViewMixin:
         return self._get_item_property(db_map, entity_id, self.ui.graphicsView.arc_width_parameter, time_line_index)
 
     def get_vertex_radius(self, db_map, entity_id, time_line_index):
-        return self._get_item_property(
-            db_map, entity_id, self.ui.graphicsView.vertex_radius_parameter, time_line_index
-        )
+        return self._get_item_property(db_map, entity_id, self.ui.graphicsView.vertex_radius_parameter, time_line_index)
 
     def _get_item_property(self, db_map, entity_id, pname, time_line_index):
         """Returns a tuple of (min_value, value, max_value) for given entity and property.

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -650,10 +650,10 @@ class GraphViewMixin:
 
     def get_vertex_radius(self, db_map, entity_id, time_line_index):
         return self._get_item_property(
-            db_map, item_type, entity_id, self.ui.graphicsView.vertex_radius_parameter, time_line_index
+            db_map, entity_id, self.ui.graphicsView.vertex_radius_parameter, time_line_index
         )
 
-    def _get_item_property(self, db_map, item_type, entity_id, pname, time_line_index):
+    def _get_item_property(self, db_map, entity_id, pname, time_line_index):
         """Returns a tuple of (min_value, value, max_value) for given entity and property.
         Returns self.NOT_SPECIFIED if the property is not defined for the entity.
         Returns None if the property is not defined for *any* entity.

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -451,7 +451,9 @@ class SpineDBEditorBase(QMainWindow):
 
     @Slot(bool)
     def import_file(self, checked=False):
-        """Import file. It supports SQLite, JSON, and Excel."""
+        """Imports file.
+
+        It supports SQLite, JSON, and Excel."""
         self.qsettings.beginGroup(self.settings_group)
         file_path, selected_filter = get_open_file_name_in_last_dir(
             self.qsettings,
@@ -469,7 +471,7 @@ class SpineDBEditorBase(QMainWindow):
             self.import_from_json(file_path)
         elif extension == ".sqlite":
             self.import_from_sqlite(file_path)
-        elif extension == "xlsx":
+        elif extension == ".xlsx":
             self.import_from_excel(file_path)
         else:
             self.msg_error.emit(f"Unrecognized file type {extension} - must be a .json, .sqlite, or .xlsx file")

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
@@ -65,6 +65,30 @@ class TestSpineDBEditorBase(unittest.TestCase):
         saved_dict = {saved[0][0]: saved[0][1] for saved in qsettings_save_calls}
         self.assertIn("windowState", saved_dict)
 
+    def test_import_file_recognizes_excel(self):
+        with mock.patch.object(self.db_editor, "qsettings"), mock.patch.object(
+            self.db_editor, "import_from_excel"
+        ) as mock_import_from_excel, mock.patch("spinetoolbox.helpers.QFileDialog") as mock_file_dialog:
+            mock_file_dialog.getOpenFileName.return_value = "my_excel_file.xlsx", "Excel files (*.xlsx)"
+            self.db_editor.import_file()
+            mock_import_from_excel.assert_called_once_with("my_excel_file.xlsx")
+
+    def test_import_file_recognizes_sqlite(self):
+        with mock.patch.object(self.db_editor, "qsettings"), mock.patch.object(
+            self.db_editor, "import_from_sqlite"
+        ) as mock_import_from_sqlite, mock.patch("spinetoolbox.helpers.QFileDialog") as mock_file_dialog:
+            mock_file_dialog.getOpenFileName.return_value = "my_sqlite_file.sqlite", "SQLite files (*.sqlite)"
+            self.db_editor.import_file()
+            mock_import_from_sqlite.assert_called_once_with("my_sqlite_file.sqlite")
+
+    def test_import_file_recognizes_json(self):
+        with mock.patch.object(self.db_editor, "qsettings"), mock.patch.object(
+            self.db_editor, "import_from_json"
+        ) as mock_import_from_json, mock.patch("spinetoolbox.helpers.QFileDialog") as mock_file_dialog:
+            mock_file_dialog.getOpenFileName.return_value = "my_json_file.json", "JSON files (*.json)"
+            self.db_editor.import_file()
+            mock_import_from_json.assert_called_once_with("my_json_file.json")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug where Excel files exported from Database editor would appear empty.

PR spine-tools/Spine-Database-API#286 fixes a related issue.

Fixes #2339

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
