### PR TITLE
Fix Traceback in Pivot table when some data is not available in the database

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_model.py
@@ -166,12 +166,18 @@ class PivotModel:
             result = {index_getter(k): None for k in self._data if frozen_getter(k) == self.frozen_value}
         else:
             result = {index_getter(k): None for k in self._data}
-        return sorted(
-            (x for x in result if None not in x),
-            key=lambda x: tuple(
-                self.top_left_headers[header_name].header_data(header_id) for header_name, header_id in zip(indexes, x)
-            ),
-        )
+        accepted = {}
+        headers = self.top_left_headers
+        for x in result:
+            sort_keys = []
+            for header_name, header_id in zip(indexes, x):
+                header = headers[header_name]
+                if not header.accepts(header_id):
+                    break
+                sort_keys.append(header.header_data(header_id))
+            else:
+                accepted[x] = sort_keys
+        return [item[0] for item in sorted(accepted.items(), key=operator.itemgetter(1))]
 
     def set_pivot(self, rows, columns, frozen, frozen_value):
         """Sets pivot."""

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -60,6 +60,18 @@ class TopLeftHeaderItem:
         if role == Qt.ItemDataRole.ToolTipRole:
             return item.get("description", "No description")
 
+    @staticmethod
+    def accepts(header_id):
+        """Tests if header id is valid.
+
+        Args:
+            header_id (Any): header id
+
+        Returns:
+            bool: True if id is valid, False otherwise
+        """
+        return any(id_ is not None for id_ in header_id[1:])
+
     def header_data(self, header_id, role=Qt.ItemDataRole.DisplayRole):
         """Returns header data for given id.
 

--- a/tests/spine_db_editor/mvcmodels/test_PivotModel.py
+++ b/tests/spine_db_editor/mvcmodels/test_PivotModel.py
@@ -18,6 +18,10 @@ from spinetoolbox.spine_db_editor.mvcmodels.pivot_model import PivotModel
 
 
 class _Header:
+    @staticmethod
+    def accepts(header_id):
+        return True
+
     def header_data(self, header_id):
         return header_id
 


### PR DESCRIPTION
This PR fixes a Traceback that happened e.g. there were no entities to show in Parameter value pivot.

Fixes #2386

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
