### PR TITLE
Make multidimension entity naming consistent

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -21,6 +21,7 @@ from PySide6.QtCore import Qt, Signal, Slot, QTimer, QAbstractTableModel, QModel
 from PySide6.QtGui import QFont
 
 from spinedb_api import DatabaseMapping
+from spinedb_api.helpers import name_from_elements
 from spinedb_api.parameter_value import join_value_and_type, split_value_and_type
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR, parameter_identifier
 from spinetoolbox.fetch_parent import FlexibleFetchParent
@@ -1461,11 +1462,8 @@ class ElementPivotTableModel(PivotTableModelBase):
 
     def _batch_set_entity_data(self, row_map, column_map, data, values):
         def entity_to_add(db_map, header_ids):
-            ent_cls_name = self.db_mngr.get_item(db_map, "entity_class", self._parent.current_class_id.get(db_map))[
-                "name"
-            ]
             element_names = [self.db_mngr.get_item(db_map, "entity", id_)["name"] for id_ in header_ids]
-            name = ent_cls_name + "_" + "__".join(element_names)
+            name = name_from_elements(element_names)
             return dict(element_id_list=list(header_ids), class_id=self._parent.current_class_id.get(db_map), name=name)
 
         to_add = {}

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -36,6 +36,8 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Slot, Qt, QSize, QModelIndex
 from PySide6.QtGui import QIcon
+
+from spinedb_api.helpers import name_from_elements
 from ...mvcmodels.empty_row_model import EmptyRowModel
 from ...mvcmodels.compound_table_model import CompoundTableModel
 from ...mvcmodels.minimal_table_model import MinimalTableModel
@@ -273,10 +275,7 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
             else:
                 col_data = lambda j: self.model.index(row, j).data()  # pylint: disable=cell-var-from-loop
                 obj_cls_names = [col_data(j) for j in range(self.number_of_dimensions) if col_data(j)]
-                if len(obj_cls_names) == 1:
-                    relationship_class_name = obj_cls_names[0] + "__"
-                else:
-                    relationship_class_name = "__".join(obj_cls_names)
+                relationship_class_name = name_from_dimensions(obj_cls_names)
                 self.model.setData(self.model.index(row, self.number_of_dimensions), relationship_class_name)
 
     @Slot()
@@ -401,7 +400,7 @@ class AddEntitiesOrManageElementsDialog(GetEntityClassesMixin, GetEntitiesMixin,
         for row in range(top, bottom + 1):
             if header.index('entity name') not in range(left, right + 1):
                 el_names = [n for n in (self.model.index(row, j).data() for j in range(dimension_count)) if n]
-                entity_name = el_names[0] + "__" if len(el_names) == 1 else "__".join(el_names)
+                entity_name = name_from_elements(el_names)
                 self.model.setData(self.model.index(row, dimension_count), entity_name)
 
 

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -491,7 +491,9 @@ class TestScenarioModelWithTwoDatabases(_TestBase):
         self._db_mngr.add_scenarios({self._db_map1: [{"name": "my_scenario"}]})
         self._db_mngr.add_alternatives({self._db_map1: [{"name": "alternative_1"}]})
         scenario_id = self._db_map1.get_scenario_item(name="my_scenario")["id"]
-        self._db_mngr.set_scenario_alternatives({self._db_map1: [{"id": scenario_id, "alternative_name_list": ["alternative_1", "Base"]}]})
+        self._db_mngr.set_scenario_alternatives(
+            {self._db_map1: [{"id": scenario_id, "alternative_name_list": ["alternative_1", "Base"]}]}
+        )
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map1, self._db_map2)
         model.build_tree()
         self._fetch_recursively(model)

--- a/tests/test_spine_db_fetcher.py
+++ b/tests/test_spine_db_fetcher.py
@@ -174,7 +174,7 @@ class TestSpineDBFetcher(unittest.TestCase):
         self._import_data(entity_classes=(("oc",), ("rc", ("oc",))), entities=(("oc", "obj"), ("rc", None, ("obj",))))
         item = {
             'id': -2,
-            'name': 'obj',
+            'name': 'obj__',
             'class_id': -2,
             'element_id_list': (-1,),
             'description': None,


### PR DESCRIPTION
Pivot table was creating multidimensional entity names by appending the entity names by the class name plus `__` which we do not do anywhere else. We now use `name_from_dimensions()` and `name_from_elements()` from `spinedb_api` to achieve consistent naming everywhere.

Fixes #2423

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
