### PR TITLE
Prevent Traceback in BooleanValueDelegate

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1299,6 +1299,16 @@ class SignalWaiter(QObject):
 
 @contextmanager
 def signal_waiter(signal, condition=None, timeout=None):
+    """Gives a context manager that waits for the emission of given Qt signal.
+
+    Args:
+        signal (Any): signal to wait
+        condition (Callable, optional): a callable that takes the signal's parameters and returns True to stop waiting
+        timeout (float, optional): timeout in seconds; if None, wait indefinitely
+
+    Yields:
+        SignalWaiter: waiter instance
+    """
     waiter = SignalWaiter(condition=condition, timeout=timeout)
     signal.connect(waiter.trigger)
     try:

--- a/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
@@ -474,9 +474,15 @@ class AlternativeNameDelegate(TableDelegate):
 
 
 class BooleanValueDelegate(TableDelegate):
+    TRUE = "true"
+    FALSE = "false"
+
     def setModelData(self, editor, model, index):
-        """Send signal."""
-        value = {"True": True, "False": False}[editor.data()]
+        """Sends signal."""
+        try:
+            value = {self.TRUE: True, self.FALSE: False}[editor.data()]
+        except KeyError:
+            return
         self.data_committed.emit(index, value)
 
     def createEditor(self, parent, option, index):
@@ -485,7 +491,7 @@ class BooleanValueDelegate(TableDelegate):
         if not db_map:
             return None
         editor = SearchBarEditor(self.parent(), parent)
-        editor.set_data(str(index.data(Qt.ItemDataRole.EditRole)), ["True", "False"])
+        editor.set_data(str(index.data(Qt.ItemDataRole.EditRole)), [self.TRUE, self.FALSE])
         editor.data_committed.connect(lambda *_: self._close_editor(editor, index))
         return editor
 

--- a/tests/spine_db_editor/widgets/test_custom_delegates.py
+++ b/tests/spine_db_editor/widgets/test_custom_delegates.py
@@ -1,0 +1,64 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for ``custom_delegates`` module."""
+import unittest
+from unittest import mock
+
+from PySide6.QtGui import QStandardItem, QStandardItemModel
+from PySide6.QtWidgets import QApplication
+
+from spinetoolbox.helpers import signal_waiter
+from spinetoolbox.spine_db_editor.widgets.custom_delegates import BooleanValueDelegate
+
+
+class TestBooleanValueDelegate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._model = QStandardItemModel()
+        row = [QStandardItem()]
+        self._model.appendRow(row)
+        self._delegate = BooleanValueDelegate(None, None)
+
+    def tearDown(self):
+        self._model.deleteLater()
+        self._delegate.deleteLater()
+
+    def test_set_model_data_emits_when_true_is_selected(self):
+        editor = mock.MagicMock()
+        index = self._model.index(0, 0)
+        for editor_value, value in {BooleanValueDelegate.TRUE: True, BooleanValueDelegate.FALSE: False}.items():
+            with self.subTest(editor_value=editor_value):
+                editor.data.return_value = editor_value
+                with signal_waiter(self._delegate.data_committed) as waiter:
+                    self._delegate.setModelData(editor, self._model, index)
+                    waiter.wait()
+                    self.assertEqual(len(waiter.args), 2)
+                    self.assertEqual(waiter.args[0], index)
+                    if value:
+                        self.assertTrue(waiter.args[1])
+                    else:
+                        self.assertFalse(waiter.args[1])
+
+    def test_set_model_data_does_not_emit_when_editor_value_is_unrecognized(self):
+        editor = mock.MagicMock()
+        index = self._model.index(0, 0)
+        editor.data.return_value = None
+        with mock.patch.object(self._delegate, "data_committed") as data_committed_signal:
+            self._delegate.setModelData(editor, self._model, index)
+            data_committed_signal.emit.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
User may enter an unrecognized value to the editor which we now graciously ignore.

Fixes #2414

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
