### PR TITLE
Fix scenario table view getting cleared when scenario deleted

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -706,6 +706,7 @@ class PivotTableView(ResizingViewMixin, CopyPasteTableView):
                 db_map, id_ = source_model._header_id(index)
                 db_map_typed_data.setdefault(db_map, {}).setdefault("scenario", set()).add(id_)
             self._db_editor.db_mngr.remove_items(db_map_typed_data)
+            self._db_editor.do_reload_pivot_table()
 
         def duplicate_scenario(self):
             """Duplicates current scenario in the database."""


### PR DESCRIPTION
Now the table is refreshed after deletion.

Fixes #2406

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
