### PR TITLE
Make line edits work more naturally, fix undo/redo after item/connection removal

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -50,6 +50,7 @@ from PySide6.QtGui import (
     QColor,
     QFont,
     QPainter,
+    QUndoCommand,
 )
 from spine_engine.utils.serialization import deserialize_path
 from spinedb_api.spine_io.gdx_utils import find_gams_directory
@@ -1622,3 +1623,21 @@ def remove_first(lst, items):
             break
         except ValueError:
             pass
+
+
+class SealCommand(QUndoCommand):
+    """A 'meta' command that does not store undo data but can be used in mergeWith methods of other commands."""
+
+    def __init__(self, command_id=1):
+        """
+        Args:
+            command_id (int): command id
+        """
+        super().__init__("")
+        self._id = command_id
+
+    def redo(self):
+        self.setObsolete(True)
+
+    def id(self):
+        return self._id

--- a/spinetoolbox/metaobject.py
+++ b/spinetoolbox/metaobject.py
@@ -16,9 +16,10 @@ from spine_engine.utils.helpers import shorten
 
 
 class MetaObject(QObject):
-    def __init__(self, name, description):
-        """Class for an object which has a name, type, and some description.
+    """Class for an object which has a name, type, and some description."""
 
+    def __init__(self, name, description):
+        """
         Args:
             name (str): Object name
             description (str): Object description

--- a/spinetoolbox/project_commands.py
+++ b/spinetoolbox/project_commands.py
@@ -30,31 +30,37 @@ class SpineToolboxCommand(QUndoCommand):
 
 
 class SetItemSpecificationCommand(SpineToolboxCommand):
-    def __init__(self, item, spec, old_spec):
-        """Command to set the specification for a Tool.
+    """Command to set the specification for a project item."""
 
+    def __init__(self, item_name, spec, old_spec, project):
+        """
         Args:
-            item (ProjectItem): the Item
+            item_name (str): item's name
             spec (ProjectItemSpecification): the new spec
             old_spec (ProjectItemSpecification): the old spec
+            project (SpineToolboxProject): project
         """
         super().__init__()
-        self.item = item
-        self.spec = spec
-        self.old_spec = old_spec
-        self.setText(f"set specification of {item.name}")
+        self._item_name = item_name
+        self._spec = spec
+        self._old_spec = old_spec
+        self._project = project
+        self.setText(f"set specification of {item_name}")
 
     def redo(self):
-        self.item.do_set_specification(self.spec)
+        item = self._project.get_item(self._item_name)
+        item.do_set_specification(self._spec)
 
     def undo(self):
-        self.item.do_set_specification(self.old_spec)
+        item = self._project.get_item(self._item_name)
+        item.do_set_specification(self._old_spec)
 
 
 class MoveIconCommand(SpineToolboxCommand):
-    def __init__(self, icon, project):
-        """Command to move icons in the Design view.
+    """Command to move icons in the Design view."""
 
+    def __init__(self, icon, project):
+        """
         Args:
             icon (ProjectItemIcon): the icon
             project (SpineToolboxProject): project
@@ -87,9 +93,10 @@ class MoveIconCommand(SpineToolboxCommand):
 
 
 class SetProjectDescriptionCommand(SpineToolboxCommand):
-    def __init__(self, project, description):
-        """Command to set the project description.
+    """Command to set the project description."""
 
+    def __init__(self, project, description):
+        """
         Args:
             project (SpineToolboxProject): the project
             description (str): The new description
@@ -108,9 +115,10 @@ class SetProjectDescriptionCommand(SpineToolboxCommand):
 
 
 class AddProjectItemsCommand(SpineToolboxCommand):
-    def __init__(self, project, items_dict, item_factories, silent=True):
-        """Command to add items.
+    """Command to add items."""
 
+    def __init__(self, project, items_dict, item_factories, silent=True):
+        """
         Args:
             project (SpineToolboxProject): the project
             items_dict (dict): a mapping from item name to item dict
@@ -138,9 +146,10 @@ class AddProjectItemsCommand(SpineToolboxCommand):
 
 
 class RemoveAllProjectItemsCommand(SpineToolboxCommand):
-    def __init__(self, project, item_factories, delete_data=False):
-        """Command to remove all items from project.
+    """Command to remove all items from project."""
 
+    def __init__(self, project, item_factories, delete_data=False):
+        """
         Args:
             project (SpineToolboxProject): the project
             item_factories (dict): a mapping from item type to ProjectItemFactory
@@ -165,9 +174,10 @@ class RemoveAllProjectItemsCommand(SpineToolboxCommand):
 
 
 class RemoveProjectItemsCommand(SpineToolboxCommand):
-    def __init__(self, project, item_factories, item_names, delete_data=False):
-        """Command to remove items.
+    """Command to remove items."""
 
+    def __init__(self, project, item_factories, item_names, delete_data=False):
+        """
         Args:
             project (SpineToolboxProject): The project
             item_factories (dict): a mapping from item type to ProjectItemFactory
@@ -206,9 +216,10 @@ class RemoveProjectItemsCommand(SpineToolboxCommand):
 
 
 class RenameProjectItemCommand(SpineToolboxCommand):
-    def __init__(self, project, previous_name, new_name):
-        """Command to rename project items.
+    """Command to rename project items."""
 
+    def __init__(self, project, previous_name, new_name):
+        """
         Args:
             project (SpineToolboxProject): the project
             previous_name (str): item's previous name
@@ -235,9 +246,10 @@ class RenameProjectItemCommand(SpineToolboxCommand):
 
 
 class AddConnectionCommand(SpineToolboxCommand):
-    def __init__(self, project, source_name, source_position, destination_name, destination_position):
-        """Command to add connection between project items.
+    """Command to add connection between project items."""
 
+    def __init__(self, project, source_name, source_position, destination_name, destination_position):
+        """
         Args:
             project (SpineToolboxProject): project
             source_name (str): source item's name
@@ -280,9 +292,10 @@ class AddConnectionCommand(SpineToolboxCommand):
 
 
 class RemoveConnectionsCommand(SpineToolboxCommand):
-    def __init__(self, project, connections):
-        """Command to remove links.
+    """Command to remove links."""
 
+    def __init__(self, project, connections):
+        """
         Args:
             project (SpineToolboxProject): project
             connections (list of LoggingConnection): the connections
@@ -309,9 +322,10 @@ class RemoveConnectionsCommand(SpineToolboxCommand):
 
 
 class AddJumpCommand(SpineToolboxCommand):
-    def __init__(self, project, source_name, source_position, destination_name, destination_position):
-        """Command to add a jump between project items.
+    """Command to add a jump between project items."""
 
+    def __init__(self, project, source_name, source_position, destination_name, destination_position):
+        """
         Args:
             project (SpineToolboxProject): project
             source_name (str): source item's name
@@ -382,53 +396,66 @@ class RemoveJumpsCommand(SpineToolboxCommand):
 class SetJumpConditionCommand(SpineToolboxCommand):
     """Command to set jump condition."""
 
-    def __init__(self, jump_properties, jump, condition):
+    def __init__(self, project, jump, jump_properties, condition):
         """
         Args:
-            jump_properties (JumpPropertiesWidget): jump's properties tab
+            project (SpineToolboxProject): project
             jump (Jump): target jump
-            condition (str): jump condition
+            jump_properties (JumpPropertiesWidget): jump's properties tab
+            condition (dict): jump condition
         """
         super().__init__()
+        self._project = project
         self._jump_properties = jump_properties
-        self._jump = jump
+        self._jump_source = jump.source
+        self._jump_destination = jump.destination
         self._condition = condition
         self._previous_condition = jump.condition
-        self.setText("change loop condition")
+        self.setText(f"change loop condition for jump {jump.name}")
 
     def redo(self):
-        self._jump_properties.set_condition(self._jump, self._condition)
+        jump = self._project.find_jump(self._jump_source, self._jump_destination)
+        self._jump_properties.set_condition(jump, self._condition)
 
     def undo(self):
-        self._jump_properties.set_condition(self._jump, self._previous_condition)
+        jump = self._project.find_jump(self._jump_source, self._jump_destination)
+        self._jump_properties.set_condition(jump, self._previous_condition)
 
 
 class UpdateJumpCmdLineArgsCommand(SpineToolboxCommand):
-    def __init__(self, jump_properties, jump, cmd_line_args):
-        """Command to update Jump command line args.
+    """Command to update Jump command line args."""
 
+    def __init__(self, project, jump, jump_properties, cmd_line_args):
+        """
         Args:
+            project (SpineToolboxProject): project
+            jump (Jump): jump
             jump_properties (JumpPropertiesWidget): the item
             cmd_line_args (list): list of command line args
         """
         super().__init__()
+        self._project = project
         self._jump_properties = jump_properties
-        self._jump = jump
+        self._jump_source = jump.source
+        self._jump_destination = jump.destination
         self._redo_cmd_line_args = cmd_line_args
-        self._undo_cmd_line_args = self._jump.cmd_line_args
-        self.setText(f"change command line arguments of {jump.name}")
+        self._undo_cmd_line_args = jump.cmd_line_args
+        self.setText(f"change command line arguments of jump {jump.name}")
 
     def redo(self):
-        self._jump_properties.update_cmd_line_args(self._jump, self._redo_cmd_line_args)
+        jump = self._project.find_jump(self._jump_source, self._jump_destination)
+        self._jump_properties.update_cmd_line_args(jump, self._redo_cmd_line_args)
 
     def undo(self):
-        self._jump_properties.update_cmd_line_args(self._jump, self._undo_cmd_line_args)
+        jump = self._project.find_jump(self._jump_source, self._jump_destination)
+        self._jump_properties.update_cmd_line_args(jump, self._undo_cmd_line_args)
 
 
 class SetFiltersOnlineCommand(SpineToolboxCommand):
-    def __init__(self, project, connection, resource, filter_type, online):
-        """Command to toggle filter value.
+    """Command to toggle filter value."""
 
+    def __init__(self, project, connection, resource, filter_type, online):
+        """
         Args:
             project (SpineToolboxProject): project
             connection (Connection): connection
@@ -512,9 +539,10 @@ class SetConnectionFilterTypeEnabled(SpineToolboxCommand):
 
 
 class SetConnectionOptionsCommand(SpineToolboxCommand):
-    def __init__(self, project, connection, options):
-        """Command to set connection options.
+    """Command to set connection options."""
 
+    def __init__(self, project, connection, options):
+        """
         Args:
             project (SpineToolboxProject): project
             connection (LoggingConnection): project
@@ -539,9 +567,10 @@ class SetConnectionOptionsCommand(SpineToolboxCommand):
 
 
 class AddSpecificationCommand(SpineToolboxCommand):
-    def __init__(self, project, specification, save_to_disk):
-        """Command to add item specification to a project.
+    """Command to add item specification to a project."""
 
+    def __init__(self, project, specification, save_to_disk):
+        """
         Args:
             project (ToolboxUI): the toolbox
             specification (ProjectItemSpecification): the spec
@@ -566,9 +595,10 @@ class AddSpecificationCommand(SpineToolboxCommand):
 
 
 class ReplaceSpecificationCommand(SpineToolboxCommand):
-    def __init__(self, project, name, specification):
-        """Command to replace item specification in project.
+    """Command to replace item specification in project."""
 
+    def __init__(self, project, name, specification):
+        """
         Args:
             project (ToolboxUI): the toolbox
             name (str): the name of the spec to be replaced
@@ -595,9 +625,10 @@ class ReplaceSpecificationCommand(SpineToolboxCommand):
 
 
 class RemoveSpecificationCommand(SpineToolboxCommand):
-    def __init__(self, project, name):
-        """Command to remove specs from a project.
+    """Command to remove specs from a project."""
 
+    def __init__(self, project, name):
+        """
         Args:
             project (SpineToolboxProject): the project
             name (str): specification's name
@@ -616,9 +647,10 @@ class RemoveSpecificationCommand(SpineToolboxCommand):
 
 
 class SaveSpecificationAsCommand(SpineToolboxCommand):
-    def __init__(self, project, name, path):
-        """Command to remove item specs from a project.
+    """Command to remove item specs from a project."""
 
+    def __init__(self, project, name, path):
+        """
         Args:
             project (SpineToolboxProject): the project
             name (str): specification's name

--- a/spinetoolbox/project_item/project_item.py
+++ b/spinetoolbox/project_item/project_item.py
@@ -158,7 +158,9 @@ class ProjectItem(LogMixin, MetaObject):
         """Pushes a new SetItemSpecificationCommand to the toolbox' undo stack."""
         if specification == self._specification:
             return
-        self._toolbox.undo_stack.push(SetItemSpecificationCommand(self, specification, self.undo_specification()))
+        self._toolbox.undo_stack.push(
+            SetItemSpecificationCommand(self.name, specification, self.undo_specification(), self._project)
+        )
 
     def do_set_specification(self, specification):
         """Sets specification for this item. Removes specification if None given as argument.

--- a/spinetoolbox/widgets/jump_properties_widget.py
+++ b/spinetoolbox/widgets/jump_properties_widget.py
@@ -86,7 +86,7 @@ class JumpPropertiesWidget(PropertiesWidgetBase):
             return
         condition = self._make_condition_from_ui()
         if self._jump.condition != condition:
-            self._toolbox.undo_stack.push(SetJumpConditionCommand(self, self._jump, condition))
+            self._toolbox.undo_stack.push(SetJumpConditionCommand(self._toolbox.project(), self._jump, self, condition))
 
     @Slot(bool)
     def _show_tool_spec_form(self, _checked=False):
@@ -123,7 +123,9 @@ class JumpPropertiesWidget(PropertiesWidgetBase):
     @Slot(list)
     def _push_update_cmd_line_args_command(self, cmd_line_args):
         if self._jump.cmd_line_args != cmd_line_args:
-            self._toolbox.undo_stack.push(UpdateJumpCmdLineArgsCommand(self, self._jump, cmd_line_args))
+            self._toolbox.undo_stack.push(
+                UpdateJumpCmdLineArgsCommand(self._toolbox.project(), self._jump, self, cmd_line_args)
+            )
 
     @Slot(bool)
     def _remove_arg(self, _=False):

--- a/tests/project_item/test_specification_editor_window.py
+++ b/tests/project_item/test_specification_editor_window.py
@@ -104,8 +104,9 @@ class TestSpecificationEditorWindowBase(unittest.TestCase):
             mock_make_specification.return_value = specification
             mock_save.return_value = {}
             window = SpecificationEditorWindowBase(self._toolbox)
-            window._spec_toolbar._line_edit_name.setText("spec name")
-            window._spec_toolbar._line_edit_name.editingFinished.emit()
+            name_edit = window._spec_toolbar._line_edit_name
+            name_edit.setText("spec name")
+            name_edit.textEdited.emit(name_edit.text())
             window._spec_toolbar.save_action.trigger()
             mock_save.assert_called_once()
             window.deleteLater()
@@ -124,10 +125,12 @@ class TestSpecificationEditorWindowBase(unittest.TestCase):
             mock_save.return_value = {}
             project_item = _MockProjectItem("item name", "item description", 0.0, 0.0, self._toolbox.project())
             project_item._toolbox = self._toolbox
+            self._toolbox.project().add_item(project_item)
             window = SpecificationEditorWindowBase(self._toolbox, item=project_item)
             self.assertIs(window.item, project_item)
-            window._spec_toolbar._line_edit_name.setText("spec name")
-            window._spec_toolbar._line_edit_name.editingFinished.emit()
+            name_edit = window._spec_toolbar._line_edit_name
+            name_edit.setText("spec name")
+            name_edit.textEdited.emit(name_edit.text())
             window._spec_toolbar.save_action.trigger()
             self.assertIs(project_item.specification(), specification)
             window.deleteLater()
@@ -158,8 +161,9 @@ class TestSpecificationEditorWindowBase(unittest.TestCase):
                 name, window._spec_toolbar.description(), "Mock"
             )
             mock_save.return_value = {}
-            window._spec_toolbar._line_edit_name.setText("new spec name")
-            window._spec_toolbar._line_edit_name.editingFinished.emit()
+            name_edit = window._spec_toolbar._line_edit_name
+            name_edit.setText("new spec name")
+            name_edit.textEdited.emit(name_edit.text())
             window._spec_toolbar.save_action.trigger()
             item_specification = project_item.specification()
             self.assertEqual(item_specification.name, "new spec name")
@@ -172,6 +176,9 @@ class _MockProjectItem(ProjectItem):
     @staticmethod
     def item_type():
         return "Mock"
+
+    def get_icon(self):
+        return ProjectItemIcon(self._toolbox, ":/icons/item_icons/hammer.svg", QColor("white"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Many line edits now update the underlying name/description/option etc. while editing, not when the `editingFinished` signal is emitted. This makes the text fields feel more "fluid".

Also included:

- Fixed numerous issues with undoing changes to items/connections after the item/connection was removed. We now use item names or connection source&destination instead of direct reference to identify the item because they are valid even if the item gets deleted and then resurrected.
- Fixed minor issues like tab order when navigating windows using keyboard.

Implements #2629

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
