### PR TITLE
Delete and set fethcers obsolete when they get out of scope

### DIFF
--- a/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
+++ b/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
@@ -292,6 +292,8 @@ class LazyFilterCheckboxListModel(SimpleFilterCheckboxListModel):
         self._db_mngr = db_mngr
         self._db_maps = db_maps
         self._fetch_parent = fetch_parent
+        self._fetch_parent.setParent(self)
+        self.destroyed.connect(self._fetch_parent.set_obsolete(True))
 
     def canFetchMore(self, _parent):
         result = False

--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -172,6 +172,8 @@ class TreeItem:
     def tear_down_recursively(self):
         for child in self._created_children.values():
             child.tear_down_recursively()
+        for child in self._children:
+            child.tear_down_recursively()
         self.tear_down()
 
     def remove_children(self, position, count):

--- a/spinetoolbox/project_item/logging_connection.py
+++ b/spinetoolbox/project_item/logging_connection.py
@@ -186,7 +186,9 @@ class LoggingConnection(LogMixin, HeadlessConnection):
         obsolete_urls = set(self._db_maps) - resource_urls
         for url in obsolete_urls:
             db_map = self._db_maps.pop(url)
-            self._fetch_parents.pop(db_map)
+            fetch_parent = self._fetch_parents.pop(db_map)
+            fetch_parent.set_obsolete(True)
+            fetch_parent.deleteLater()
             self._toolbox.db_mngr.unregister_listener(self, db_map)
 
     def _make_fetch_parent(self, db_map, item_type):

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -53,6 +53,8 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
             handle_items_updated=self.handle_items_updated,
             owner=self,
         )
+        self._fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._fetch_parent.set_obsolete(True))
 
     def _make_header(self):
         raise NotImplementedError()

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -305,3 +305,4 @@ class EntityItem(MultiDBTreeItem):
     def tear_down(self):
         super().tear_down()
         self._entity_group_fetch_parent.set_obsolete(True)
+        self._entity_group_fetch_parent.deleteLater()

--- a/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
@@ -58,6 +58,8 @@ class ItemMetadataTableModel(MetadataTableModelBase):
             accepts_item=self._accepts_entity_metadata_item,
             owner=self,
         )
+        self._entity_metadata_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._entity_metadata_fetch_parent.set_obsolete(True))
         self._parameter_value_metadata_fetch_parent = FlexibleFetchParent(
             "parameter_value_metadata",
             handle_items_added=self.add_item_metadata,
@@ -66,6 +68,8 @@ class ItemMetadataTableModel(MetadataTableModelBase):
             accepts_item=self._accepts_parameter_value_metadata_item,
             owner=self,
         )
+        self._parameter_value_metadata_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._parameter_value_metadata_fetch_parent.set_obsolete(True))
 
     def _fetch_parents(self):
         yield self._entity_metadata_fetch_parent

--- a/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model.py
@@ -46,6 +46,8 @@ class MetadataTableModel(MetadataTableModelBase):
             handle_items_updated=self.update_metadata,
             owner=self,
         )
+        self._metadata_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._metadata_fetch_parent.set_obsolete(True))
 
     @staticmethod
     def _make_hidden_adder_columns():

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -234,7 +234,7 @@ class MultiDBTreeItem(TreeItem):
 
         Args:
             db_map (DatabaseMapping)
-            id (int)
+            id_ (int)
 
         Returns:
             MultiDBTreemItem
@@ -492,6 +492,7 @@ class MultiDBTreeItem(TreeItem):
     def tear_down(self):
         super().tear_down()
         self._fetch_parent.set_obsolete(True)
+        self._fetch_parent.deleteLater()
 
     def register_fetch_parent(self):
         """Registers item's fetch parent for all model's databases."""

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -929,6 +929,8 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             accepts_item=self._parent.accepts_entity_item,
             owner=self,
         )
+        self._entity_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._entity_fetch_parent.set_obsolete(True))
         self._parameter_definition_fetch_parent = FlexibleFetchParent(
             "parameter_definition",
             handle_items_added=self._handle_parameter_definitions_added,
@@ -937,6 +939,8 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             accepts_item=self._parent.accepts_parameter_item,
             owner=self,
         )
+        self._entity_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._entity_fetch_parent.set_obsolete(True))
         self._parameter_value_fetch_parent = FlexibleFetchParent(
             "parameter_value",
             handle_items_added=self._handle_parameter_values_added,
@@ -946,6 +950,8 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             owner=self,
             chunk_size=None,
         )
+        self._parameter_value_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._parameter_value_fetch_parent.set_obsolete(True))
         self._alternative_fetch_parent = FlexibleFetchParent(
             "alternative",
             handle_items_added=self._handle_alternatives_added,
@@ -953,6 +959,8 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
             handle_items_updated=lambda _: self._parent.refresh_views(),
             owner=self,
         )
+        self._alternative_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._alternative_fetch_parent.set_obsolete(True))
 
     def _handle_entities_added(self, db_map_data):
         data = self._load_empty_parameter_value_data(db_map_entities=db_map_data)
@@ -1338,6 +1346,8 @@ class ElementPivotTableModel(PivotTableModelBase):
             owner=self,
             chunk_size=None,
         )
+        self._entity_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._entity_fetch_parent.set_obsolete(True))
         self._element_fetch_parent = FlexibleFetchParent(
             "entity",
             handle_items_added=self._handle_elements_added,
@@ -1346,6 +1356,8 @@ class ElementPivotTableModel(PivotTableModelBase):
             accepts_item=self._parent.accepts_element_item,
             owner=self,
         )
+        self._element_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._element_fetch_parent.set_obsolete(True))
 
     def _handle_entities_added(self, db_map_data):
         data = self._parent.load_full_element_data(db_map_entities=db_map_data, action="add")
@@ -1462,6 +1474,8 @@ class ScenarioAlternativePivotTableModel(PivotTableModelBase):
             handle_items_updated=lambda _: self._parent.refresh_views(),
             owner=self,
         )
+        self._scenario_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._scenario_fetch_parent.set_obsolete(True))
         self._alternative_fetch_parent = FlexibleFetchParent(
             "alternative",
             handle_items_added=self._handle_alternatives_added,
@@ -1469,6 +1483,8 @@ class ScenarioAlternativePivotTableModel(PivotTableModelBase):
             handle_items_updated=lambda _: self._parent.refresh_views(),
             owner=self,
         )
+        self._alternative_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._alternative_fetch_parent.set_obsolete(True))
         self._scenario_alternative_fetch_parent = FlexibleFetchParent(
             "scenario_alternative",
             handle_items_added=self._handle_scenario_alternatives_changed,
@@ -1476,6 +1492,8 @@ class ScenarioAlternativePivotTableModel(PivotTableModelBase):
             owner=self,
             chunk_size=None,
         )
+        self._scenario_alternative_fetch_parent.setParent(self)
+        self.destroyed.connect(lambda: self._scenario_alternative_fetch_parent.set_obsolete(True))
 
     def _handle_scenarios_added(self, db_map_data):
         data = self._parent.load_scenario_alternative_data(db_map_scenarios=db_map_data)

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
@@ -149,6 +149,7 @@ class FetchMoreMixin:
     def tear_down(self):
         super().tear_down()
         self._natural_fetch_parent.set_obsolete(True)
+        self._natural_fetch_parent.deleteLater()
 
     @property
     def fetch_item_type(self):

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_model_base.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_model_base.py
@@ -48,7 +48,7 @@ class TreeModelBase(MinimalTreeModel):
         """Builds tree."""
         self.beginResetModel()
         self._invisible_root_item = StandardTreeItem(self)
-        self.destroyed.connect(lambda obj=None: self._invisible_root_item.tear_down_recursively())
+        self.destroyed.connect(lambda: self._invisible_root_item.tear_down_recursively())
         self.endResetModel()
         for db_map in self.db_maps:
             db_item = self._make_db_item(db_map)

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -107,9 +107,11 @@ class GraphViewMixin:
             handle_items_updated=self._graph_handle_entities_updated,
             owner=self,
         )
+        self._entity_fetch_parent.setParent(self)
         self._parameter_value_fetch_parent = FlexibleFetchParent(
             "parameter_value", handle_items_added=self._graph_handle_parameter_values_added, owner=self
         )
+        self._parameter_value_fetch_parent.setParent(self)
         self._graph_fetch_more_later()
 
     @Slot(int)
@@ -870,6 +872,8 @@ class GraphViewMixin:
         self.ui.treeView_entity.tree_selection_changed.disconnect(self._handle_entity_tree_selection_changed_in_graph)
         if self.scene is not None:
             self.scene.deleteLater()
+        self._entity_fetch_parent.set_obsolete(True)
+        self._parameter_value_fetch_parent.set_obsolete(True)
         super().closeEvent(event)
 
 

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -245,8 +245,8 @@ class SpineDBWorker(QObject):
 
     def refresh_session(self):
         """Refreshes session."""
-        for parents in self._parents_by_type.values():
-            for parent in parents:
+        for parent_type in self._parents_by_type:
+            for parent in self._get_parents(parent_type):
                 parent.reset()
         self._db_map.refresh_session()
         self._parents_fetching.clear()


### PR DESCRIPTION
This should fix problems when fetchers try to access Database editor objects after the editor has been closed and C++ stuff has been deleted.

Fixes #2355

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
~- [ ] Unit tests pass~ Tests pass locally
