### PR TITLE
Fix opening infinite db editor tabs from same db

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
@@ -14,7 +14,7 @@ Contains the MultiSpineDBEditor class.
 """
 
 import os
-from PySide6.QtWidgets import QMenu, QStatusBar, QToolButton
+from PySide6.QtWidgets import QMenu, QStatusBar, QToolButton, QMessageBox
 from PySide6.QtCore import Slot, QPoint
 from PySide6.QtGui import QIcon, QFont
 from .spine_db_editor import SpineDBEditor
@@ -46,7 +46,7 @@ class MultiSpineDBEditor(MultiTabWindow):
         self.statusBar().hide()
         self.tab_load_success = True
         if db_url_codenames is not None:
-            if not self.add_new_tab(db_url_codenames):
+            if not self.add_new_tab(db_url_codenames, window=True):
                 self.tab_load_success = False
 
     def _make_other(self):
@@ -87,11 +87,28 @@ class MultiSpineDBEditor(MultiTabWindow):
         tab.ui.actionClose.triggered.disconnect(self.handle_close_request_from_tab)
         return True
 
-    def _make_new_tab(self, db_url_codenames=None):  # pylint: disable=arguments-differ
+    def _make_new_tab(self, db_url_codenames=None, window=False):  # pylint: disable=arguments-differ
         """Makes a new tab, if successful return the tab, returns None otherwise"""
         tab = SpineDBEditor(self.db_mngr)
-        if not tab.load_db_urls(db_url_codenames, create=True):
+        if not tab.load_db_urls(db_url_codenames, create=True, window=window):
             return
+        # Checks if the same url is already opened under a different codename
+        for url, codename in db_url_codenames.items():
+            current_codename = codename
+            for db_map in self.db_mngr.db_maps:
+                is_same = str(url) == db_map.db_url
+                is_same = is_same and codename != db_map.codename
+                if is_same:
+                    existing = db_map.codename
+                    msg = QMessageBox(self.parent())
+                    msg.setIcon(QMessageBox.Icon.Information)
+                    msg.setWindowTitle(current_codename)
+                    msg.setText(
+                        f"<p>The same database is already open in another window. Opening the new window under "
+                        f"the same name as the existing one: <b>{existing}</b></p>"
+                    )
+                    msg.exec()
+                    break
         return tab
 
     def show_plus_button_context_menu(self, global_pos):

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -147,7 +147,7 @@ class SpineDBEditorBase(QMainWindow):
         """
         return True
 
-    def load_db_urls(self, db_url_codenames, create=False, update_history=True):
+    def load_db_urls(self, db_url_codenames, create=False, update_history=True, window=False):
         self.ui.actionImport.setEnabled(False)
         self.ui.actionExport.setEnabled(False)
         self.ui.actionMass_remove_items.setEnabled(False)
@@ -163,7 +163,7 @@ class SpineDBEditorBase(QMainWindow):
         self._changelog.clear()
         self._purge_change_notifiers()
         for url, codename in db_url_codenames.items():
-            db_map = self.db_mngr.get_db_map(url, self, codename=codename, create=create)
+            db_map = self.db_mngr.get_db_map(url, self, codename=codename, create=create, window=window)
             if db_map is not None:
                 self.db_maps.append(db_map)
         if not self.db_maps:

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -301,7 +301,12 @@ class TestOpenDBEditor(unittest.TestCase):
         self._db_mngr.open_db_editor({self._db_url: "not_the_same"})
         self.assertEqual(len(editors), 1)
         editor = editors[0]
-        self.assertEqual(editor.tab_widget.count(), 2)
+        self.assertEqual(editor.tab_widget.count(), 1)
+        # Finally try to open the first tab again
+        self._db_mngr.open_db_editor({self._db_url: "test"})
+        editors = list(self._db_mngr.get_all_multi_spine_db_editors())
+        editor = editors[0]
+        self.assertEqual(editor.tab_widget.count(), 1)
         for editor in self._db_mngr.get_all_multi_spine_db_editors():
             QApplication.processEvents()
             editor.close()


### PR DESCRIPTION
If a db_map is already opened in a db editor, new tabs with the same db_map won't be opened anymore. Instead the one already open is brought up. If however the same db_map is opened in a new window, it is allowed to open.

Fixes #2435

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
