### PR TITLE
Fix Traceback when writing regular expression in filter search field

### DIFF
--- a/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
+++ b/spinetoolbox/mvcmodels/filter_checkbox_list_model.py
@@ -178,9 +178,13 @@ class SimpleFilterCheckboxListModel(QAbstractListModel):
         return self._data_set.difference(self._selected)
 
     def set_filter(self, filter_expression):
-        if filter_expression and (isinstance(filter_expression, str) and not filter_expression.isspace()):
+        filter_expression = filter_expression.strip()
+        if filter_expression:
+            try:
+                self._filter_expression = re.compile(filter_expression)
+            except re.error:
+                return
             self._action_rows[0] = self._SELECT_ALL_STR
-            self._filter_expression = re.compile(filter_expression)
             self._filter_index = [i for i, item in enumerate(self._data) if self.search_filter_expression(item)]
             self._selected_filtered = set(self._data[i] for i in self._filter_index)
             self._add_to_selection = False

--- a/tests/mvcmodels/test_FilterCheckboxList.py
+++ b/tests/mvcmodels/test_FilterCheckboxList.py
@@ -352,6 +352,22 @@ class TestFilterCheckboxListModel(unittest.TestCase):
         self.assertEqual(self.model._selected_filtered, set(self.data[4:]))
         self.assertTrue(self.model._all_selected)
 
+    def test_half_finished_expression_does_not_raise_exception(self):
+        self.model.set_list(self.data)
+        self.model.set_filter("[")
+        self.assertEqual(
+            [self.model.index(row, 0).data() for row in range(self.model.rowCount())],
+            ["(Select all)", "(Empty)"] + self.data,
+        )
+
+    def test_only_whitespaces_in_filter_expression_does_not_filter(self):
+        self.model.set_list(self.data)
+        self.model.set_filter("   ")
+        self.assertEqual(
+            [self.model.index(row, 0).data() for row in range(self.model.rowCount())],
+            ["(Select all)", "(Empty)"] + self.data,
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug where this would Traceback:

![image](https://github.com/spine-tools/Spine-Toolbox/assets/19147159/c0185376-9da5-40be-92bc-d839ab4d6478)

Fixes #2659

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
