### PR TITLE
Backport fix for Frozen table crash from 0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8.1, <3.12"
 dependencies = [
-    "pyside6 >= 6.5.0, != 6.5.3",
+    "pyside6 >= 6.5.0, != 6.5.3, < 6.6",
     # As of 2022-09-05 psutil 5.9.2 requires extra Microsoft Visual
     # Build Tools installation
     "psutil < 5.9.2",

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -765,6 +765,8 @@ class TabularViewMixin:
         destination = self._get_insert_index(catcher_list, catcher, position)
         if dropped.area == "frozen" and catcher.area == "frozen":
             source = dropped_list.index(dropped.identifier)
+            if source == destination:
+                return
             self.frozen_table_model.moveColumn(QModelIndex(), source, QModelIndex(), destination)
             self.pivot_table_model.set_frozen(self.frozen_table_model.headers)
             return


### PR DESCRIPTION
Backporting the fix (but not unit tests) from PR #2388

Fixes #2385

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly to `0.8-dev` branch
- [x] Code has been formatted by black
- [x] Unit tests pass
