### PR TITLE
Fix duplicating scenario causes Traceback

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -615,7 +615,7 @@ class SpineDBEditorBase(QMainWindow):
         orig_name = self.db_mngr.get_item(db_map, "scenario", scen_id)["name"]
         parcel = SpineDBParcel(self.db_mngr)
         parcel.full_push_scenario_ids({db_map: {scen_id}})
-        existing_names = {i.name for i in self.db_mngr.get_items(db_map, "scenario")}
+        existing_names = {i.get("name") for i in self.db_mngr.get_items(db_map, "scenario")}
         dup_name = unique_name(orig_name, existing_names)
         self.db_mngr.duplicate_scenario(parcel.data, dup_name, db_map)
 

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -41,7 +41,7 @@ class TestParameterValueFormatting(unittest.TestCase):
             if item_type != "parameter_value":
                 return {}
             try:
-                parsed_value = from_database(value, value_type=type_)
+                parsed_value = from_database(value, type_=type_)
             except ParameterValueFormatError as error:
                 parsed_value = error
             return {"parsed_value": parsed_value, "value": value, "type": type_, "list_value_id": None}


### PR DESCRIPTION
Duplicating scenarios now works on 0.8 again.

Fixes #2402

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
