### PR TITLE
Convert yellow links automatically to blue links

### DIFF
--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -16,9 +16,9 @@ from itertools import chain
 import os
 from pathlib import Path
 import json
-import random
 from PySide6.QtCore import Signal, QCoreApplication
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QMessageBox
 import networkx as nx
 from spine_engine.exception import EngineInitFailed, RemoteEngineInitFailed
 from spine_engine.utils.helpers import create_timestamp, gather_leaf_data
@@ -34,7 +34,6 @@ from spine_engine.utils.helpers import (
 )
 from spine_engine.utils.serialization import deserialize_path, serialize_path
 from spine_engine.server.util.zip_handler import ZipHandler
-from .widgets.notification import Notification
 from .project_settings import ProjectSettings
 from .server.engine_client import EngineClient
 from .metaobject import MetaObject
@@ -759,12 +758,25 @@ class SpineToolboxProject(MetaObject):
         self.connection_established.emit(connection)
         self._update_jump_icons()
         if not self._is_dag_valid(dag):
+            src = connection.source
+            dst = connection.destination
             self.remove_connection(connection)
-            n = Notification(
-                self._toolbox,
-                "Feedback loops not allowed. Draw the link again with the ALT key pressed to make a Jump link.",
+            msg = "This connection creates a cycle into the DAG.\n\nWould you like to add a Loop connection?"
+            title = f"Add Loop?"
+            message_box = QMessageBox(
+                QMessageBox.Icon.Question,
+                title,
+                msg,
+                QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+                parent=self._toolbox,
             )
-            n.show()
+            message_box.button(QMessageBox.StandardButton.Ok).setText("Add Loop")
+            answer = message_box.exec()
+            if answer == QMessageBox.StandardButton.Cancel:
+                return False
+            source_connector = self.get_item(src).get_icon().conn_button(args[1])  # args[1]: jump.source_position
+            destination_connector = self.get_item(dst).get_icon().conn_button(args[3])  # args[3]: jump.dst_position)
+            self._toolbox.ui.graphicsView.add_jump(source_connector, destination_connector)
             return False
         destination = self._project_items[connection.destination]
         source = self._project_items[connection.source]


### PR DESCRIPTION
When a user is about to make a (yellow) connection which adds a cycle into the DAG, a popup asks the user for permission to add a (blue) Loop connection instead.

Fixes #2614

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
