### PR TITLE
Fix only other db editor shows dirty

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -186,6 +186,7 @@ class SpineDBEditorBase(QMainWindow):
         if update_history:
             self.url_toolbar.add_urls_to_history(self.db_urls)
         self.restore_ui()
+        self.update_commit_enabled()
         return True
 
     def init_add_undo_redo_actions(self):


### PR DESCRIPTION
Now if one has the same DB open in two DB editors, their dirty states are linked like they should be.

Fixes #2433

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass (locally)
