### PR TITLE
Fix segfault in Database editor

### DIFF
--- a/execution_tests/active_by_default/.spinetoolbox/items/exporter/.export-manifest-e7cb0c670df62a5135b1dd6236afee47eaaad217.json
+++ b/execution_tests/active_by_default/.spinetoolbox/items/exporter/.export-manifest-e7cb0c670df62a5135b1dd6236afee47eaaad217.json
@@ -1,0 +1,1 @@
+{"data.csv": ["output\\base_scenario_e7cb0c670df62a5135b1dd6236afee47eaaad217\\data.csv"]}

--- a/execution_tests/active_by_default/.spinetoolbox/items/exporter/output/base_scenario_e7cb0c670df62a5135b1dd6236afee47eaaad217/.filter_id
+++ b/execution_tests/active_by_default/.spinetoolbox/items/exporter/output/base_scenario_e7cb0c670df62a5135b1dd6236afee47eaaad217/.filter_id
@@ -1,0 +1,1 @@
+base_scenario - Test data

--- a/execution_tests/active_by_default/.spinetoolbox/items/exporter/output/base_scenario_e7cb0c670df62a5135b1dd6236afee47eaaad217/data.csv
+++ b/execution_tests/active_by_default/.spinetoolbox/items/exporter/output/base_scenario_e7cb0c670df62a5135b1dd6236afee47eaaad217/data.csv
@@ -1,0 +1,1 @@
+VisibleByDefault,visible

--- a/execution_tests/active_by_default/.spinetoolbox/local/project_local_data.json
+++ b/execution_tests/active_by_default/.spinetoolbox/local/project_local_data.json
@@ -1,0 +1,11 @@
+{
+    "items": {
+        "Test data": {
+            "url": {
+                "username": "",
+                "password": ""
+            }
+        },
+        "Exporter": {}
+    }
+}

--- a/execution_tests/active_by_default/.spinetoolbox/local/specification_local_data.json
+++ b/execution_tests/active_by_default/.spinetoolbox/local/specification_local_data.json
@@ -1,0 +1,13 @@
+{
+    "Tool": {
+        "Run SpineOpt": {
+            "execution_settings": {}
+        },
+        "Load template": {
+            "execution_settings": {}
+        },
+        "Run SpineOpt detached": {
+            "execution_settings": {}
+        }
+    }
+}

--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -147,7 +147,7 @@ class TreeItem:
         """
         bad_types = [type(child) for child in children if not isinstance(child, TreeItem)]
         if bad_types:
-            raise TypeError(f"Can't insert children of type {bad_types} to an item of type {type(self)}")
+            raise TypeError(f"Can't insert children of type {bad_types} to an item of type {type(self).__name__}")
         if position < 0 or position > self.child_count():
             return False
         self._polish_children(children)

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -201,7 +201,7 @@ class MultiDBTreeItem(TreeItem):
     def deep_merge(self, other):
         """Merges another item and all its descendants into this one."""
         if not isinstance(other, type(self)):
-            raise ValueError(f"Can't merge an instance of {type(other)} into a MultiDBTreeItem.")
+            raise ValueError(f"Can't merge an instance of {type(other).__name__} into a MultiDBTreeItem.")
         for db_map in other.db_maps:
             self.add_db_map_id(db_map, other.db_map_id(db_map))
         self._merge_children(other.children)


### PR DESCRIPTION
This PR fixes a bug in Database editor where adding more databases to a tab would sometimes cause Toolbox to crash.

Fixes #2488

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
