### PR TITLE
Remove opening db under same name info box

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
@@ -90,26 +90,6 @@ class MultiSpineDBEditor(MultiTabWindow):
         tab = SpineDBEditor(self.db_mngr)
         if not tab.load_db_urls(db_url_codenames, create=True, window=window):
             return
-        # Checks if the same url is already opened under a different codename
-        if db_url_codenames:
-            for url, codename in db_url_codenames.items():
-                if not codename:
-                    continue
-                current_codename = codename
-                for db_map in self.db_mngr.db_maps:
-                    is_same = str(url) == db_map.db_url
-                    is_same = is_same and codename != db_map.codename
-                    if is_same:
-                        existing = db_map.codename
-                        msg = QMessageBox(self.parent())
-                        msg.setIcon(QMessageBox.Icon.Information)
-                        msg.setWindowTitle(current_codename)
-                        msg.setText(
-                            f"<p>The same database is already open in another window. Opening the new window under "
-                            f"the same name as the existing one: <b>{existing}</b></p>"
-                        )
-                        msg.exec()
-                        break
         return tab
 
     def show_plus_button_context_menu(self, global_pos):


### PR DESCRIPTION
Removed the box informing that the db is already open and a new window will be opened under the same name. It seemed to cause way more problems compared to its usefulness in its one specific edge case.

Fixes #2620, #2507

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
