### PR TITLE
Speed up app startup and optimize link drawing on Design View

### DIFF
--- a/spinetoolbox/link.py
+++ b/spinetoolbox/link.py
@@ -286,7 +286,7 @@ class _IconBase(QGraphicsEllipseItem):
 
 
 class _SvgIcon(_IconBase):
-    """A svg icon to show over a Link."""
+    """An SVG icon to show over a Link."""
 
     def __init__(self, parent, extent, path, tooltip=None, active=False):
         super().__init__(0, 0, extent, extent, parent, tooltip=tooltip, active=active)

--- a/spinetoolbox/project_item_icon.py
+++ b/spinetoolbox/project_item_icon.py
@@ -323,9 +323,13 @@ class ProjectItemIcon(QGraphicsPathItem):
         if not scene:
             return
         icon_group = scene.icon_group | {self}
-        scene.dirty_links |= set(
-            link for icon in icon_group for conn in icon.connectors.values() for link in conn.links
-        )
+        dirty_links = set(link for icon in icon_group for conn in icon.connectors.values() for link in conn.links)
+        if not dirty_links:
+            return
+        qsettings = self._toolbox.qsettings()
+        curved_links = qsettings.value("appSettings/curvedLinks", defaultValue="false") == "true"
+        for link in dirty_links:
+            link.update_geometry(curved_links)
 
     def mouseReleaseEvent(self, event):
         """Clears pre-bump rects, and pushes a move icon command if necessary."""

--- a/spinetoolbox/widgets/custom_qgraphicsscene.py
+++ b/spinetoolbox/widgets/custom_qgraphicsscene.py
@@ -12,7 +12,7 @@
 
 """Custom QGraphicsScene used in the Design View."""
 import math
-from PySide6.QtCore import Qt, Signal, Slot, QPointF, QEvent, QTimer
+from PySide6.QtCore import Qt, Signal, Slot, QPointF, QEvent
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene
 from PySide6.QtGui import QColor, QPen, QBrush
 from ..project_item_icon import ProjectItemIcon
@@ -68,19 +68,8 @@ class DesignGraphicsScene(CustomGraphicsScene):
         self._jump_drawer.hide()
         self.link_drawer = None
         self.icon_group = set()  # Group of project item icons that are moving together
-        self.dirty_links = set()
-        self._timer = QTimer(self)
-        self._timer.setInterval(5)
-        self._timer.timeout.connect(self._handle_timeout)
-        self._timer.start()
         self._cat = Cat(self)
         self.connect_signals()
-
-    @Slot()
-    def _handle_timeout(self):
-        for link in self.dirty_links:
-            link.update_geometry()
-        self.dirty_links.clear()
 
     def clear_icons_and_links(self):
         for item in self.items():

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -217,14 +217,16 @@ class TestToolboxUI(unittest.TestCase):
             # Make sure that the test uses LocalSpineEngineManager
             mock_qsettings_value.side_effect = qsettings_value_side_effect
             # Selecting cancel on the project close confirmation
-            with mock.patch.object(QMessageBox, 'exec', return_value=QMessageBox.Cancel):
+            with mock.patch.object(QMessageBox, "exec", return_value=QMessageBox.Cancel):
                 self.assertFalse(self.toolbox.close_project())
             mock_qsettings_value.assert_called()
         with mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"), mock.patch(
             "spinetoolbox.project.create_dir"
         ), mock.patch("spinetoolbox.project_item.project_item.create_dir"), mock.patch(
             "spinetoolbox.ui_main.ToolboxUI.update_recent_projects"
-        ), mock.patch.object(QMessageBox, 'exec', return_value=QMessageBox.Cancel):
+        ), mock.patch.object(
+            QMessageBox, "exec", return_value=QMessageBox.Cancel
+        ):
             # Selecting cancel on the project close confirmation
             with mock.patch("spinetoolbox.ui_main.ToolboxUI.add_warning_message") as warning_msg:
                 # trying to open the same project but selecting cancel when asked about unsaved changes
@@ -235,7 +237,6 @@ class TestToolboxUI(unittest.TestCase):
         self.assertIsNotNone(self.toolbox.project())
         self.assertEqual(self.toolbox.project().get_item("DC1").name, "DC1")
         self.assertEqual(self.toolbox.project().get_item("DC2").name, "DC2")
-
 
     def test_close_project(self):
         self.assertIsNone(self.toolbox.project())


### PR DESCRIPTION
This PR removes a QTimer that was fired every 5ms in the background. The timer was never stopped and it kept on hammering in the background, just waiting for something to do. Removing it seems to reduce the app start up time. At least on my system the app startup time went from over 15s to about 3s. Sometimes it's faster, sometimes slower, depending on the phase of the moon. If you disable 'curved links' from Settings, the app may startup even faster.

In addition, redrawing links while moving icons on Design View should be a bit smoother.

Re issue #2186

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
