### PR TITLE
Fix pasting bogus data on Parameter value table

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -201,8 +201,8 @@ class EntityMixin:
 
     def _make_item(self, row):
         item = super()._make_item(row)
-        if item["entity_byname"]:
-            item["entity_byname"] = tuple(item["entity_byname"].split(DB_ITEM_SEPARATOR))
+        byname = item["entity_byname"]
+        item["entity_byname"] = tuple(byname.split(DB_ITEM_SEPARATOR)) if byname else ()
         return item
 
     @staticmethod

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -34,6 +34,28 @@ class TestParameterTableView(TestBase):
     def tearDown(self):
         self._common_tear_down()
 
+    def test_paste_empty_string_to_entity_byname_column(self):
+        table_view = self._db_editor.ui.tableView_parameter_value
+        model = table_view.model()
+        byname_column = model.header.index("entity_byname")
+        table_view.selectionModel().setCurrentIndex(
+            model.index(0, byname_column), QItemSelectionModel.SelectionFlag.ClearAndSelect
+        )
+        mock_clipboard = mock.MagicMock()
+        mock_clipboard.text.return_value = "''"
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as clipboard:
+            clipboard.return_value = mock_clipboard
+            self.assertTrue(table_view.paste())
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.columnCount(), 6)
+        expected = [
+            [None, "", None, None, None, "TestParameterTableView_db"],
+        ]
+        for row in range(model.rowCount()):
+            for column in range(model.columnCount()):
+                with self.subTest(row=row, column=column):
+                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+
     def test_remove_last_empty_row(self):
         table_view = self._db_editor.ui.tableView_parameter_value
         model = table_view.model()

--- a/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
+++ b/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
@@ -77,8 +77,8 @@ class TestMassRemoveItemsDialog(unittest.TestCase):
         entities = [item._asdict() for item in self._db_mngr.get_items(self._db_map, "entity")]
         self.assertEqual(len(entities), 1)
         entity_id = entities[0]["id"]
-        self.assertEqual(entities
-            ,
+        self.assertEqual(
+            entities,
             [
                 {
                     'class_id': class_id,

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -265,22 +265,24 @@ class TestImportExportData(unittest.TestCase):
             'entity_classes': [('A', (), None, None, False)],
             'entities': [('A', 'aa', None)],
             'parameter_definitions': [('A', 'test1', None, None, None)],
-            'parameter_values': [(
-                'A',
-                'aa',
-                'test1',
-                {
-                    'type': 'time_series',
-                    'index': {
-                        'start': '2000-01-01 00:00:00',
-                        'resolution': '1h',
-                        'ignore_year': False,
-                        'repeat': False
+            'parameter_values': [
+                (
+                    'A',
+                    'aa',
+                    'test1',
+                    {
+                        'type': 'time_series',
+                        'index': {
+                            'start': '2000-01-01 00:00:00',
+                            'resolution': '1h',
+                            'ignore_year': False,
+                            'repeat': False,
+                        },
+                        'data': [0.0, 1.0, 2.0, 4.0, 8.0, 0.0],
                     },
-                    'data': [0.0, 1.0, 2.0, 4.0, 8.0, 0.0]
-                },
-                'Base'
-            )],
+                    'Base',
+                )
+            ],
             'alternatives': [('Base', 'Base alternative')],
         }
 
@@ -305,7 +307,7 @@ class TestImportExportData(unittest.TestCase):
             ),
             (0.0, 1.0, 2.0, 4.0, 8.0, 0.0),
             False,
-            False
+            False,
         )
         self.assertEqual(time_series, expected_result)
 


### PR DESCRIPTION
We now properly handle cases where entity byname is `"''"` or similar non-data.

Fixes #2549

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
