### PR TITLE
Fix tree views not being updated after external commit if they already have items

### DIFF
--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -252,6 +252,7 @@ class SpineDBWorker(QObject):
 
     def refresh_session(self):
         """Refreshes session."""
+        self._db_map.refresh_session()
         for parent_type in self._parents_by_type:
             for parent in self._get_parents(parent_type):
                 parent.reset()

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -134,7 +134,7 @@ class SpineDBWorker(QObject):
             self._do_fetch_more(parent)
 
     def _do_fetch_more(self, parent):
-        if self._iterate_mapping(parent):
+        if self._iterate_mapping(parent) and not self._db_map.has_external_commits():
             # Something fetched from mapping
             return
         item_type = parent.fetch_item_type


### PR DESCRIPTION
This PR fixes a bug where tree views did not show new items imported into the database by an Importer item.

See also the accompanying db-api PR spine-tools/Spine-Database-API#292

Fixes #2353

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
