### PR TITLE
Fix warnings in GitHub actions

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -21,13 +21,13 @@ jobs:
         python-version: [3.8, 3.9, "3.10", 3.11]
         os: [windows-latest, ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Version from Git tags
       run: git describe --tags
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display Python version
@@ -43,13 +43,13 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
     - name: List packages
       run:
-        pip list
+        python -m pip list
     - name: Install python3 kernelspecs
       run: |
-        pip install ipykernel
+        python -m pip install ipykernel
         python -m ipykernel install --user
     - name: Run tests
       run: |
@@ -59,7 +59,7 @@ jobs:
         coverage run -m unittest discover --verbose
       shell: bash
     - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
   execution-tests:
     name: Execution tests
     runs-on: ${{ matrix.os }}
@@ -70,9 +70,9 @@ jobs:
         os: [windows-latest, ubuntu-22.04]
 #    needs: unit-tests
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install additional packages for Linux
@@ -85,10 +85,10 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
     - name: List packages
       run: 
-        pip list
+        python -m pip list
     - name: Run tests
       run:
         python -m unittest discover --pattern execution_test.py --verbose


### PR DESCRIPTION
This fixes deprecation warnings in GitHub actions due to some Node.js version being phased out.

Fixes spine-tools/Spine-Database-API#358

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
