### PR TITLE
Fix circular dependency, allow DB editor be opened in new window

### DIFF
--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -1646,15 +1646,16 @@ class SpineDBManager(QObject):
                     return multi_db_editor, db_editor
         return None
 
-    def open_db_editor(self, db_url_codenames):
+    def open_db_editor(self, db_url_codenames, reuse_existing_editor):
         """Opens a SpineDBEditor with given urls. Uses an existing MultiSpineDBEditor if any.
         Also, if the same urls are open in an existing SpineDBEditor, just raises that one
         instead of creating another.
 
         Args:
             db_url_codenames (dict): mapping url to codename
+            reuse_existing_editor (bool): if True and the same URL is already open, just raise the existing window
         """
-        multi_db_editor = next(self.get_all_multi_spine_db_editors(), None)
+        multi_db_editor = next(self.get_all_multi_spine_db_editors(), None) if reuse_existing_editor else None
         if multi_db_editor is None:
             multi_db_editor = MultiSpineDBEditor(self, db_url_codenames)
             if multi_db_editor.tab_load_success:  # don't open an editor if tabs were not loaded successfully

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -49,7 +49,6 @@ from ..helpers import (
     open_url,
     is_valid_conda_executable,
 )
-from spine_items.tool.tool_specifications import PythonTool, JuliaTool
 
 
 class SettingsWidgetBase(QWidget):
@@ -751,10 +750,10 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         n = 0
         for item in project.get_items():
             if item.item_type() == "Tool" and item.specification() is not None:
-                if isinstance(item.specification(), PythonTool) and _type == "python":
+                if type(item.specification()).__name__ == "PythonTool" and _type == "python":
                     item.specification().set_execution_settings(use_jupyter_console, exe_path, kernel, env)
                     n += 1
-                elif isinstance(item.specification(), JuliaTool) and _type == "julia":
+                elif type(item.specification()).__name__ == "JuliaTool" and _type == "julia":
                     item.specification().set_execution_settings(use_jupyter_console, exe_path, julia_project, kernel)
                     n += 1
         if n == 0:

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -293,18 +293,18 @@ class TestOpenDBEditor(unittest.TestCase):
     def test_open_db_editor(self):
         editors = list(self._db_mngr.get_all_multi_spine_db_editors())
         self.assertFalse(editors)
-        self._db_mngr.open_db_editor({self._db_url: "test"})
+        self._db_mngr.open_db_editor({self._db_url: "test"}, reuse_existing_editor=True)
         editors = list(self._db_mngr.get_all_multi_spine_db_editors())
         self.assertEqual(len(editors), 1)
-        self._db_mngr.open_db_editor({self._db_url: "test"})
+        self._db_mngr.open_db_editor({self._db_url: "test"}, reuse_existing_editor=True)
         editors = list(self._db_mngr.get_all_multi_spine_db_editors())
         self.assertEqual(len(editors), 1)
-        self._db_mngr.open_db_editor({self._db_url: "not_the_same"})
+        self._db_mngr.open_db_editor({self._db_url: "not_the_same"}, reuse_existing_editor=True)
         self.assertEqual(len(editors), 1)
         editor = editors[0]
         self.assertEqual(editor.tab_widget.count(), 1)
         # Finally try to open the first tab again
-        self._db_mngr.open_db_editor({self._db_url: "test"})
+        self._db_mngr.open_db_editor({self._db_url: "test"}, reuse_existing_editor=True)
         editors = list(self._db_mngr.get_all_multi_spine_db_editors())
         editor = editors[0]
         self.assertEqual(editor.tab_widget.count(), 1)


### PR DESCRIPTION
`settings_widget.py` was importing spine_items which introduced a circular dependency when Database editor was opened without Toolbox.

Also, `SpineDBManager.open_db_editor()` now accepts a new parameter that allows opening the db URL in new window. This simplifies some code in Spine-Items.

No related issue

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
