### PR TITLE
Add support for active_by_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - New context menu action (Select superclass) for entity class items in the entity tree.
 
 ### Changed
+
+#### Spine data structure
+
+Many parts of the Spine data structure have been redesigned.
+
+- *Entities* have replaced objects and relationships.
+  Zero-dimensional entities correspond to objects while multidimensional entities replace the former relationships.
+  Unlike relationships, the *elements* of multidimensional entities can now be other multidimensional entities.
+- Simple inheritance is now supported by *superclasses*.
+- Tools, features and methods have been removed.
+  The functionality that was previously implemented using the is_active parameter
+  has been replaced by *entity alternatives*.
+  Entity classes have a default setting for the entity alternative called *active by default*.
+
+#### Miscellaneous changes
+
 - Julia execution settings are now Tool specification settings instead of global application settings. You can 
   select a different Julia executable & project or Julia kernel for each Tool spec.
 - Headless mode now supports remote execution (see 'python -m spinetoolbox --help')

--- a/execution_tests/active_by_default/.gitignore
+++ b/execution_tests/active_by_default/.gitignore
@@ -1,0 +1,3 @@
+.spinetoolbox/local/
+.spinetoolbox/items/
+*.bak*

--- a/execution_tests/active_by_default/.spinetoolbox/project.json
+++ b/execution_tests/active_by_default/.spinetoolbox/project.json
@@ -1,0 +1,79 @@
+{
+    "project": {
+        "version": 12,
+        "description": "",
+        "settings": {
+            "enable_execute_all": true
+        },
+        "specifications": {
+            "Exporter": [
+                {
+                    "type": "path",
+                    "relative": true,
+                    "path": ".spinetoolbox/specifications/Exporter/export_entities.json"
+                }
+            ]
+        },
+        "connections": [
+            {
+                "name": "from Test data to Exporter",
+                "from": [
+                    "Test data",
+                    "right"
+                ],
+                "to": [
+                    "Exporter",
+                    "left"
+                ],
+                "options": {
+                    "require_scenario_filter": true
+                },
+                "filter_settings": {
+                    "known_filters": {
+                        "db_url@Test data": {
+                            "scenario_filter": {
+                                "base_scenario": true
+                            }
+                        }
+                    },
+                    "auto_online": true
+                }
+            }
+        ],
+        "jumps": []
+    },
+    "items": {
+        "Test data": {
+            "type": "Data Store",
+            "description": "",
+            "x": -115.31149147072384,
+            "y": 22.059589672660213,
+            "url": {
+                "dialect": "sqlite",
+                "host": "",
+                "port": "",
+                "database": {
+                    "type": "path",
+                    "relative": true,
+                    "path": "Test data.sqlite"
+                },
+                "schema": ""
+            }
+        },
+        "Exporter": {
+            "type": "Exporter",
+            "description": "",
+            "x": 17.046046565237432,
+            "y": 22.05958967266021,
+            "output_time_stamps": false,
+            "cancel_on_error": true,
+            "output_labels": [
+                {
+                    "in_label": "db_url@Test data",
+                    "out_label": "data.csv"
+                }
+            ],
+            "specification": "Export entities"
+        }
+    }
+}

--- a/execution_tests/active_by_default/.spinetoolbox/specifications/Exporter/export_entities.json
+++ b/execution_tests/active_by_default/.spinetoolbox/specifications/Exporter/export_entities.json
@@ -1,0 +1,25 @@
+{
+    "item_type": "Exporter",
+    "output_format": "csv",
+    "name": "Export entities",
+    "description": "",
+    "mappings": {
+        "Mapping (1)": {
+            "type": "entities",
+            "mapping": [
+                {
+                    "map_type": "EntityClass",
+                    "position": 0
+                },
+                {
+                    "map_type": "Entity",
+                    "position": 1
+                }
+            ],
+            "enabled": true,
+            "always_export_header": true,
+            "group_fn": "no_group",
+            "use_fixed_table_name": false
+        }
+    }
+}

--- a/execution_tests/active_by_default/execution_test.py
+++ b/execution_tests/active_by_default/execution_test.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import unittest
+from spinedb_api import DatabaseMapping
+
+class ActiveByDefault(unittest.TestCase):
+    _root_path = Path(__file__).parent
+    _database_path = _root_path / "Test data.sqlite"
+    _exporter_output_path = _root_path / ".spinetoolbox" / "items" / "exporter" / "output"
+
+    def _check_addition(self, result):
+        error = result[1]
+        self.assertIsNone(error)
+
+    def setUp(self):
+        if self._exporter_output_path.exists():
+            shutil.rmtree(self._exporter_output_path)
+        self._database_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._database_path.exists():
+            self._database_path.unlink()
+        url = "sqlite:///" + str(self._database_path)
+        with DatabaseMapping(url, create=True) as db_map:
+            self._check_addition(db_map.add_entity_class_item(name="HiddenByDefault", active_by_default=False))
+            self._check_addition(db_map.add_entity_item(name="hidden", entity_class_name="HiddenByDefault"))
+            self._check_addition(db_map.add_entity_class_item(name="VisibleByDefault", active_by_default=True))
+            self._check_addition(db_map.add_entity_item(name="visible", entity_class_name="VisibleByDefault"))
+            self._check_addition(db_map.add_scenario_item(name="base_scenario"))
+            self._check_addition(db_map.add_scenario_alternative_item(scenario_name="base_scenario", alternative_name="Base", rank=0))
+            db_map.commit_session("Add test data.")
+
+    def test_execution(self):
+        this_file = Path(__file__)
+        completed = subprocess.run((sys.executable, "-m", "spinetoolbox", "--execute-only", str(this_file.parent)))
+        self.assertEqual(completed.returncode, 0)
+        self.assertTrue(self._exporter_output_path.exists())
+        self.assertEqual(len(list(self._exporter_output_path.iterdir())), 1)
+        output_dir = next(iter(self._exporter_output_path.iterdir()))
+        filter_id = (output_dir / ".filter_id").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(filter_id), 1)
+        self.assertEqual(filter_id, ["base_scenario - Test data"])
+        entities = (output_dir / "data.csv").read_text(encoding="utf-8").splitlines()
+        expected = ["VisibleByDefault,visible"]
+        self.assertCountEqual(entities, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/execution_tests/export_entities_with_entity_alternatives/execution_test.py
+++ b/execution_tests/export_entities_with_entity_alternatives/execution_test.py
@@ -20,7 +20,7 @@ class ExportEntitiesWithEntityAlternatives(unittest.TestCase):
             self._database_path.unlink()
         url = "sqlite:///" + str(self._database_path)
         with DatabaseMapping(url, create=True) as db_map:
-            self._assert_item_added(db_map.add_entity_class_item(name="Object"))
+            self._assert_item_added(db_map.add_entity_class_item(name="Object", active_by_default=True))
             self._assert_item_added(db_map.add_entity_item(entity_class_name="Object", name="none_none"))
             self._assert_item_added(db_map.add_entity_item(entity_class_name="Object", name="true_none"))
             self._assert_item_added(db_map.add_entity_item(entity_class_name="Object", name="none_true"))

--- a/execution_tests/modify_connection_filter_by_script/execution_test.py
+++ b/execution_tests/modify_connection_filter_by_script/execution_test.py
@@ -8,6 +8,7 @@ from spinedb_api import (
     DatabaseMapping,
     import_alternatives,
     import_entities,
+    import_entity_alternatives,
     import_entity_classes,
     import_parameter_definitions,
     import_parameter_values,
@@ -30,10 +31,11 @@ class ModifyConnectionFilterByScript(unittest.TestCase):
             self._database_path.unlink()
         url = "sqlite:///" + str(self._database_path)
         with DatabaseMapping(url, create=True) as db_map:
-            import_entity_classes(db_map, ("object_class",))
+            import_entity_classes(db_map, (("object_class",),))
             import_entities(db_map, (("object_class", "object"),))
             import_parameter_definitions(db_map, (("object_class", "parameter"),))
             import_alternatives(db_map, ("alternative",))
+            import_entity_alternatives(db_map, (("object_class", "object", "alternative", True),))
             import_parameter_values(
                 db_map,
                 (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
+-e git+https://github.com/spine-tools/Spine-Database-API.git@316_entity_alternative_default_activity#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git@0.8-dev#egg=spine_items
 -e .[dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/spine-tools/Spine-Database-API.git@316_entity_alternative_default_activity#egg=spinedb_api
+-e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git@0.8-dev#egg=spine_items
 -e .[dev]

--- a/spinetoolbox/mvcmodels/empty_row_model.py
+++ b/spinetoolbox/mvcmodels/empty_row_model.py
@@ -8,10 +8,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Contains a table model with an empty last row.
-"""
+""" Contains a table model with an empty last row. """
 
 from PySide6.QtCore import Qt, Slot, QModelIndex
 from .minimal_table_model import MinimalTableModel

--- a/spinetoolbox/mvcmodels/minimal_table_model.py
+++ b/spinetoolbox/mvcmodels/minimal_table_model.py
@@ -8,10 +8,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Contains a minimal table model.
-"""
+""" Contains a minimal table model. """
 
 from PySide6.QtCore import Qt, QModelIndex, QAbstractTableModel
 

--- a/spinetoolbox/mvcmodels/minimal_table_model.py
+++ b/spinetoolbox/mvcmodels/minimal_table_model.py
@@ -14,9 +14,10 @@ from PySide6.QtCore import Qt, QModelIndex, QAbstractTableModel
 
 
 class MinimalTableModel(QAbstractTableModel):
-    def __init__(self, parent=None, header=None, lazy=True):
-        """Table model for outlining simple tabular data.
+    """Table model for outlining simple tabular data."""
 
+    def __init__(self, parent=None, header=None, lazy=True):
+        """
         Args:
             parent (QObject, optional): the parent object
             header (list of str): header labels

--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -1,0 +1,44 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+""" Helpers and utilities for Spine Database editor. """
+
+
+def string_to_display_icon(x):
+    """Converts a 'foreign' string (from e.g. Excel) to entity class display icon.
+
+    Args:
+        x (str): string to convert
+
+    Returns:
+        int: display icon or None if conversion failed
+    """
+    try:
+        return int(x)
+    except ValueError:
+        return None
+
+
+TRUE_STRING = "true"
+FALSE_STRING = "false"
+GENERIC_TRUE = TRUE_STRING.casefold()
+GENERIC_FALSE = FALSE_STRING.casefold()
+
+
+def string_to_bool(x):
+    """Converts a 'foreign' string (from e.g. Excel) to boolean.
+
+    Args:
+        x (str): string to convert
+
+    Returns:
+        bool: boolean value
+    """
+    return x.casefold() == GENERIC_TRUE

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -8,11 +8,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Compound models.
-These models concatenate several 'single' models and one 'empty' model.
-"""
+""" Compound models. These models concatenate several 'single' models and one 'empty' model. """
 from PySide6.QtCore import Qt, Slot, QTimer, QModelIndex
 from PySide6.QtGui import QFont
 from spinedb_api.parameter_value import join_value_and_type

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -9,7 +9,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 """ Classes for custom QDialogs to add items to databases. """
-
+from contextlib import suppress
 from itertools import product
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -34,6 +34,7 @@ from PySide6.QtCore import Slot, Qt, QSize, QModelIndex
 from PySide6.QtGui import QIcon
 
 from spinedb_api.helpers import name_from_elements, name_from_dimensions
+from ..helpers import string_to_bool, string_to_display_icon
 from ...mvcmodels.empty_row_model import EmptyRowModel
 from ...mvcmodels.compound_table_model import CompoundTableModel
 from ...mvcmodels.minimal_table_model import MinimalTableModel
@@ -189,6 +190,8 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
         """
         super().__init__(parent, db_mngr, *db_maps)
         self.setWindowTitle("Add entity classes")
+        self.table_view.set_column_converter_for_pasting("display icon", string_to_display_icon)
+        self.table_view.set_column_converter_for_pasting("active by default", string_to_bool)
         self.model = EmptyRowModel(self)
         self.model.force_default = force_default
         self.table_view.setModel(self.model)

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -8,16 +8,14 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Custom QTableView classes that support copy-paste and the like.
-"""
+""" Custom QTableView classes that support copy-paste and the like. """
 
 from dataclasses import replace
 from PySide6.QtCore import Qt, Signal, Slot, QTimer, QModelIndex, QPoint, QItemSelection, QItemSelectionModel
 from PySide6.QtWidgets import QTableView, QMenu, QWidget
 from PySide6.QtGui import QKeySequence, QAction
 from .scenario_generator import ScenarioGenerator
+from ..helpers import string_to_bool
 from ..mvcmodels.pivot_table_models import (
     ParameterValuePivotTableModel,
     ElementPivotTableModel,
@@ -363,6 +361,10 @@ class ParameterValueTableView(ParameterTableView):
 
 class EntityAlternativeTableView(StackedTableView):
     """Visualize entities and their alternatives."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.set_column_converter_for_pasting("active", string_to_bool)
 
     def create_delegates(self):
         super().create_delegates()

--- a/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
@@ -8,10 +8,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Classes for custom QDialogs to edit items in databases.
-"""
+""" Classes for custom QDialogs to edit items in databases. """
 
 from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QComboBox, QTabWidget
@@ -57,13 +54,15 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
         self.table_view.setModel(self.model)
         self.table_view.setItemDelegate(ManageEntityClassesDelegate(self))
         self.connect_signals()
-        self.model.set_horizontal_header_labels(['entity class name', 'description', 'display icon', 'databases'])
+        self.model.set_horizontal_header_labels(
+            ['entity class name', 'description', 'display icon', "active by default", 'databases']
+        )
         self.orig_data = list()
         self.default_display_icon = default_icon_id()
         model_data = list()
         for item in selected:
             data = item.db_map_data(item.first_db_map)
-            row_data = [item.name, data['description'], data['display_icon']]
+            row_data = [item.name, data['description'], data['display_icon'], data["active_by_default"]]
             self.orig_data.append(row_data.copy())
             row_data.append(item.display_database)
             model_data.append(row_data)
@@ -82,7 +81,7 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
         """Collect info from dialog and try to update items."""
         db_map_data = dict()
         for i in range(self.model.rowCount()):
-            name, description, display_icon, db_names = self.model.row_data(i)
+            name, description, display_icon, active_by_default, db_names = self.model.row_data(i)
             if db_names is None:
                 db_names = ""
             item = self.items[i]
@@ -101,10 +100,14 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
                 continue
             if not display_icon:
                 display_icon = self.default_display_icon
-            pre_db_item = {'name': name, 'description': description, 'display_icon': display_icon}
             for db_map in db_maps:
-                db_item = pre_db_item.copy()
-                db_item['id'] = item.db_map_id(db_map)
+                db_item = {
+                    "id": item.db_map_id(db_map),
+                    'name': name,
+                    'description': description,
+                    'display_icon': display_icon,
+                    "active_by_default": active_by_default,
+                }
                 db_map_data.setdefault(db_map, []).append(db_item)
         if not db_map_data:
             self.parent().msg_error.emit("Nothing to update")

--- a/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
@@ -12,6 +12,8 @@
 
 from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QComboBox, QTabWidget
+
+from ..helpers import string_to_bool, string_to_display_icon
 from ...mvcmodels.minimal_table_model import MinimalTableModel
 from .custom_delegates import ManageEntityClassesDelegate, ManageEntitiesDelegate, RemoveEntitiesDelegate
 from .manage_items_dialogs import (
@@ -50,6 +52,8 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
         """
         super().__init__(parent, db_mngr)
         self.setWindowTitle("Edit entity classes")
+        self.table_view.set_column_converter_for_pasting("display icon", string_to_display_icon)
+        self.table_view.set_column_converter_for_pasting("active by default", string_to_bool)
         self.model = MinimalTableModel(self)
         self.table_view.setModel(self.model)
         self.table_view.setItemDelegate(ManageEntityClassesDelegate(self))

--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -22,8 +22,7 @@ from ...helpers import busy_effect, preferred_row_height, DB_ITEM_SEPARATOR
 
 class DialogWithButtons(QDialog):
     def __init__(self, parent, db_mngr):
-        """Init class.
-
+        """
         Args:
             parent (SpineDBEditor): data store widget
             db_mngr (SpineDBManager)
@@ -55,8 +54,7 @@ class DialogWithButtons(QDialog):
 
 class DialogWithTableAndButtons(DialogWithButtons):
     def __init__(self, parent, db_mngr):
-        """Init class.
-
+        """
         Args:
             parent (SpineDBEditor): data store widget
             db_mngr (SpineDBManager)
@@ -102,8 +100,7 @@ class ManageItemsDialog(DialogWithTableAndButtons):
     """
 
     def __init__(self, parent, db_mngr):
-        """Init class.
-
+        """
         Args:
             parent (SpineDBEditor): data store widget
             db_mngr (SpineDBManager)

--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -8,10 +8,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Classes for custom QDialogs to add edit and remove database items.
-"""
+""" Classes for custom QDialogs to add edit and remove database items. """
 
 from functools import reduce, cached_property
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QGridLayout

--- a/spinetoolbox/widgets/custom_editors.py
+++ b/spinetoolbox/widgets/custom_editors.py
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QPalette, QStandardItemModel, QStandardItem, QColor
 from ..helpers import IconListManager, interpret_icon_id, make_icon_id, try_number_from_string
+from ..spine_db_editor.helpers import FALSE_STRING, TRUE_STRING
 
 
 class CustomLineEditor(QLineEdit):
@@ -286,16 +287,13 @@ class SearchBarEditor(QTableView):
 
 
 class BooleanSearchBarEditor(SearchBarEditor):
-    TRUE = "true"
-    FALSE = "false"
-
     def data(self):
         data = super().data()
-        return {self.TRUE: True, self.FALSE: False}[data]
+        return {TRUE_STRING: True, FALSE_STRING: False}.get(data, False)
 
     def set_data(self, current, items):
-        current = {True: self.TRUE, False: self.FALSE}[bool(current)]
-        super().set_data(current, [self.TRUE, self.FALSE])
+        current = {True: TRUE_STRING, False: FALSE_STRING}[bool(current)]
+        super().set_data(current, [TRUE_STRING, FALSE_STRING])
 
 
 class CheckListEditor(QTableView):

--- a/spinetoolbox/widgets/custom_editors.py
+++ b/spinetoolbox/widgets/custom_editors.py
@@ -8,10 +8,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Custom editors for model/view programming.
-"""
+""" Custom editors for model/view programming. """
 
 from PySide6.QtCore import Qt, Slot, Signal, QSortFilterProxyModel, QEvent, QCoreApplication, QModelIndex, QPoint, QSize
 from PySide6.QtWidgets import (
@@ -286,6 +283,19 @@ class SearchBarEditor(QTableView):
             return
         self.proxy_model.setData(self.first_index, index.data(Qt.ItemDataRole.EditRole))
         self.data_committed.emit()
+
+
+class BooleanSearchBarEditor(SearchBarEditor):
+    TRUE = "true"
+    FALSE = "false"
+
+    def data(self):
+        data = super().data()
+        return {self.TRUE: True, self.FALSE: False}[data]
+
+    def set_data(self, current, items):
+        current = {True: self.TRUE, False: self.FALSE}[bool(current)]
+        super().set_data(current, [self.TRUE, self.FALSE])
 
 
 class CheckListEditor(QTableView):

--- a/tests/spine_db_editor/test_helpers.py
+++ b/tests/spine_db_editor/test_helpers.py
@@ -1,0 +1,34 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+""" Unit tests for Database editor's ``helpers`` module. """
+
+import unittest
+
+from spinetoolbox.spine_db_editor.helpers import string_to_bool, string_to_display_icon
+
+
+class TestStringToDisplayIcon(unittest.TestCase):
+    def test_converts_correctly(self):
+        self.assertEqual(string_to_display_icon("23"), 23)
+        self.assertIsNone(string_to_display_icon(""))
+        self.assertIsNone(string_to_display_icon("rubbish"))
+
+
+class TestStringToBool(unittest.TestCase):
+    def test_converts_correctly(self):
+        self.assertTrue(string_to_bool("true"))
+        self.assertTrue(string_to_bool("TRUE"))
+        self.assertFalse(string_to_bool("false"))
+        self.assertFalse(string_to_bool(""))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -66,7 +66,7 @@ class TestAddItemsDialog(unittest.TestCase):
         model = dialog.model
         header = model.header
         model.fetchMore(QModelIndex())
-        self.assertEqual(header, ['entity class name', 'description', 'display icon', 'databases'])
+        self.assertEqual(header, ['entity class name', 'description', 'display icon', "active by default", 'databases'])
         indexes = [model.index(0, header.index(field)) for field in ('entity class name', 'databases')]
         values = ['fish', 'mock_db']
         model.batch_set_data(indexes, values)
@@ -86,7 +86,7 @@ class TestAddItemsDialog(unittest.TestCase):
         model = dialog.model
         header = model.header
         model.fetchMore(QModelIndex())
-        self.assertEqual(header, ['entity class name', 'description', 'display icon', 'databases'])
+        self.assertEqual(header, ['entity class name', 'description', 'display icon', "active by default", 'databases'])
         indexes = [model.index(0, header.index(field)) for field in ('entity class name', 'databases')]
         values = ['fish', 'gibberish']
         model.batch_set_data(indexes, values)

--- a/tests/spine_db_editor/widgets/test_custom_delegates.py
+++ b/tests/spine_db_editor/widgets/test_custom_delegates.py
@@ -38,10 +38,10 @@ class TestBooleanValueDelegate(unittest.TestCase):
     def test_set_model_data_emits_when_true_is_selected(self):
         editor = mock.MagicMock()
         index = self._model.index(0, 0)
-        for editor_value, value in {BooleanValueDelegate.TRUE: True, BooleanValueDelegate.FALSE: False}.items():
-            with self.subTest(editor_value=editor_value):
-                editor.data.return_value = editor_value
-                with signal_waiter(self._delegate.data_committed) as waiter:
+        for value in (True, False):
+            with self.subTest(value=value):
+                editor.data.return_value = value
+                with signal_waiter(self._delegate.data_committed, timeout=1.0) as waiter:
                     self._delegate.setModelData(editor, self._model, index)
                     waiter.wait()
                     self.assertEqual(len(waiter.args), 2)

--- a/tests/spine_db_editor/widgets/test_edit_or_remove_items_dialogs.py
+++ b/tests/spine_db_editor/widgets/test_edit_or_remove_items_dialogs.py
@@ -1,0 +1,94 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+""" Unit tests for edit_or_remove_items_dialogs module. """
+import unittest
+from unittest import mock
+
+from PySide6.QtCore import QItemSelectionModel
+from PySide6.QtWidgets import QApplication
+
+from spinetoolbox.spine_db_editor.widgets.edit_or_remove_items_dialogs import EditEntityClassesDialog
+from tests.spine_db_editor.widgets.helpers import TestBase
+
+
+class TestEditEntityClassesDialog(TestBase):
+    def setUp(self):
+        self._common_setup("sqlite://", create=True)
+
+    def tearDown(self):
+        self._common_tear_down()
+
+    def test_pasting_gibberish_to_active_by_default_column_gives_false(self):
+        self._db_map.add_entity_class_item(name="Object")
+        entity_tree = self._db_editor.ui.treeView_entity
+        entity_model = entity_tree.model()
+        entity_model.root_item.fetch_more()
+        while not entity_model.root_item.children:
+            QApplication.processEvents()
+        self.assertEqual(len(entity_model.root_item.children), 1)
+        dialog = EditEntityClassesDialog(self._db_editor, self._db_mngr, entity_model.root_item.children)
+        model = dialog.model
+        self._assert_table_contents(model, [["Object", None, None, False, "TestEditEntityClassesDialog_db"]])
+        dialog.table_view.selectionModel().setCurrentIndex(
+            model.index(0, 3), QItemSelectionModel.SelectionFlag.ClearAndSelect
+        )
+        mock_clipboard = mock.MagicMock()
+        mock_clipboard.text.return_value = "true"
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as clipboard:
+            clipboard.return_value = mock_clipboard
+            self.assertTrue(dialog.table_view.paste())
+        self._assert_table_contents(model, [["Object", None, None, True, "TestEditEntityClassesDialog_db"]])
+        mock_clipboard = mock.MagicMock()
+        mock_clipboard.text.return_value = "GIBBERISH"
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as clipboard:
+            clipboard.return_value = mock_clipboard
+            self.assertTrue(dialog.table_view.paste())
+        self._assert_table_contents(model, [["Object", None, None, False, "TestEditEntityClassesDialog_db"]])
+
+    def test_pasting_gibberish_to_display_icon_column_gives_none(self):
+        self._db_map.add_entity_class_item(name="Object")
+        entity_tree = self._db_editor.ui.treeView_entity
+        entity_model = entity_tree.model()
+        entity_model.root_item.fetch_more()
+        while not entity_model.root_item.children:
+            QApplication.processEvents()
+        self.assertEqual(len(entity_model.root_item.children), 1)
+        dialog = EditEntityClassesDialog(self._db_editor, self._db_mngr, entity_model.root_item.children)
+        model = dialog.model
+        self._assert_table_contents(model, [["Object", None, None, False, "TestEditEntityClassesDialog_db"]])
+        dialog.table_view.selectionModel().setCurrentIndex(
+            model.index(0, 2), QItemSelectionModel.SelectionFlag.ClearAndSelect
+        )
+        mock_clipboard = mock.MagicMock()
+        mock_clipboard.text.return_value = "23"
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as clipboard:
+            clipboard.return_value = mock_clipboard
+            self.assertTrue(dialog.table_view.paste())
+        self._assert_table_contents(model, [["Object", None, 23, False, "TestEditEntityClassesDialog_db"]])
+        mock_clipboard = mock.MagicMock()
+        mock_clipboard.text.return_value = "GIBBERISH"
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as clipboard:
+            clipboard.return_value = mock_clipboard
+            self.assertTrue(dialog.table_view.paste())
+        self._assert_table_contents(model, [["Object", None, None, False, "TestEditEntityClassesDialog_db"]])
+
+    def _assert_table_contents(self, model, expected):
+        data_table = []
+        for row in range(model.rowCount()):
+            row_data = []
+            for column in range(model.columnCount()):
+                row_data.append(model.index(row, column).data())
+            data_table.append(row_data)
+        self.assertEqual(data_table, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_spine_db_fetcher.py
+++ b/tests/test_spine_db_fetcher.py
@@ -116,6 +116,7 @@ class TestSpineDBFetcher(unittest.TestCase):
             'display_order': 99,
             'display_icon': None,
             'hidden': 0,
+            "active_by_default": False,
             'dimension_id_list': (),
         }
         fetcher = TestItemTypeFetchParent("entity_class")
@@ -157,6 +158,7 @@ class TestSpineDBFetcher(unittest.TestCase):
             'display_order': 99,
             'display_icon': None,
             'hidden': 0,
+            "active_by_default": True,
             'dimension_id_list': (1,),
         }
         for item_type in ("entity_class",):


### PR DESCRIPTION
This PR implements support for the new active_by_default column in entity_class tables. It is now possible to change the value of the flag while creating or editing entity classes in Database editor.

See PR spine-tools/Spine-Database-API#336 for the db API side changes.

Re spine-tools/Spine-Database-API#316

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
