### PR TITLE
Fix undoing Purge action in Database editor

### DIFF
--- a/spinetoolbox/project_item_icon.py
+++ b/spinetoolbox/project_item_icon.py
@@ -113,9 +113,7 @@ class ProjectItemIcon(QGraphicsPathItem):
         dim_max = max(size.width(), size.height())
         rect_w = 0.3 * self.rect().width()  # Parent rect width
         self.spec_item.setScale(rect_w / dim_max)
-        self.spec_item.setPos(
-            self.sceneBoundingRect().bottomLeft() - self.spec_item.sceneBoundingRect().center()
-        )
+        self.spec_item.setPos(self.sceneBoundingRect().bottomLeft() - self.spec_item.sceneBoundingRect().center())
 
     def remove_specification_icon(self):
         """Removes the specification icon SVG from the scene."""

--- a/spinetoolbox/spine_db_icon_manager.py
+++ b/spinetoolbox/spine_db_icon_manager.py
@@ -135,8 +135,7 @@ class SpineDBIconManager:
 
     def class_renderer(self, entity_class):
         name, dimension_name_list = entity_class["name"], entity_class["dimension_name_list"]
-        display_icon = self.display_icons.get(name)
-        if display_icon:
+        if not dimension_name_list:
             if name not in self._class_renderers:
                 self._create_class_renderer(name)
             return self._class_renderers[name]

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -15,7 +15,7 @@ The SpineDBWorker class
 """
 from PySide6.QtCore import QObject, Signal, Slot
 from PySide6.QtCore import QTimer
-from spinedb_api import DatabaseMapping
+from spinedb_api import Asterisk, DatabaseMapping
 from .qthread_pool_executor import QtBasedThreadPoolExecutor, SynchronousExecutor
 from .helpers import busy_effect
 
@@ -273,6 +273,8 @@ class SpineDBWorker(QObject):
             ids (set): ids of items to restore
         """
         items = self._db_map.restore_items(item_type, *ids)
+        if Asterisk in ids:
+            items = self._db_map.get_items(item_type)
         self._db_mngr.update_icons(self._db_map, item_type, items)
         self._db_mngr.items_added.emit(item_type, {self._db_map: items})
         return items


### PR DESCRIPTION
This fixes a Traceback that could occur when undoing database purge.

Fixes #2551
## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
