### PR TITLE
Simplify items package scanning

### DIFF
--- a/spinetoolbox/load_project_items.py
+++ b/spinetoolbox/load_project_items.py
@@ -9,19 +9,8 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Functions to load project item modules.
-"""
-import pathlib
+""" Functions to load project item modules. """
 import importlib
-import importlib.util
-import pkgutil
-from spine_engine.project_item.project_item_info import ProjectItemInfo
-from spine_engine import __version__ as curr_engine_version
-from spinedb_api import __version__ as curr_db_api_version
-from .version import __version__ as curr_toolbox_version
-from .project_item.project_item_factory import ProjectItemFactory
 
 
 def load_project_items(items_package_name):
@@ -36,38 +25,4 @@ def load_project_items(items_package_name):
             while second maps item type to item factory
     """
     items = importlib.import_module(items_package_name)
-    items_root = pathlib.Path(items.__file__).parent
-    categories = dict()
-    factories = dict()
-    for child in items_root.iterdir():
-        if child.is_dir() and (child.joinpath("__init__.py").exists() or child.joinpath("__init__.pyc").exists()):
-            spec = importlib.util.find_spec(f"{items_package_name}.{child.stem}")
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            module_material = _find_module_material(module)
-            if module_material is not None:
-                item_type, category, factory = module_material
-                categories[item_type] = category
-                factories[item_type] = factory
-    return categories, factories
-
-
-def _find_module_material(module):
-    item_type = None
-    category = None
-    factory = None
-    prefix = module.__name__ + "."
-    for _, modname, _ in pkgutil.iter_modules(module.__path__, prefix):
-        submodule = __import__(modname, fromlist="dummy")
-        for name in dir(submodule):
-            attr = getattr(submodule, name)
-            if not isinstance(attr, type):
-                continue
-            if attr is not ProjectItemInfo and issubclass(attr, ProjectItemInfo):
-                item_type = attr.item_type()
-                category = attr.item_category()
-            if attr is not ProjectItemFactory and issubclass(attr, ProjectItemFactory):
-                factory = attr
-            if item_type is not None and factory is not None:
-                return item_type, category, factory
-    return None
+    return items.item_categories(), items.item_factories()


### PR DESCRIPTION
`spine_items` now offers functions that directly return item factories and categories removing the need to scan the package's files.

No related issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
