### PR TITLE
Fix Traceback from "database" type Pivot table filter

### DIFF
--- a/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
+++ b/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
@@ -25,10 +25,10 @@ class SimpleFilterCheckboxListModel(QAbstractListModel):
     _ADD_TO_SELECTION_STR = 'Add current selection to filter'
 
     def __init__(self, parent, show_empty=True):
-        """Init class.
-
+        """
         Args:
-            parent (QWidget)
+            parent (QWidget): parent widget
+            show_empty (bool): if True, adds an empty row to the end of the list
         """
         super().__init__(parent)
         self._data = []
@@ -282,11 +282,13 @@ class LazyFilterCheckboxListModel(SimpleFilterCheckboxListModel):
     """Extends SimpleFilterCheckboxListModel to allow for lazy loading in synch with another model."""
 
     def __init__(self, parent, db_mngr, db_maps, fetch_parent, show_empty=True):
-        """Init class.
-
+        """
         Args:
-            parent (SpineDBEditor)
-            fetch_parent (FetchParent)
+            parent (SpineDBEditor): parent widget
+            db_mngr (SpineDBManager): database manager
+            db_maps (Sequence of DatabaseMapping): database maps
+            fetch_parent (FetchParent): fetch parent
+            show_empty (bool): if True, show an empty row at the end of the list
         """
         super().__init__(parent, show_empty=show_empty)
         self._db_mngr = db_mngr
@@ -315,11 +317,11 @@ class DataToValueFilterCheckboxListModel(SimpleFilterCheckboxListModel):
     """Extends SimpleFilterCheckboxListModel to allow for translating internal data to a value for display role."""
 
     def __init__(self, parent, data_to_value, show_empty=True):
-        """Init class.
-
+        """
         Args:
-            parent (SpineDBEditor)
+            parent (SpineDBEditor): parent widget
             data_to_value (method): a method to translate item data to a value for display role
+            show_empty (bool): if True, add an empty row to the end of the list
         """
         super().__init__(parent, show_empty=show_empty)
         self.data_to_value = data_to_value

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -20,7 +20,7 @@ from PySide6.QtGui import QAction, QIcon, QActionGroup
 from PySide6.QtWidgets import QWidget
 
 from spinedb_api.helpers import fix_name_ambiguity
-from .custom_menus import TabularViewFilterMenu
+from .custom_menus import TabularViewCodenameFilterMenu, TabularViewDBItemFilterMenu
 from .tabular_view_header_widget import TabularViewHeaderWidget
 from ...helpers import busy_effect, CharIconEngine, preferred_row_height, disconnect
 from ..mvcmodels.pivot_table_models import (
@@ -644,13 +644,13 @@ class TabularViewMixin:
         self.ui.frozen_table.setCurrentIndex(self.frozen_table_model.index(1, 0))
 
     def create_filter_menu(self, identifier):
-        """Returns a filter menu for given given object_class identifier.
+        """Returns a filter menu for given filterable item.
 
         Args:
-            identifier (int)
+            identifier (str): item identifier
 
         Returns:
-            TabularViewFilterMenu
+            TabularViewDBItemFilterMenu: filter menu corresponding to identifier
         """
         if identifier not in self.filter_menus:
             header = self.pivot_table_model.top_left_headers[identifier]
@@ -670,9 +670,13 @@ class TabularViewMixin:
                 accepts_item = self.accepts_parameter_item
             else:
                 accepts_item = None
-            self.filter_menus[identifier] = menu = TabularViewFilterMenu(
-                self, self.db_mngr, self.db_maps, item_type, accepts_item, identifier, show_empty=False
-            )
+            if identifier == "database":
+                menu = TabularViewCodenameFilterMenu(self, self.db_maps, identifier, show_empty=False)
+            else:
+                menu = TabularViewDBItemFilterMenu(
+                    self, self.db_mngr, self.db_maps, item_type, accepts_item, identifier, show_empty=False
+                )
+            self.filter_menus[identifier] = menu
             menu.filterChanged.connect(self.change_filter)
         return self.filter_menus[identifier]
 

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -146,10 +146,10 @@ class SpineDBManager(QObject):
         """Returns a worker.
 
         Args:
-            db_map (DiffDatabaseMapping)
+            db_map (DatabaseMapping): database mapping
 
         Returns:
-            SpineDBWorker
+            SpineDBWorker: worker for the db_map
         """
         return self._workers[db_map]
 

--- a/tests/spine_db_editor/widgets/test_custom_menus.py
+++ b/tests/spine_db_editor/widgets/test_custom_menus.py
@@ -1,0 +1,60 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for ``custom_menus`` module."""
+import unittest
+from unittest import mock
+from PySide6.QtWidgets import QApplication, QWidget
+
+from spinetoolbox.helpers import signal_waiter
+from spinetoolbox.spine_db_editor.widgets.custom_menus import TabularViewCodenameFilterMenu
+
+
+class TestTabularViewCodenameFilterMenu(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._parent = QWidget()
+
+    def tearDown(self):
+        self._parent.deleteLater()
+
+    def test_init_fills_filter_list_with_database_codenames(self):
+        db_map1 = mock.MagicMock()
+        db_map1.codename = "db map 1"
+        db_map2 = mock.MagicMock()
+        db_map2.codename = "db map 2"
+        db_maps = [db_map1, db_map2]
+        menu = TabularViewCodenameFilterMenu(self._parent, db_maps, "database")
+        self.assertIs(menu.anchor, self._parent)
+        filter_list_model = menu._filter._filter_model
+        filter_rows = []
+        for row in range(filter_list_model.rowCount()):
+            filter_rows.append(filter_list_model.index(row, 0).data())
+        self.assertEqual(filter_rows, ["(Select all)", "(Empty)", "db map 1", "db map 2"])
+
+    def test_filter_changed_signal_is_emitted_correctly(self):
+        db_map1 = mock.MagicMock()
+        db_map1.codename = "db map 1"
+        db_map2 = mock.MagicMock()
+        db_map2.codename = "db map 2"
+        db_maps = [db_map1, db_map2]
+        menu = TabularViewCodenameFilterMenu(self._parent, db_maps, "database")
+        with signal_waiter(menu.filterChanged, timeout=0.1) as waiter:
+            menu._clear_filter()
+            waiter.wait()
+            self.assertEqual(waiter.args, ("database", {None, "db map 1", "db map 2"}, False))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Database codenames are not database items like entities or alternatives so we need a special filter menu for them.

Fixes #2391

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
