### PR TITLE
Fix add entity classes widget expanding

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -83,6 +83,7 @@ class DialogWithTableAndButtons(DialogWithButtons):
         raise NotImplementedError()
 
     def resize_window_to_columns(self, height=None):
+        self.table_view.resizeColumnsToContents()
         if height is None:
             height = self.sizeHint().height()
         slack = 64


### PR DESCRIPTION
Now the add entity widget also retracts instead of just always expanding.

Fixes #2137

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass (locally)
