### PR TITLE
Prevent iterating database mapping while fetching

### DIFF
--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -136,6 +136,8 @@ class SpineDBWorker(QObject):
 
     def _do_fetch_more(self, parent):
         item_type = parent.fetch_item_type
+        if parent in self._parents_fetching.get(item_type, set()):
+            return
         fully_fetched = item_type in self._fetched_item_types
         # Only trust mapping if no external commits or fully fetched
         if not self._db_map.has_external_commits() or fully_fetched:

--- a/tests/spine_db_editor/mvcmodels/test_metadata_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_metadata_table_model.py
@@ -108,6 +108,8 @@ class TestMetadataTableModel(unittest.TestCase):
                 self.assertTrue(self._model.setData(index, "title"))
                 index = self._model.index(1, Column.VALUE)
                 self.assertTrue(self._model.setData(index, "My precious."))
+                while self._model.rowCount() != 3:
+                    QApplication.processEvents()
             finally:
                 self._db_mngr.close_session(url)
         self.assertEqual(self._model.rowCount(), 3)

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
@@ -54,7 +54,6 @@ class TestSpineDBEditorBase(unittest.TestCase):
         self.db_editor.deleteLater()
         self.db_editor = None
 
-
     def test_import_file_recognizes_excel(self):
         with mock.patch.object(self.db_editor, "qsettings"), mock.patch.object(
             self.db_editor, "import_from_excel"

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
@@ -70,12 +70,13 @@ class TestSpineDBEditorWithDBMapping(unittest.TestCase):
         self.spine_db_editor = None
         self._temp_dir.cleanup()
 
-    def fetch_object_tree_model(self):
+    def fetch_entity_tree_model(self):
         for item in self.spine_db_editor.entity_tree_model.visit_all():
-            if item.can_fetch_more():
+            while item.can_fetch_more():
                 item.fetch_more()
+                QApplication.processEvents()
 
-    def test_duplicate_object_in_object_tree_model(self):
+    def test_duplicate_zero_dimensional_entity_in_entity_tree_model(self):
         data = {
             "entity_classes": [("fish",), ("dog",), ("fish__dog", ("fish", "dog"))],
             "entities": [("fish", "nemo"), ("dog", "pluto"), ("fish__dog", ("nemo", "pluto"))],
@@ -83,7 +84,7 @@ class TestSpineDBEditorWithDBMapping(unittest.TestCase):
             "parameter_values": [("fish", "nemo", "color", "orange")],
         }
         self.db_mngr.import_data({self.db_map: data})
-        self.fetch_object_tree_model()
+        self.fetch_entity_tree_model()
         root_item = self.spine_db_editor.entity_tree_model.root_item
         fish_item = next(iter(item for item in root_item.children if item.display_data == "fish"))
         nemo_item = fish_item.child(0)


### PR DESCRIPTION
This PR fixes a Traceback caused by accessing database mapping while DB worker is fetching more data.

Fixes #2703

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
