### PR TITLE
Fix pivot table unit tests

### DIFF
--- a/execution_tests/simple_importer_on_server/execution_test.py
+++ b/execution_tests/simple_importer_on_server/execution_test.py
@@ -49,7 +49,6 @@ class RunSimpleImporterOnServer(unittest.TestCase):
         # Check that DS1.sqlite is empty
         with DatabaseMapping(self._db_url) as db_map:
             entities = db_map.get_items("entity")
-            print(entities)
             self.assertEqual(0, len(entities))
         completed = subprocess.run(
             (

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -237,6 +237,7 @@ class TabularViewMixin:
     def _update_class_attributes(self, current_index):
         """Updates current class (type and id) and reloads pivot table for it."""
         current_class_item = self._get_current_class_item(current_index)
+        print(f"current_class_item {current_class_item}")
         if current_class_item is None:
             return
         class_id = current_class_item.db_map_ids
@@ -548,15 +549,18 @@ class TabularViewMixin:
     def do_reload_pivot_table(self):
         """Reloads pivot table."""
         if not self._can_build_pivot_table():
+            print("*** Cannot build pivot table")
             return
         if not self.ui.dockWidget_pivot_table.isVisible():
             self._pending_reload = True
+            print("*** Pivot table widget is invisible")
             return
         self.pivot_actions[self.current_input_type].setChecked(True)
         self.ui.dockWidget_frozen_table.setVisible(True)
         self._pending_reload = False
         pivot_table_model = self._pivot_table_models[self.current_input_type]
         if self.pivot_table_model is not pivot_table_model:
+            print(f"*** Setting model to {pivot_table_model}")
             self.pivot_table_model = pivot_table_model
             self.pivot_table_proxy.setSourceModel(self.pivot_table_model)
             self.pivot_table_model.modelReset.connect(self.make_pivot_headers)
@@ -565,6 +569,8 @@ class TabularViewMixin:
             self.pivot_table_model.frozen_values_removed.connect(self._remove_values_from_frozen_table)
             delegate = self.pivot_table_model.make_delegate(self)
             self.ui.pivot_table.setItemDelegate(delegate)
+        else:
+            print("*** Pivot table widget is the same")
         pivot = self.get_pivot_preferences()
         self.wipe_out_filter_menus()
         self.pivot_table_model.call_reset_model(pivot)

--- a/tests/spine_db_editor/mvcmodels/test_PivotTableModel.py
+++ b/tests/spine_db_editor/mvcmodels/test_PivotTableModel.py
@@ -42,6 +42,8 @@ class TestParameterValuePivotTableModel(TestBase):
             ),
         }
         self._db_mngr.import_data({self._db_map: data})
+        while self._db_editor.entity_tree_model._root_item.row_count() == 0:
+            QApplication.processEvents()
 
     def _start(self):
         get_item_exceptions = []
@@ -123,6 +125,8 @@ class TestParameterValuePivotTableModel(TestBase):
             "entity_classes": (("class1",),),
         }
         self._db_mngr.import_data({self._db_map: data})
+        while self._db_editor.entity_tree_model._root_item.row_count() == 0:
+            QApplication.processEvents()
         self._start()
         self.assertEqual(self._model.rowCount(), 3)
         self.assertEqual(self._model.columnCount(), 2)


### PR DESCRIPTION
This came up while trying to get the Toolbox tests to run on push to Spine-Database-API repository.

Some tests in TestParameterValuePivotTableModel were failing due to a timing issue. We need to wait for the Entity tree to finish fetching before we can use it.

Re spine-tools/Spine-Database-API#358

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
