### PR TITLE
Remove resizing columns to contents from table views in Database editor

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -326,6 +326,8 @@ class Ui_MainWindow(object):
         self.pivot_table.setObjectName(u"pivot_table")
         self.pivot_table.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.pivot_table.setTabKeyNavigation(False)
+        self.pivot_table.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.pivot_table.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
         self.verticalLayout_13.addWidget(self.pivot_table)
 

--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -220,7 +220,6 @@ class Ui_MainWindow(object):
         self.tableView_parameter_value.setSortingEnabled(False)
         self.tableView_parameter_value.setWordWrap(False)
         self.tableView_parameter_value.horizontalHeader().setHighlightSections(False)
-        self.tableView_parameter_value.horizontalHeader().setStretchLastSection(True)
         self.tableView_parameter_value.verticalHeader().setVisible(False)
         self.tableView_parameter_value.verticalHeader().setHighlightSections(False)
 
@@ -239,13 +238,11 @@ class Ui_MainWindow(object):
         self.tableView_parameter_definition = ParameterDefinitionTableView(self.dockWidgetContents_5)
         self.tableView_parameter_definition.setObjectName(u"tableView_parameter_definition")
         self.tableView_parameter_definition.setContextMenuPolicy(Qt.DefaultContextMenu)
-        self.tableView_parameter_definition.setLayoutDirection(Qt.LeftToRight)
         self.tableView_parameter_definition.setTabKeyNavigation(False)
         self.tableView_parameter_definition.setSelectionBehavior(QAbstractItemView.SelectItems)
         self.tableView_parameter_definition.setSortingEnabled(False)
         self.tableView_parameter_definition.setWordWrap(False)
         self.tableView_parameter_definition.horizontalHeader().setHighlightSections(False)
-        self.tableView_parameter_definition.horizontalHeader().setStretchLastSection(True)
         self.tableView_parameter_definition.verticalHeader().setVisible(False)
         self.tableView_parameter_definition.verticalHeader().setHighlightSections(False)
 

--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
@@ -405,6 +405,12 @@
        <property name="tabKeyNavigation">
         <bool>false</bool>
        </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
+       <property name="horizontalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
       </widget>
      </item>
     </layout>

--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
@@ -188,9 +188,6 @@
        <attribute name="horizontalHeaderHighlightSections">
         <bool>false</bool>
        </attribute>
-       <attribute name="horizontalHeaderStretchLastSection">
-        <bool>true</bool>
-       </attribute>
        <attribute name="verticalHeaderVisible">
         <bool>false</bool>
        </attribute>
@@ -234,9 +231,6 @@
        <property name="accessibleName">
         <string>parameter definition</string>
        </property>
-       <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
-       </property>
        <property name="tabKeyNavigation">
         <bool>false</bool>
        </property>
@@ -251,9 +245,6 @@
        </property>
        <attribute name="horizontalHeaderHighlightSections">
         <bool>false</bool>
-       </attribute>
-       <attribute name="horizontalHeaderStretchLastSection">
-        <bool>true</bool>
        </attribute>
        <attribute name="verticalHeaderVisible">
         <bool>false</bool>

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -12,7 +12,16 @@
 
 """Custom QTableView classes that support copy-paste and the like."""
 from dataclasses import replace
-from PySide6.QtCore import Qt, Signal, Slot, QTimer, QModelIndex, QPoint, QItemSelection, QItemSelectionModel
+from PySide6.QtCore import (
+    Qt,
+    Signal,
+    Slot,
+    QTimer,
+    QModelIndex,
+    QPoint,
+    QItemSelection,
+    QItemSelectionModel,
+)
 from PySide6.QtWidgets import QHeaderView, QTableView, QMenu, QWidget
 from PySide6.QtGui import QKeySequence, QAction
 from .scenario_generator import ScenarioGenerator
@@ -66,6 +75,9 @@ def _set_data(index, new_value):
 class StackedTableView(AutoFilterCopyPasteTableView):
     """Base stacked view."""
 
+    _EXPECTED_COLUMN_COUNT = NotImplemented
+    _STRETCH_COLUMNS = set()
+
     def __init__(self, parent):
         """
         Args:
@@ -75,7 +87,7 @@ class StackedTableView(AutoFilterCopyPasteTableView):
         self._menu = QMenu(self)
         self._spine_db_editor = None
         header = self.horizontalHeader()
-        header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        header.sectionCountChanged.connect(self._set_column_resize_modes)
 
     def connect_spine_db_editor(self, spine_db_editor):
         """Connects a Spine db editor to work with this view.
@@ -201,15 +213,26 @@ class StackedTableView(AutoFilterCopyPasteTableView):
         """Enables or disables copy and paste actions."""
         self._spine_db_editor.refresh_copy_paste_actions()
 
+    @Slot(int, int)
+    def _set_column_resize_modes(self, old_column_count, new_column_count):
+        if new_column_count != self._EXPECTED_COLUMN_COUNT:
+            return
+        header = self.horizontalHeader()
+        model = header.model()
+        for column in range(model.columnCount()):
+            data = model.headerData(column, Qt.Orientation.Horizontal)
+            if data in self._STRETCH_COLUMNS:
+                header.setSectionResizeMode(column, QHeaderView.ResizeMode.Stretch)
+
 
 class ParameterTableView(StackedTableView):
     value_column_header: str = NotImplemented
-    """Either "default value" or "value". Used to identify the value column for advanced editing and plotting."""
+    """Either "default_value" or "value". Used to identify the value column for advanced editing and plotting."""
 
     def __init__(self, parent):
         """
         Args:
-            parent (QObject): parent object
+            parent (QWidget): parent widget
         """
         super().__init__(parent=parent)
         self._open_in_editor_action = None
@@ -292,6 +315,9 @@ class ParameterTableView(StackedTableView):
 class ParameterDefinitionTableView(ParameterTableView):
     value_column_header = "default_value"
 
+    _EXPECTED_COLUMN_COUNT = 6
+    _STRETCH_COLUMNS = {"description"}
+
     def create_delegates(self):
         super().create_delegates()
         self._make_delegate("value_list_name", ValueListDelegate)
@@ -317,6 +343,9 @@ class ParameterDefinitionTableView(ParameterTableView):
 
 class ParameterValueTableView(ParameterTableView):
     value_column_header = "value"
+
+    _EXPECTED_COLUMN_COUNT = 6
+    _STRETCH_COLUMNS = {"entity_class_name", "entity_byname", "parameter_name", "alternative_name", "value"}
 
     def connect_spine_db_editor(self, spine_db_editor):
         super().connect_spine_db_editor(spine_db_editor)
@@ -365,6 +394,9 @@ class ParameterValueTableView(ParameterTableView):
 
 class EntityAlternativeTableView(StackedTableView):
     """Visualize entities and their alternatives."""
+
+    _EXPECTED_COLUMN_COUNT = 5
+    _STRETCH_COLUMNS = {"entity_class_name", "entity_byname", "alternative_name"}
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -983,8 +1015,9 @@ class MetadataTableViewBase(CopyPasteTableView):
             parent (QWidget, optional): parent widget
         """
         super().__init__(parent)
-        self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
-        self.verticalHeader().setDefaultSectionSize(preferred_row_height(self))
+        horizontal_header = self.horizontalHeader()
+        horizontal_header.sectionCountChanged.connect(self._set_horizontal_header_resize_modes)
+        self.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
         self._menu = QMenu(self)
         self._db_editor = None
 
@@ -1041,6 +1074,12 @@ class MetadataTableViewBase(CopyPasteTableView):
     @Slot(QModelIndex, QModelIndex)
     def _refresh_copy_paste_actions(self):
         self._db_editor.refresh_copy_paste_actions()
+
+    @Slot(int, int)
+    def _set_horizontal_header_resize_modes(self, old_column_count, new_column_count):
+        if new_column_count != 3:
+            return
+        self.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
 
 
 class MetadataTableView(MetadataTableViewBase):

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -44,10 +44,8 @@ class StackedViewMixin:
         for model, view in self._all_stacked_models.items():
             view.setModel(model)
             view.verticalHeader().setDefaultSectionSize(preferred_row_height(self))
-            view.horizontalHeader().setResizeContentsPrecision(self.visible_rows)
-            view.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
-            view.horizontalHeader().setStretchLastSection(True)
-            view.horizontalHeader().setSectionsMovable(True)
+            horizontal_header = view.horizontalHeader()
+            horizontal_header.setSectionsMovable(True)
             view.connect_spine_db_editor(self)
 
     def connect_signals(self):


### PR DESCRIPTION
Resizing column widths to contents works very well in tree views in my humble opinion. However, it is troublesome in Database editor's table views, especially if the column contains long texts like the "description" column often does. There are also performance concerns.

This PR tries a different approach with the table views: we now stretch some of the columns to fill the view. Let's see how it feels.

Also, this fixes a bug in Pivot table where the header widgets were drawn too narrow hiding the "expansion arrow".

Re #2542

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
