### PR TITLE
Fix rearranging alternatives in a scenario

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/scenario_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/scenario_model.py
@@ -143,7 +143,10 @@ class ScenarioModel(TreeModelBase):
             if target_db_map != scenario_item.db_map:
                 continue
             for name in alternative_names:
-                new_alternative_ids.append(scenario_item.db_map.get_alternative_item(name=name)["id"])
+                if isinstance(name, int):  # When rearranging alternatives in a scenario, the id is given straight
+                    new_alternative_ids.append(name)
+                else:
+                    new_alternative_ids.append(scenario_item.db_map.get_alternative_item(name=name)["id"])
         alternative_id_list = [id_ for id_ in old_alternative_id_list[:row] if id_ not in new_alternative_ids]
         alternative_id_list += new_alternative_ids
         alternative_id_list += [id_ for id_ in old_alternative_id_list[row:] if id_ not in new_alternative_ids]

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -258,9 +258,7 @@ class TestScenarioModel(_TestBase):
             ]
         ]
         self.assertEqual(model_data, expected)
-        mime_data = QMimeData()
-        data = {self._db_mngr.db_map_key(self._db_map): ["Base"]}
-        mime_data.setData(mime_types.ALTERNATIVE_DATA, QByteArray(pickle.dumps(data)))
+        mime_data = model.mimeData([model.index(1, 0, scenario_index)])
         self.assertTrue(model.dropMimeData(mime_data, Qt.DropAction.CopyAction, 0, 0, scenario_index))
         self._fetch_recursively(model)
         model_data = model_data_to_dict(model)


### PR DESCRIPTION
Now rearranging alternatives inside a scenario works again.

Fixes #2464

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
