### PR TITLE
Remember URL specific view configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Many parts of the Spine data structure have been redesigned.
 
 - "Rubber band" selection of items in Design and Graph views is now done with **left mouse button**
   (no need to press Ctrl anymore). The views can be dragged around by holding the **right mouse button**.
+- Spine Database Editor now remembers the configuration of the docs in each view for a specific URL. The docks
+  can be reset from the hamburger menu **View->Docks...->Reset docks**.
 - You can now select a different Julia executable & project or Julia kernel for each Tool spec.
   This overrides the global setting from Toolbox Settings.
 - Headless mode now supports remote execution (see 'python -m spinetoolbox --help')

--- a/docs/source/spine_db_editor/getting_started.rst
+++ b/docs/source/spine_db_editor/getting_started.rst
@@ -75,8 +75,8 @@ like this:
 
 The dock widgets can be scaled by dragging them from the sides and moved around by dragging them from their
 darker colored headers. Like with other widgets, Toolbox remembers the customizations and the editor will
-open in the same configuration when it is opened the next time. If the view is changed from the hamburger
-menu, the modifications will be lost and the UI will be reverted back to default.
+open in the same configuration when it is opened the next time. The dock configurations are URL specific.
+the configurations for the URL can be restored back to default from the hamburger menu **View->Docks...->Reset docks**.
 
 Tab bar
 =======

--- a/tests/spine_db_editor/widgets/test_SpineDBEditor.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditor.py
@@ -41,6 +41,18 @@ class TestSpineDBEditor(DBEditorTestBase):
             row_data.append(tuple(model.index(row, h(field)).data() for field in ("entity_class_name", "database")))
         self.assertIn(("fish", "database"), row_data)
 
+    def test_save_window_state(self):
+        self.spine_db_editor.db_maps = [self.mock_db_map]
+        self.spine_db_editor.db_urls = [""]
+        self.spine_db_editor.save_window_state()
+        self.spine_db_editor.qsettings.beginGroup.assert_has_calls([mock.call("spineDBEditor"), mock.call("")])
+        self.spine_db_editor.qsettings.endGroup.assert_has_calls([mock.call(), mock.call()])
+        qsettings_save_calls = self.spine_db_editor.qsettings.setValue.call_args_list
+        self.assertEqual(len(qsettings_save_calls), 2)
+        saved_dict = {saved[0][0]: saved[0][1] for saved in qsettings_save_calls}
+        self.assertIn("windowState", saved_dict)
+        self.assertIn("last_open", saved_dict)
+
 
 class TestClosingDBEditors(unittest.TestCase):
     @classmethod

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
@@ -54,14 +54,6 @@ class TestSpineDBEditorBase(unittest.TestCase):
         self.db_editor.deleteLater()
         self.db_editor = None
 
-    def test_save_window_state(self):
-        self.db_editor.save_window_state()
-        self.db_editor.qsettings.beginGroup.assert_has_calls([mock.call("spineDBEditor"), mock.call("")])
-        self.db_editor.qsettings.endGroup.assert_has_calls([mock.call(), mock.call()])
-        qsettings_save_calls = self.db_editor.qsettings.setValue.call_args_list
-        self.assertEqual(len(qsettings_save_calls), 1)
-        saved_dict = {saved[0][0]: saved[0][1] for saved in qsettings_save_calls}
-        self.assertIn("windowState", saved_dict)
 
     def test_import_file_recognizes_excel(self):
         with mock.patch.object(self.db_editor, "qsettings"), mock.patch.object(


### PR DESCRIPTION
Now by default db editor always remembers the dock configurations per URL. Can be reset for specific URL form hamburger menu -> docks. Doesn't save the configurations if there are more than one URL open in the same tab.

Fixes #2537

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
