### PR TITLE
Fix pendulum version causing trouble after installing toolbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "jill >=0.9.2",
     "pyzmq >=21.0",
     "spine-items>=0.21.3",
+    # dagster versions lower that 1.5.7 do not support pendulum >= 3.0.0
+    "pendulum < 3.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Restrict pendulum version to under 3.0.0. Already done for 0.8-dev branch in 7c5b864f89bcd72a590f08694ee16881afdee253.

Fixes #2474

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
