### PR TITLE
Trigger Downloads page update when bundling succeeds

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -5,20 +5,15 @@ on: workflow_dispatch
 jobs:
   bundle:
     name: Bundle
-    strategy:
-      fail-fast: True
-      matrix:
-        python-version: ["3.11"]
-        os: [windows-latest]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: pip
       - name: Install dependencies
         run: |
@@ -52,3 +47,17 @@ jobs:
           path: dist
           if-no-files-found: error
           overwrite: true
+  update-downloads-page:
+    name: Trigger Downloads page generation
+    needs: bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger workflow
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.DOWNLOADS_TRIGGER_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/spine-tools/Downloads/actions/workflows/generate_readme.yml/dispatches \
+          -d '{"ref":"main"}'


### PR DESCRIPTION
The 'PyInstaller Bundle' workflow in GitHub Actions now triggers a workflow in the Downloads repository that regenerates the downloads page with new links to artifacts.