### PR TITLE
Add coverage to dev-requirements

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -55,6 +55,9 @@ jobs:
       run: |
         python -m pip install ipykernel
         python -m ipykernel install --user
+    - name: Install coverage
+      run: |
+        python -m pip install coverage
     - name: Run tests
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -57,7 +57,7 @@ jobs:
         python -m ipykernel install --user
     - name: Install coverage
       run: |
-        python -m pip install coverage
+        python -m pip install coverage[toml]
     - name: Run tests
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -56,7 +56,7 @@ jobs:
         python -m pip install ipykernel
         python -m ipykernel install --user
     - name: Install coverage
-      run: |
+      run:
         python -m pip install coverage[toml]
     - name: Run tests
       run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,5 @@ setuptools_scm[toml] >= 6.2
 build
 wheel >=0.36.2
 twine >= 3.4.1
+coverage
 -r "docs/requirements.txt"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,5 +7,5 @@ setuptools_scm[toml] >= 6.2
 build
 wheel >=0.36.2
 twine >= 3.4.1
-coverage
+coverage[toml]
 -r "docs/requirements.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ dependencies = [
 Documentation = "https://spine-toolbox.readthedocs.io/"
 Repository = "https://github.com/spine-tools/Spine-Toolbox"
 
-[project.optional-dependencies]
-dev = ["coverage[toml]"]
-
 [project.scripts]
 spinetoolbox = "spinetoolbox.main:main"
 spine-db-editor = "spinetoolbox.spine_db_editor.main:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git@0.8-dev#egg=spine_items
--e .[dev]
+-e .


### PR DESCRIPTION
This PR removes `coverage` from pyproject.toml and places it into dev-requirements.txt so that `pip install -r requirements.txt` does not install `coverage` anymore. In addition, this PR adds a step to Github test runner action to install coverage.

Re #2268

## Checklist before merging
- [x] Unit tests pass
