### PR TITLE
Fix db editor parameter definition row refresh

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/single_and_empty_model_mixins.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_and_empty_model_mixins.py
@@ -33,7 +33,7 @@ class ConvertToDBMixin:
         item = item.copy()
         for field, real_field in self.field_map.items():
             if field in item:
-                item[real_field] = item.pop(field, None)
+                item[real_field] = item.pop(field)
         return item.copy(), []
 
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_and_empty_model_mixins.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_and_empty_model_mixins.py
@@ -32,7 +32,8 @@ class ConvertToDBMixin:
         """
         item = item.copy()
         for field, real_field in self.field_map.items():
-            item[real_field] = item.pop(field, None)
+            if field in item:
+                item[real_field] = item.pop(field, None)
         return item.copy(), []
 
 


### PR DESCRIPTION
Added one line to check which fields to change (do not to change those fields that have not been changed by the user - this resulted in emptying those cells in the DB editor).

Fixes #2418

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
