### PR TITLE
Fix parameter default value editing

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -491,8 +491,10 @@ class EditParameterValueMixin:
             return ""
         database = self.index(index.row(), self.columnCount() - 1).data()
         if self.item_type == "parameter_definition":
+            parameter_name = item["name"]
             names = [item["entity_class_name"]]
         elif self.item_type == "parameter_value":
+            parameter_name = item["parameter_name"]
             names = list(item["entity_byname"])
         else:
             raise ValueError(
@@ -501,7 +503,7 @@ class EditParameterValueMixin:
         alternative_name = {"parameter_definition": lambda x: None, "parameter_value": lambda x: x["alternative_name"]}[
             self.item_type
         ](item)
-        return parameter_identifier(database, item["parameter_name"], names, alternative_name)
+        return parameter_identifier(database, parameter_name, names, alternative_name)
 
     def get_set_data_delayed(self, index):
         """Returns a function that ParameterValueEditor can call to set data for the given index at any later time,

--- a/tests/spine_db_editor/helpers.py
+++ b/tests/spine_db_editor/helpers.py
@@ -1,0 +1,64 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""Helper utilities for Database editor's tests."""
+import unittest
+from unittest import mock
+
+from PySide6.QtWidgets import QApplication
+
+from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
+from tests.mock_helpers import TestSpineDBManager
+
+
+class TestBase(unittest.TestCase):
+    """Base class for Database editor's table and tree view tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db_codename = cls.__name__ + "_db"
+        if not QApplication.instance():
+            QApplication()
+
+    def _common_setup(self, url, create):
+        with mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"), mock.patch(
+            "spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.show"
+        ):
+            mock_settings = mock.MagicMock()
+            mock_settings.value.side_effect = lambda *args, **kwargs: 0
+            self._db_mngr = TestSpineDBManager(mock_settings, None)
+            logger = mock.MagicMock()
+            self._db_map = self._db_mngr.get_db_map(url, logger, codename=self.db_codename, create=create)
+            self._db_editor = SpineDBEditor(self._db_mngr, {url: self.db_codename})
+        QApplication.processEvents()
+
+    def _common_tear_down(self):
+        with mock.patch(
+            "spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.save_window_state"
+        ), mock.patch("spinetoolbox.spine_db_manager.QMessageBox"):
+            self._db_editor.close()
+        self._db_mngr.close_all_sessions()
+        while not self._db_map.closed:
+            QApplication.processEvents()
+        self._db_mngr.clean_up()
+        self._db_editor.deleteLater()
+        self._db_editor = None
+
+    def _commit_changes_to_database(self, commit_message):
+        with mock.patch.object(self._db_editor, "_get_commit_msg") as commit_msg:
+            commit_msg.return_value = commit_message
+            self._db_editor.ui.actionCommit.trigger()
+
+    def assert_success(self, result):
+        item, error = result
+        self.assertIsNone(error)
+        return item

--- a/tests/spine_db_editor/mvcmodels/test_PivotTableModel.py
+++ b/tests/spine_db_editor/mvcmodels/test_PivotTableModel.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 from PySide6.QtWidgets import QApplication
 from spinedb_api import Map
 from tests.mock_helpers import fetch_model
-from tests.spine_db_editor.widgets.helpers import TestBase
+from tests.spine_db_editor.helpers import TestBase
 
 
 class TestParameterValuePivotTableModel(TestBase):

--- a/tests/spine_db_editor/widgets/helpers.py
+++ b/tests/spine_db_editor/widgets/helpers.py
@@ -10,18 +10,15 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""Helper utilites for unit tests that test Database manager's table and tree views."""
+"""Helper utilities for unit tests that test Database editor's table and tree views."""
 from types import MethodType
-import unittest
 from unittest import mock
 from PySide6.QtCore import QEvent, Qt
 from PySide6.QtGui import QKeyEvent
 from PySide6.QtWidgets import QApplication
-from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
 from spinetoolbox.spine_db_editor.widgets.add_items_dialogs import AddEntityClassesDialog, AddEntitiesDialog
 from spinetoolbox.helpers import signal_waiter
 from spinetoolbox.spine_db_editor.widgets.custom_editors import SearchBarEditor
-from tests.mock_helpers import TestSpineDBManager
 
 
 class EditorDelegateMocking:
@@ -118,42 +115,3 @@ def add_entity(view, name, entity_class_index=0):
     class_index = model.index(entity_class_index, 0, root_index)
     view._context_item = model.item_from_index(class_index)
     add_entity_tree_item({0: name}, view, "Add entities", AddEntitiesDialog)
-
-
-class TestBase(unittest.TestCase):
-    """Base class for Database editor's table and tree view tests."""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.db_codename = cls.__name__ + "_db"
-        if not QApplication.instance():
-            QApplication()
-
-    def _common_setup(self, url, create):
-        with mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"), mock.patch(
-            "spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.show"
-        ):
-            mock_settings = mock.MagicMock()
-            mock_settings.value.side_effect = lambda *args, **kwargs: 0
-            self._db_mngr = TestSpineDBManager(mock_settings, None)
-            logger = mock.MagicMock()
-            self._db_map = self._db_mngr.get_db_map(url, logger, codename=self.db_codename, create=create)
-            self._db_editor = SpineDBEditor(self._db_mngr, {url: self.db_codename})
-        QApplication.processEvents()
-
-    def _common_tear_down(self):
-        with mock.patch(
-            "spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.save_window_state"
-        ), mock.patch("spinetoolbox.spine_db_manager.QMessageBox"):
-            self._db_editor.close()
-        self._db_mngr.close_all_sessions()
-        while not self._db_map.closed:
-            QApplication.processEvents()
-        self._db_mngr.clean_up()
-        self._db_editor.deleteLater()
-        self._db_editor = None
-
-    def _commit_changes_to_database(self, commit_message):
-        with mock.patch.object(self._db_editor, "_get_commit_msg") as commit_msg:
-            commit_msg.return_value = commit_message
-            self._db_editor.ui.actionCommit.trigger()

--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_manager import SpineDBManager
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
 from spinetoolbox.spine_db_editor.widgets.add_items_dialogs import AddEntityClassesDialog, ManageElementsDialog
-from tests.spine_db_editor.widgets.helpers import TestBase
+from tests.spine_db_editor.helpers import TestBase
 
 
 class TestAddItemsDialog(unittest.TestCase):

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -19,10 +19,10 @@ from unittest import mock
 from PySide6.QtCore import QItemSelectionModel, QModelIndex
 from PySide6.QtWidgets import QApplication, QMessageBox
 from spinedb_api import DatabaseMapping, import_functions
+from tests.spine_db_editor.helpers import TestBase
 from tests.spine_db_editor.widgets.helpers import (
     add_entity,
     add_zero_dimension_entity_class,
-    TestBase,
     EditorDelegateMocking,
 )
 

--- a/tests/spine_db_editor/widgets/test_custom_qtreeview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtreeview.py
@@ -30,12 +30,12 @@ from spinetoolbox.spine_db_editor.widgets.edit_or_remove_items_dialogs import (
     EditEntitiesDialog,
     RemoveEntitiesDialog,
 )
+from tests.spine_db_editor.helpers import TestBase
 from tests.spine_db_editor.widgets.helpers import (
     EditorDelegateMocking,
     add_entity_tree_item,
     add_zero_dimension_entity_class,
     add_entity,
-    TestBase,
 )
 
 

--- a/tests/spine_db_editor/widgets/test_edit_or_remove_items_dialogs.py
+++ b/tests/spine_db_editor/widgets/test_edit_or_remove_items_dialogs.py
@@ -16,7 +16,7 @@ from unittest import mock
 from PySide6.QtCore import QItemSelectionModel
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.widgets.edit_or_remove_items_dialogs import EditEntityClassesDialog
-from tests.spine_db_editor.widgets.helpers import TestBase
+from tests.spine_db_editor.helpers import TestBase
 
 
 class TestEditEntityClassesDialog(TestBase):

--- a/tests/spine_db_editor/widgets/test_scenario_generator.py
+++ b/tests/spine_db_editor/widgets/test_scenario_generator.py
@@ -14,7 +14,7 @@
 import unittest
 from PySide6.QtCore import Qt
 from spinetoolbox.spine_db_editor.widgets.scenario_generator import ScenarioGenerator
-from .helpers import TestBase
+from tests.spine_db_editor.helpers import TestBase
 
 
 class TestScenarioGenerator(TestBase):

--- a/tests/spine_db_editor/widgets/test_tabular_view_mixin.py
+++ b/tests/spine_db_editor/widgets/test_tabular_view_mixin.py
@@ -18,7 +18,7 @@ from PySide6.QtCore import QItemSelectionModel
 from PySide6.QtWidgets import QApplication
 from spinedb_api import Map
 from tests.mock_helpers import fetch_model
-from tests.spine_db_editor.widgets.helpers import TestBase
+from tests.spine_db_editor.helpers import TestBase
 
 
 class TestPivotHeaderDraggingAndDropping(TestBase):


### PR DESCRIPTION
This PR fixes a bug that prevented opening default values in parameter value editors.

Fixes #2655 

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
