### PR TITLE
Fix entity duplication

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -597,12 +597,10 @@ class SpineDBEditorBase(QMainWindow):
             entity_item (EntityTreeItem of EntityItem)
         """
         orig_name = entity_item.name
+        class_name = entity_item.parent_item.name
         existing_names = {ent.name for ent in entity_item.parent_item.children}
         dup_name = unique_name(orig_name, existing_names)
-        parcel = SpineDBParcel(self.db_mngr)
-        db_map_ent_ids = {db_map: {entity_item.db_map_id(db_map)} for db_map in entity_item.db_maps}
-        parcel.inner_push_entity_ids(db_map_ent_ids)
-        self.db_mngr.duplicate_entity(parcel.data, orig_name, dup_name, entity_item.db_maps)
+        self.db_mngr.duplicate_entity(orig_name, dup_name, class_name, entity_item.db_maps)
 
     def duplicate_scenario(self, db_map, scen_id):
         """

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -491,7 +491,9 @@ class TestScenarioModelWithTwoDatabases(_TestBase):
         self._db_mngr.add_scenarios({self._db_map1: [{"name": "my_scenario"}]})
         self._db_mngr.add_alternatives({self._db_map1: [{"name": "alternative_1"}]})
         scenario_id = self._db_map1.get_scenario_item(name="my_scenario")["id"]
-        self._db_mngr.set_scenario_alternatives({self._db_map1: [{"id": scenario_id, "alternative_name_list": ["alternative_1", "Base"]}]})
+        self._db_mngr.set_scenario_alternatives(
+            {self._db_map1: [{"id": scenario_id, "alternative_name_list": ["alternative_1", "Base"]}]}
+        )
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map1, self._db_map2)
         model.build_tree()
         self._fetch_recursively(model)

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
@@ -19,7 +19,6 @@ import sys
 from PySide6.QtCore import QItemSelectionModel
 from PySide6.QtWidgets import QApplication
 
-from spinetoolbox.helpers import signal_waiter
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
 from tests.mock_helpers import TestSpineDBManager
 

--- a/tests/test_spine_db_fetcher.py
+++ b/tests/test_spine_db_fetcher.py
@@ -174,7 +174,7 @@ class TestSpineDBFetcher(unittest.TestCase):
         self._import_data(entity_classes=(("oc",), ("rc", ("oc",))), entities=(("oc", "obj"), ("rc", None, ("obj",))))
         item = {
             'id': -2,
-            'name': 'obj',
+            'name': 'obj__',
             'class_id': -2,
             'element_id_list': (-1,),
             'description': None,


### PR DESCRIPTION
This PR fixes duplication of entities in Database editor's Entity tree which failed to duplicate multidimensional entities the duplicated entity was an element of.

Fixes #2421

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
