### PR TITLE
Automatically select newly created project items

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "jill >=0.9.2",
     "pyzmq >=21.0",
     "spine-items>=0.21.0",
+    "pendulum < 3.0.0"
 ]
 
 [project.urls]

--- a/spinetoolbox/widgets/add_project_item_widget.py
+++ b/spinetoolbox/widgets/add_project_item_widget.py
@@ -14,7 +14,7 @@ Widget shown to user when a new Project Item is created.
 """
 
 from PySide6.QtWidgets import QWidget, QStatusBar
-from PySide6.QtCore import Slot, Qt
+from PySide6.QtCore import Slot, Qt, QItemSelectionModel
 from spine_engine.utils.helpers import shorten
 from ..config import STATUSBAR_SS
 from ..helpers import unique_name
@@ -110,6 +110,10 @@ class AddProjectItemWidget(QWidget):
             return
         self.call_add_item()
         self.close()
+        # Select the newly created item
+        index = self._toolbox.project_item_model.find_item(self.name)
+        self._toolbox.ui.treeView_project.selectionModel().select(index, QItemSelectionModel.ClearAndSelect)
+        self._toolbox.refresh_active_elements(self._toolbox._project._project_items.get(self.name), None, None)
 
     def call_add_item(self):
         """Creates new Item according to user's selections.


### PR DESCRIPTION
Now when a new item is created, it is automatically selected right away so that its properties show up immediately without the user needing to click the item manually.

Fixes #2456

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
