### PR TITLE
Fix caching in GitHub actions

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
+        cache-dependency-path: |
+          requirements.txt
+          pyproject.toml
     - name: Display Python version
       run:
          python -c "import sys; print(sys.version)"
@@ -44,7 +47,7 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        pip install -r requirements.txt
     - name: List packages
       run:
         python -m pip list

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -47,7 +47,7 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
     - name: List packages
       run:
         python -m pip list
@@ -82,6 +82,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
+        cache-dependency-path: |
+          requirements.txt
+          pyproject.toml
     - name: Install additional packages for Linux
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
This PR gets caching finally flying. Execution time of the "Install dependencies" task is now ~1min less on Windows hosts and ~20s on Linux.

Re #2642

## Checklist before merging
- [ ] Unit tests pass
