### PR TITLE
Disable Edit menu when project is not open

### DIFF
--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -1728,13 +1728,7 @@ class ToolboxUI(QMainWindow):
         context menu, and in Design View context menus just before the
         menus are shown to user."""
         if not self.project():
-            self.ui.actionCopy.setEnabled(False)
-            self.ui.actionPaste.setEnabled(False)
-            self.ui.actionPasteAndDuplicateFiles.setEnabled(False)
-            self.ui.actionDuplicate.setEnabled(False)
-            self.ui.actionDuplicateAndDuplicateFiles.setEnabled(False)
-            self.ui.actionRemove.setEnabled(False)
-            self.ui.actionRemove_all.setEnabled(False)
+            self.disable_edit_actions()
             return
         clipboard = QApplication.clipboard()
         byte_data = clipboard.mimeData().data("application/vnd.spinetoolbox.ProjectItem")
@@ -1766,6 +1760,16 @@ class ToolboxUI(QMainWindow):
         self.ui.actionRemove.setEnabled(bool(selected_items))
         self.ui.actionRemove_all.setEnabled(has_items)
 
+    def disable_edit_actions(self):
+        """Disables edit actions."""
+        self.ui.actionCopy.setEnabled(False)
+        self.ui.actionPaste.setEnabled(False)
+        self.ui.actionPasteAndDuplicateFiles.setEnabled(False)
+        self.ui.actionDuplicate.setEnabled(False)
+        self.ui.actionDuplicateAndDuplicateFiles.setEnabled(False)
+        self.ui.actionRemove.setEnabled(False)
+        self.ui.actionRemove_all.setEnabled(False)
+
     @Slot()
     def enable_edit_actions(self):
         """Enables project item edit actions after a QMenu has been shown.
@@ -1776,6 +1780,7 @@ class ToolboxUI(QMainWindow):
         self.ui.actionPasteAndDuplicateFiles.setEnabled(True)
         self.ui.actionDuplicate.setEnabled(True)
         self.ui.actionDuplicateAndDuplicateFiles.setEnabled(True)
+        self.ui.actionRemove.setEnabled(True)
 
     def _tasks_before_exit(self):
         """Returns a list of tasks to perform before exiting the application.

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -737,7 +737,7 @@ class ToolboxUI(QMainWindow):
         self._project.tear_down()
         self._project = None
         self._disable_project_actions()
-        self.undo_stack.setClean()
+        self.undo_stack.clear()
         self.update_window_title()
         if clear_event_log:
             self.ui.textBrowser_eventlog.clear()
@@ -1727,6 +1727,15 @@ class ToolboxUI(QMainWindow):
         remove and rename actions in File-Edit menu, project tree view
         context menu, and in Design View context menus just before the
         menus are shown to user."""
+        if not self.project():
+            self.ui.actionCopy.setEnabled(False)
+            self.ui.actionPaste.setEnabled(False)
+            self.ui.actionPasteAndDuplicateFiles.setEnabled(False)
+            self.ui.actionDuplicate.setEnabled(False)
+            self.ui.actionDuplicateAndDuplicateFiles.setEnabled(False)
+            self.ui.actionRemove.setEnabled(False)
+            self.ui.actionRemove_all.setEnabled(False)
+            return
         clipboard = QApplication.clipboard()
         byte_data = clipboard.mimeData().data("application/vnd.spinetoolbox.ProjectItem")
         can_paste = not byte_data.isNull()

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -233,7 +233,6 @@ class TestToolboxUI(unittest.TestCase):
             self.toolbox.show_project_or_item_context_menu(QPoint(0, 0), dc)
 
     def test_refresh_edit_action_states(self):
-        QApplication.clipboard().clear()
         self.toolbox.refresh_edit_action_states()
         # No project
         self.assertFalse(self.toolbox.ui.actionCopy.isEnabled())
@@ -257,7 +256,9 @@ class TestToolboxUI(unittest.TestCase):
         dc = self.toolbox.project().get_item("DC")
         icon = dc.get_icon()
         icon.setSelected(True)
-        self.toolbox.refresh_edit_action_states()
+        with mock.patch("spinetoolbox.ui_main.QApplication.clipboard") as mock_clipboard:
+            self.toolbox.refresh_edit_action_states()
+            mock_clipboard.assert_called()
         self.assertTrue(self.toolbox.ui.actionCopy.isEnabled())
         self.assertFalse(self.toolbox.ui.actionPaste.isEnabled())
         self.assertFalse(self.toolbox.ui.actionPasteAndDuplicateFiles.isEnabled())

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -233,6 +233,7 @@ class TestToolboxUI(unittest.TestCase):
             self.toolbox.show_project_or_item_context_menu(QPoint(0, 0), dc)
 
     def test_refresh_edit_action_states(self):
+        QApplication.clipboard().clear()
         self.toolbox.refresh_edit_action_states()
         # No project
         self.assertFalse(self.toolbox.ui.actionCopy.isEnabled())

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -232,6 +232,48 @@ class TestToolboxUI(unittest.TestCase):
             dc = self.toolbox.project().get_item("DC")
             self.toolbox.show_project_or_item_context_menu(QPoint(0, 0), dc)
 
+    def test_refresh_edit_action_states(self):
+        self.toolbox.refresh_edit_action_states()
+        # No project
+        self.assertFalse(self.toolbox.ui.actionCopy.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionPaste.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionPasteAndDuplicateFiles.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionDuplicate.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionDuplicateAndDuplicateFiles.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionRemove.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionRemove_all.isEnabled())
+        # Make project
+        self._temp_dir = TemporaryDirectory()
+        with mock.patch("spinetoolbox.ui_main.QSettings.setValue") as mock_set_value, mock.patch(
+            "spinetoolbox.ui_main.QSettings.sync"
+        ) as mock_sync, mock.patch("PySide6.QtWidgets.QFileDialog.getExistingDirectory") as mock_dir_getter:
+            mock_dir_getter.return_value = self._temp_dir.name
+            self.toolbox.new_project()
+            mock_set_value.assert_called()
+            mock_sync.assert_called()
+            mock_dir_getter.assert_called()
+        add_dc(self.toolbox.project(), self.toolbox.item_factories, "DC")
+        dc = self.toolbox.project().get_item("DC")
+        icon = dc.get_icon()
+        icon.setSelected(True)
+        self.toolbox.refresh_edit_action_states()
+        self.assertTrue(self.toolbox.ui.actionCopy.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionPaste.isEnabled())
+        self.assertFalse(self.toolbox.ui.actionPasteAndDuplicateFiles.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionDuplicate.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionDuplicateAndDuplicateFiles.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionRemove.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionRemove_all.isEnabled())
+        # Cover enable_edit_actions()
+        self.toolbox.enable_edit_actions()
+        self.assertTrue(self.toolbox.ui.actionCopy.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionPaste.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionPasteAndDuplicateFiles.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionDuplicate.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionDuplicateAndDuplicateFiles.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionRemove.isEnabled())
+        self.assertTrue(self.toolbox.ui.actionRemove_all.isEnabled())
+
     def test_selection_in_design_view_1(self):
         """Test item selection in Design View. Simulates mouse click on a Data Connection item.
         Test a single item selection.


### PR DESCRIPTION
Fixes #2615 and #1785

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
