### PR TITLE
Remove the "broadcasting" mechanism of Python/Julia from Settings window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - New context menu action (Select superclass) for entity class items in the entity tree.
-- Added buttons to Settings->Tools widget and to Tool Specification Editor for restoring default 
-  (defined in Settings->Tools) execution settings.
 - Added Tool Specification type (Python, Gams, etc.) icons on Design View.
 - There is now a new filter type, Alternative filter available in Link properties.
   Unlike scenario filters, the execution is not parallelized.
@@ -34,8 +32,8 @@ Many parts of the Spine data structure have been redesigned.
 
 #### Miscellaneous changes
 
-- Julia execution settings are now Tool specification settings instead of global application settings. You can 
-  select a different Julia executable & project or Julia kernel for each Tool spec.
+- You can now select a different Julia executable & project or Julia kernel for each Tool spec.
+  This overrides the global setting from Toolbox Settings.
 - Headless mode now supports remote execution (see 'python -m spinetoolbox --help')
 
 ### Deprecated

--- a/spinetoolbox/project_item/project_item.py
+++ b/spinetoolbox/project_item/project_item.py
@@ -88,6 +88,10 @@ class ProjectItem(LogMixin, MetaObject):
         raise NotImplementedError()
 
     @property
+    def project(self):
+        return self._project
+
+    @property
     def logger(self):
         return self._logger
 

--- a/spinetoolbox/ui/settings.py
+++ b/spinetoolbox/ui/settings.py
@@ -479,23 +479,6 @@ class Ui_SettingsForm(object):
 
         self.verticalLayout_10.addLayout(self.horizontalLayout_14)
 
-        self.horizontalLayout = QHBoxLayout()
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
-
-        self.horizontalLayout.addItem(self.horizontalSpacer_2)
-
-        self.toolButton_set_julia_defaults = QToolButton(self.groupBox_julia)
-        self.toolButton_set_julia_defaults.setObjectName(u"toolButton_set_julia_defaults")
-        icon6 = QIcon()
-        icon6.addFile(u":/icons/share.svg", QSize(), QIcon.Normal, QIcon.Off)
-        self.toolButton_set_julia_defaults.setIcon(icon6)
-
-        self.horizontalLayout.addWidget(self.toolButton_set_julia_defaults)
-
-
-        self.verticalLayout_10.addLayout(self.horizontalLayout)
-
         self.line = QFrame(self.groupBox_julia)
         self.line.setObjectName(u"line")
         self.line.setFrameShape(QFrame.HLine)
@@ -603,21 +586,6 @@ class Ui_SettingsForm(object):
 
 
         self.verticalLayout_16.addLayout(self.horizontalLayout_5)
-
-        self.horizontalLayout_3 = QHBoxLayout()
-        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
-
-        self.horizontalLayout_3.addItem(self.horizontalSpacer_3)
-
-        self.toolButton_set_python_defaults = QToolButton(self.groupBox_python)
-        self.toolButton_set_python_defaults.setObjectName(u"toolButton_set_python_defaults")
-        self.toolButton_set_python_defaults.setIcon(icon6)
-
-        self.horizontalLayout_3.addWidget(self.toolButton_set_python_defaults)
-
-
-        self.verticalLayout_16.addLayout(self.horizontalLayout_3)
 
 
         self.verticalLayout_13.addWidget(self.groupBox_python)
@@ -1038,8 +1006,7 @@ class Ui_SettingsForm(object):
         QWidget.setTabOrder(self.lineEdit_julia_project_path, self.toolButton_browse_julia_project)
         QWidget.setTabOrder(self.toolButton_browse_julia_project, self.comboBox_julia_kernel)
         QWidget.setTabOrder(self.comboBox_julia_kernel, self.pushButton_make_julia_kernel)
-        QWidget.setTabOrder(self.pushButton_make_julia_kernel, self.toolButton_set_julia_defaults)
-        QWidget.setTabOrder(self.toolButton_set_julia_defaults, self.pushButton_install_julia)
+        QWidget.setTabOrder(self.pushButton_make_julia_kernel, self.pushButton_install_julia)
         QWidget.setTabOrder(self.pushButton_install_julia, self.pushButton_add_up_spine_opt)
         QWidget.setTabOrder(self.pushButton_add_up_spine_opt, self.radioButton_use_python_basic_console)
         QWidget.setTabOrder(self.radioButton_use_python_basic_console, self.radioButton_use_python_jupyter_console)
@@ -1047,8 +1014,7 @@ class Ui_SettingsForm(object):
         QWidget.setTabOrder(self.lineEdit_python_path, self.toolButton_browse_python)
         QWidget.setTabOrder(self.toolButton_browse_python, self.comboBox_python_kernel)
         QWidget.setTabOrder(self.comboBox_python_kernel, self.pushButton_make_python_kernel)
-        QWidget.setTabOrder(self.pushButton_make_python_kernel, self.toolButton_set_python_defaults)
-        QWidget.setTabOrder(self.toolButton_set_python_defaults, self.lineEdit_conda_path)
+        QWidget.setTabOrder(self.pushButton_make_python_kernel, self.lineEdit_conda_path)
         QWidget.setTabOrder(self.lineEdit_conda_path, self.toolButton_browse_conda)
         QWidget.setTabOrder(self.toolButton_browse_conda, self.checkBox_commit_at_exit)
         QWidget.setTabOrder(self.checkBox_commit_at_exit, self.checkBox_db_editor_show_undo)
@@ -1085,7 +1051,7 @@ class Ui_SettingsForm(object):
         self.listWidget.currentRowChanged.connect(self.stackedWidget.setCurrentIndex)
 
         self.listWidget.setCurrentRow(-1)
-        self.stackedWidget.setCurrentIndex(0)
+        self.stackedWidget.setCurrentIndex(1)
 
 
         QMetaObject.connectSlotsByName(SettingsForm)
@@ -1211,9 +1177,6 @@ class Ui_SettingsForm(object):
 #endif // QT_CONFIG(tooltip)
         self.pushButton_make_julia_kernel.setText(QCoreApplication.translate("SettingsForm", u"Make Julia Kernel", None))
 #if QT_CONFIG(tooltip)
-        self.toolButton_set_julia_defaults.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Set Julia Tool execution settings in the current project to defaults</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(tooltip)
         self.pushButton_install_julia.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Installs the latest Julia on your system using Python's <span style=\" font-weight:700;\">jill</span> package</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.pushButton_install_julia.setText(QCoreApplication.translate("SettingsForm", u"Install Julia", None))
@@ -1247,9 +1210,6 @@ class Ui_SettingsForm(object):
         self.pushButton_make_python_kernel.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Creates a Python kernel for selected Python interpreter if it does not exist using the <span style=\" font-weight:700;\">ipykernel </span>package. Selects a Python kernel matching the selected Python interpreter if it already exists. </p><p>You can also create Python kernels manually using the <span style=\" font-weight:700;\">ipykernel</span> package.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.pushButton_make_python_kernel.setText(QCoreApplication.translate("SettingsForm", u"Make Python Kernel", None))
-#if QT_CONFIG(tooltip)
-        self.toolButton_set_python_defaults.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Set Python Tool execution settings in the current project to defaults</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
         self.groupBox_2.setTitle(QCoreApplication.translate("SettingsForm", u"Conda", None))
 #if QT_CONFIG(tooltip)
         self.lineEdit_conda_path.setToolTip(QCoreApplication.translate("SettingsForm", u"<html><head/><body><p>Select Miniconda executable for running Tool specifications in a Conda environment.</p><p>If you started Spine Toolbox in Miniconda, the <span style=\" font-weight:600;\">Conda executable is set up automatically</span>.</p><p>If not on Miniconda, please select <span style=\" font-weight:600;\">&lt;base_env&gt;\\scripts\\conda.exe</span> (on Win10), where <span style=\" font-weight:600;\">&lt;base_env&gt;</span> is the root directory of your Miniconda installation (i.e. base environment location).</p></body></html>", None))

--- a/spinetoolbox/ui/settings.ui
+++ b/spinetoolbox/ui/settings.ui
@@ -183,7 +183,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="General">
        <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -826,34 +826,6 @@
             </layout>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QToolButton" name="toolButton_set_julia_defaults">
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set Julia Tool execution settings in the current project to defaults&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="icon">
-                <iconset resource="resources/resources_icons.qrc">
-                 <normaloff>:/icons/share.svg</normaloff>:/icons/share.svg</iconset>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
             <widget class="Line" name="line">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
@@ -1036,34 +1008,6 @@
                 </layout>
                </item>
               </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <item>
-              <spacer name="horizontalSpacer_3">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QToolButton" name="toolButton_set_python_defaults">
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set Python Tool execution settings in the current project to defaults&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="icon">
-                <iconset resource="resources/resources_icons.qrc">
-                 <normaloff>:/icons/share.svg</normaloff>:/icons/share.svg</iconset>
-               </property>
-              </widget>
              </item>
             </layout>
            </item>
@@ -1746,7 +1690,6 @@
   <tabstop>toolButton_browse_julia_project</tabstop>
   <tabstop>comboBox_julia_kernel</tabstop>
   <tabstop>pushButton_make_julia_kernel</tabstop>
-  <tabstop>toolButton_set_julia_defaults</tabstop>
   <tabstop>pushButton_install_julia</tabstop>
   <tabstop>pushButton_add_up_spine_opt</tabstop>
   <tabstop>radioButton_use_python_basic_console</tabstop>
@@ -1755,7 +1698,6 @@
   <tabstop>toolButton_browse_python</tabstop>
   <tabstop>comboBox_python_kernel</tabstop>
   <tabstop>pushButton_make_python_kernel</tabstop>
-  <tabstop>toolButton_set_python_defaults</tabstop>
   <tabstop>lineEdit_conda_path</tabstop>
   <tabstop>toolButton_browse_conda</tabstop>
   <tabstop>checkBox_commit_at_exit</tabstop>

--- a/spinetoolbox/widgets/install_julia_wizard.py
+++ b/spinetoolbox/widgets/install_julia_wizard.py
@@ -35,7 +35,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Signal, Slot, Qt
 from PySide6.QtGui import QCursor
-from spine_engine.utils.helpers import resolve_python_interpreter
+from spine_engine.utils.helpers import resolve_current_python_interpreter
 from ..execution_managers import QProcessExecutionManager
 from ..config import APPLICATION_PATH
 from .custom_qwidgets import HyperTextLabel, QWizardProcessPage, LabelWithCopyButton
@@ -211,7 +211,7 @@ class InstallJuliaPage(QWizardProcessPage):
         # 1. sys.executable when not frozen
         # 2. PATH python if frozen (This fails if no jill installed)
         # 3. If no PATH python, uses embedded python <install_dir>/tools/python.exe
-        python = resolve_python_interpreter("")
+        python = resolve_current_python_interpreter()
         self._exec_mngr = QProcessExecutionManager(self, python, args, semisilent=True)
         self.completeChanged.emit()
         self._exec_mngr.execution_finished.connect(self._handle_julia_install_finished)

--- a/spinetoolbox/widgets/kernel_editor.py
+++ b/spinetoolbox/widgets/kernel_editor.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import QDialog, QMessageBox, QDialogButtonBox, QWidget
 from PySide6.QtCore import Slot, Qt, QTimer
 from PySide6.QtGui import QGuiApplication, QIcon
 from jupyter_client.kernelspec import find_kernel_specs
-from spine_engine.utils.helpers import resolve_python_interpreter, resolve_julia_executable
+from spine_engine.utils.helpers import resolve_current_python_interpreter, resolve_julia_executable
 from spinetoolbox.execution_managers import QProcessExecutionManager
 from spinetoolbox.helpers import (
     busy_effect,
@@ -566,16 +566,13 @@ class MiniPythonKernelEditor(KernelEditorBase):
     the constructor, then calling ``make_kernel`` starts the process.
     """
 
-    """A reduced version of KernelEditor that basically just takes care of installing one Python kernel.
-    The python exe is passed in the constructor, then calling ``make_kernel`` starts the process.
-    """
-
     def __init__(self, parent, python_exe):
         super().__init__(parent, "python")
         self.ui.label_message.setText("Finalizing Python configuration... ")
         self.ui.stackedWidget.setCurrentIndex(0)
         self.setWindowTitle("Python Kernel Specification Creator")
-        python_exe = resolve_python_interpreter(python_exe)
+        if not python_exe:
+            python_exe = resolve_current_python_interpreter()
         self.ui.lineEdit_python_interpreter.setText(python_exe)
         self.python_exe = python_exe
         self._kernel_name = "python_kernel"  # Fallback name

--- a/spinetoolbox/widgets/kernel_editor.py
+++ b/spinetoolbox/widgets/kernel_editor.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import QDialog, QMessageBox, QDialogButtonBox, QWidget
 from PySide6.QtCore import Slot, Qt, QTimer
 from PySide6.QtGui import QGuiApplication, QIcon
 from jupyter_client.kernelspec import find_kernel_specs
-from spine_engine.utils.helpers import resolve_current_python_interpreter, resolve_julia_executable
+from spine_engine.utils.helpers import resolve_current_python_interpreter, resolve_default_julia_executable
 from spinetoolbox.execution_managers import QProcessExecutionManager
 from spinetoolbox.helpers import (
     busy_effect,
@@ -624,7 +624,8 @@ class MiniJuliaKernelEditor(KernelEditorBase):
         self.ui.label_message.setText("Finalizing Julia configuration... ")
         self.ui.stackedWidget.setCurrentIndex(1)
         self.setWindowTitle("Julia Kernel Specification Creator")
-        julia_exe = resolve_julia_executable(julia_exe)
+        if not julia_exe:
+            julia_exe = resolve_default_julia_executable()
         self.ui.lineEdit_julia_executable.setText(julia_exe)
         self.ui.lineEdit_julia_project.setText(julia_project)
         self._kernel_name = "julia"  # This is a prefix, IJulia decides the final kernel name

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -17,7 +17,7 @@ from PySide6.QtCore import Slot, Qt, QSize, QSettings, QPoint, QEvent
 from PySide6.QtGui import QPixmap, QIcon, QStandardItemModel, QStandardItem
 from spine_engine.utils.helpers import (
     resolve_current_python_interpreter,
-    resolve_julia_executable,
+    resolve_default_julia_executable,
     resolve_gams_executable,
     resolve_conda_executable,
     get_julia_env,
@@ -521,7 +521,8 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         If a kernel using the selected Julia executable and project already exists, sets that kernel
         selected in the comboBox."""
         use_julia_jupyter_console, julia_exe, julia_project, julia_kernel = self._get_julia_settings()
-        julia_exe = resolve_julia_executable(julia_exe)
+        if not julia_exe:
+            julia_exe = resolve_default_julia_executable()
         julia_kernel = _get_kernel_name_by_exe(julia_exe, self._julia_kernel_model)
         if julia_kernel:  # Kernel with matching executable found
             match = _selected_project_matches_kernel_project(julia_kernel, julia_project, self._julia_kernel_model)
@@ -762,7 +763,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
             self.ui.radioButton_use_julia_jupyter_console.setChecked(True)
         else:
             self.ui.radioButton_use_julia_basic_console.setChecked(True)
-        self.ui.lineEdit_julia_path.setPlaceholderText(resolve_julia_executable(""))
+        self.ui.lineEdit_julia_path.setPlaceholderText(resolve_default_julia_executable())
         self.ui.lineEdit_julia_path.setText(julia_path)
         self.ui.lineEdit_julia_project_path.setText(julia_project_path)
         if use_python_jupyter_console == 2:

--- a/spinetoolbox/widgets/settings_widget.py
+++ b/spinetoolbox/widgets/settings_widget.py
@@ -9,17 +9,14 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Widget for controlling user settings.
-"""
+""" Widget for controlling user settings. """
 
 import os
 from PySide6.QtWidgets import QWidget, QFileDialog, QColorDialog, QMenu, QMessageBox
 from PySide6.QtCore import Slot, Qt, QSize, QSettings, QPoint, QEvent
 from PySide6.QtGui import QPixmap, QIcon, QStandardItemModel, QStandardItem
 from spine_engine.utils.helpers import (
-    resolve_python_interpreter,
+    resolve_current_python_interpreter,
     resolve_julia_executable,
     resolve_gams_executable,
     resolve_conda_executable,
@@ -348,8 +345,6 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         self.ui.toolButton_browse_python.clicked.connect(self.browse_python_button_clicked)
         self.ui.toolButton_browse_conda.clicked.connect(self.browse_conda_button_clicked)
         self.ui.toolButton_pick_secfolder.clicked.connect(self.browse_certificate_directory_clicked)
-        self.ui.toolButton_set_julia_defaults.clicked.connect(self._set_default_julia_execution_settings)
-        self.ui.toolButton_set_python_defaults.clicked.connect(self._set_default_python_execution_settings)
         self.ui.pushButton_make_python_kernel.clicked.connect(self.make_python_kernel)
         self.ui.pushButton_make_julia_kernel.clicked.connect(self.make_julia_kernel)
         self.ui.comboBox_python_kernel.customContextMenuRequested.connect(
@@ -507,7 +502,8 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         """Makes a Python kernel for Jupyter Console based on selected Python interpreter.
         If a kernel using this Python interpreter already exists, sets that kernel selected in the comboBox."""
         python_exe = self.ui.lineEdit_python_path.text().strip()
-        python_exe = resolve_python_interpreter(python_exe)
+        if not python_exe:
+            python_exe = resolve_current_python_interpreter()
         python_kernel = _get_kernel_name_by_exe(python_exe, self._python_kernel_model)
         if not python_kernel:
             mpke = MiniPythonKernelEditor(self, python_exe)
@@ -688,80 +684,6 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
     def _update_properties_widget(self, _checked=False):
         self._toolbox.ui.tabWidget_item_properties.update()
 
-    def _set_default_julia_execution_settings(self, _checked=False):
-        self._set_default_execution_settings("julia")
-
-    def _set_default_python_execution_settings(self, _checked=False):
-        self._set_default_execution_settings("python")
-
-    def _set_default_execution_settings(self, _type):
-        """Sets the default execution settings to all Julia or Python Tools in the currently opened project.
-
-        Args:
-            _type (str): 'python' sets execution settings for Python Tools, 'julia' for Julia Tools.
-        """
-        project = self._toolbox.project()
-        if not project:
-            Notification(self, "Open a project to use this feature").show()
-            return
-        if _type == "python":
-            use_jupyter_console, exe_path, kernel, env = self._get_python_settings()
-        else:
-            use_jupyter_console, exe_path, julia_project, kernel = self._get_julia_settings()
-        use_jupyter_console = True if use_jupyter_console == "2" else False
-        if use_jupyter_console:
-            if not kernel:
-                Notification(self, f"{_type.capitalize()} kernel missing").show()
-                return
-        if _type == "python":
-            exe_path = resolve_python_interpreter(exe_path)
-        else:
-            exe_path = resolve_julia_executable(exe_path)
-        if not exe_path:
-            Notification(self, f"{_type.capitalize()} executable missing").show()
-            return
-        msg = (
-            f"You are about to set all {_type.capitalize()} Tool's execution settings in "
-            f"the current project to defaults. This operation is <b>irreversible</b> because "
-            f"the project will be saved afterwards. <br><br>Do you want to continue?"
-        )
-        box = QMessageBox(
-            QMessageBox.Icon.Question,
-            f"Set {_type.capitalize()} Tools to default execution settings?",
-            msg,
-            buttons=QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
-            parent=self,
-        )
-        box.button(QMessageBox.StandardButton.Ok).setText("Do it!")
-        box.setWindowIcon(QIcon(":/symbols/app.ico"))
-        answer = box.exec()
-        if answer != QMessageBox.StandardButton.Ok:
-            return
-        # Unselect items on Design View because Tool properties still shows the old exec. settings after this operation
-        self._toolbox.ui.graphicsView.scene().clearSelection()
-        # Close all Julia or Python Tool Spec editor tabs
-        for editor in self._toolbox.get_all_multi_tab_spec_editors(item_type="Tool"):
-            n = editor.tab_widget.count()
-            for tab_index in reversed(range(n)):
-                tab = editor.tab_widget.widget(tab_index)
-                tooltype = tab._ui.comboBox_tooltype.currentText()
-                if tooltype.lower() == _type:
-                    editor._close_tab(tab_index)
-        n = 0
-        for item in project.get_items():
-            if item.item_type() == "Tool" and item.specification() is not None:
-                if type(item.specification()).__name__ == "PythonTool" and _type == "python":
-                    item.specification().set_execution_settings(use_jupyter_console, exe_path, kernel, env)
-                    n += 1
-                elif type(item.specification()).__name__ == "JuliaTool" and _type == "julia":
-                    item.specification().set_execution_settings(use_jupyter_console, exe_path, julia_project, kernel)
-                    n += 1
-        if n == 0:
-            Notification(self, f"Project does not have any Tools using {_type.capitalize()} Tool specifications").show()
-        else:
-            Notification(self, f"Project saved!\n{n} {_type.capitalize()} Tools updated").show()
-            project.save()
-
     def read_settings(self):
         """Read saved settings from app QSettings instance and update UI to display them."""
         # checkBox check state 0: unchecked, 1: partially checked, 2: checked
@@ -847,7 +769,7 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
             self.ui.radioButton_use_python_jupyter_console.setChecked(True)
         else:
             self.ui.radioButton_use_python_basic_console.setChecked(True)
-        self.ui.lineEdit_python_path.setPlaceholderText(resolve_python_interpreter(""))
+        self.ui.lineEdit_python_path.setPlaceholderText(resolve_current_python_interpreter())
         self.ui.lineEdit_python_path.setText(python_path)
         conda_placeholder_txt = resolve_conda_executable("")
         if conda_placeholder_txt:
@@ -1073,21 +995,6 @@ class SettingsWidget(SpineDBEditorSettingsMixin, SettingsWidgetBase):
         if self.ui.comboBox_julia_kernel.currentIndex() != 0:
             julia_kernel = self.ui.comboBox_julia_kernel.currentText()
         return use_julia_jupyter_console, julia_exe, julia_project, julia_kernel
-
-    def _get_python_settings(self):
-        """Returns current Python execution settings in Settings->Tools widget."""
-        use_python_jupyter_console = "2" if self.ui.radioButton_use_python_jupyter_console.isChecked() else "0"
-        python_exe = self.ui.lineEdit_python_path.text().strip()
-        python_kernel = ""
-        env = ""
-        row = self.ui.comboBox_python_kernel.currentIndex()
-        if row != 0:
-            python_kernel = self.ui.comboBox_python_kernel.currentText()
-            item = self._python_kernel_model.item(row)
-            is_conda = item.data()["is_conda"]
-            if is_conda:
-                env = "conda"
-        return use_python_jupyter_console, python_exe, python_kernel, env
 
     def set_work_directory(self, new_work_dir):
         """Sets new work directory.

--- a/tests/widgets/test_kernel_editor.py
+++ b/tests/widgets/test_kernel_editor.py
@@ -22,7 +22,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 import venv
 from PySide6.QtWidgets import QApplication, QMessageBox, QWidget
-from spine_engine.utils.helpers import resolve_julia_executable
+from spine_engine.utils.helpers import resolve_default_julia_executable
 from spinetoolbox.widgets.kernel_editor import KernelEditorBase
 
 
@@ -80,7 +80,7 @@ class TestKernelEditorBase(unittest.TestCase):
     def test_make_julia_kernel(self):
         """Makes a new Julia kernel if Julia is in PATH and the base project (@.) has
         IJulia installed. Test Julia kernel is removed in the end if available."""
-        julia_exec = resolve_julia_executable("")
+        julia_exec = resolve_default_julia_executable()
         if not julia_exec:
             self.skipTest("Julia not found in PATH.")
         kernel_name = "spinetoolbox_test_make_julia_kernel"


### PR DESCRIPTION
We now treat the Python interpreter/Julia executable set in application settings as the global default so the "broadcasting" buttons in Settings widget are not needed anymore.

Resolves #2446

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
