### PR TITLE
Support latest PySide6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8.1, <3.12"
 dependencies = [
-    "pyside6 >= 6.5.0, != 6.5.3, < 6.6",
+    "pyside6 >= 6.5.0, != 6.5.3, != 6.6.3",
     "jupyter-client >=6.0",
     "qtconsole >=5.1",
     "sqlalchemy >=1.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git@0.8-dev#egg=spine_items
+-e git+https://github.com/spine-tools/spine-items.git@support_pyside66#egg=spine_items
 -e .[dev]

--- a/tests/widgets/test_kernel_editor.py
+++ b/tests/widgets/test_kernel_editor.py
@@ -25,21 +25,23 @@ from spinetoolbox.widgets.kernel_editor import KernelEditorBase
 
 
 class MockSettingsWidget(QWidget):
-    qsettings = MagicMock()
+    def __init__(self):
+        super().__init__()
+        self.qsettings = MagicMock()
 
 
 class TestKernelEditorBase(unittest.TestCase):
-    _settings_widget = None
 
     @classmethod
     def setUpClass(cls):
         if not QApplication.instance():
             QApplication()
-        cls._settings_widget = MockSettingsWidget()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls._settings_widget.deleteLater()
+    def setUp(self):
+        self._settings_widget = MockSettingsWidget()
+
+    def tearDown(self):
+        self._settings_widget.deleteLater()
 
     def test_is_package_installed(self):
         self.assertTrue(KernelEditorBase.is_package_installed(sys.executable, "PySide6"))


### PR DESCRIPTION
Allow using the latest PySide6 (6.6.3.1). Disallow broken 6.5.2 and 6.6.3 versions.

- Updated some tests, which caused fatal Windows errors on PySide6 6.6.3.1.

Fixes #2345

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Unit tests pass
