### PR TITLE
Do not apply changes from databases that are no longer used

### DIFF
--- a/benchmarks/db_mngr_get_icon_mngr.py
+++ b/benchmarks/db_mngr_get_icon_mngr.py
@@ -1,0 +1,65 @@
+"""
+This script benchmarks SpineDBManager.get_icon_mngr().
+"""
+import os
+import sys
+
+if sys.platform == "win32" and "HOMEPATH" not in os.environ:
+    import pathlib
+    os.environ["HOMEPATH"] = str(pathlib.Path(sys.executable).parent)
+
+import time
+from typing import Optional, Iterable
+import pyperf
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication
+from spinetoolbox.spine_db_manager import SpineDBManager
+from spinedb_api import DatabaseMapping
+from spinetoolbox.spine_db_icon_manager import SpineDBIconManager
+
+
+def db_mngr_get_icon_mngr(
+    loops: int, db_mngr: SpineDBManager, db_maps: Iterable[DatabaseMapping]
+) -> float:
+    duration = 0.0
+    for _ in range(loops):
+        for db_map in db_maps:
+            start = time.perf_counter()
+            icon_mngr = db_mngr.get_icon_mngr(db_map)
+            duration += time.perf_counter() - start
+            assert isinstance(icon_mngr, SpineDBIconManager)
+    return duration
+
+
+def run_benchmark(output_file: Optional[str]):
+    if not QApplication.instance():
+        QApplication()
+    db_mngr = SpineDBManager(QSettings(), parent=None)
+    inner_loops = 10
+    db_maps = [DatabaseMapping("sqlite://", create=True) for _ in range(inner_loops)]
+    runner = pyperf.Runner()
+    benchmark = runner.bench_time_func(
+        "SpineDBManager.get_icon_mngr[always different db map]",
+        db_mngr_get_icon_mngr,
+        db_mngr,
+        db_maps,
+        inner_loops=inner_loops,
+    )
+    if output_file:
+        pyperf.add_runs(output_file, benchmark)
+    db_maps = inner_loops * [DatabaseMapping("sqlite://", create=True)]
+    benchmark = runner.bench_time_func(
+        "SpineDBManager.get_icon_mngr[always same db_map]",
+        db_mngr_get_icon_mngr,
+        db_mngr,
+        db_maps,
+        inner_loops=inner_loops,
+    )
+    if output_file:
+        pyperf.add_runs(output_file, benchmark)
+    db_mngr.close_all_sessions()
+    db_mngr.deleteLater()
+
+
+if __name__ == "__main__":
+    run_benchmark(output_file="")

--- a/benchmarks/db_mngr_get_value.py
+++ b/benchmarks/db_mngr_get_value.py
@@ -1,5 +1,5 @@
 """
-This script benchmarks SpineDatabaseManager.get_item().
+This script benchmarks SpineDBManager.get_item().
 """
 import os
 import sys
@@ -58,7 +58,7 @@ def run_benchmark(output_file: Optional[str]):
         value_items.append(item)
     runner = pyperf.Runner()
     benchmark = runner.bench_time_func(
-        "SpineDatabaseManager.get_value[parameter_value, DisplayRole]",
+        "SpineDBManager.get_value[parameter_value, DisplayRole]",
         db_mngr_get_value,
         db_mngr,
         db_map,

--- a/spinetoolbox/fetch_parent.py
+++ b/spinetoolbox/fetch_parent.py
@@ -154,10 +154,10 @@ class FetchParent(QObject):
         """Returns the key for this parent in the index.
 
         Args:
-            db_map (DiffDatabaseMapping)
+            db_map (DatabaseMapping)
 
         Returns:
-            any
+            Any
         """
         return None
 
@@ -171,7 +171,7 @@ class FetchParent(QObject):
 
         Args:
             item (dict): The item
-            db_map (DiffDatabaseMapping)
+            db_map (DatabaseMapping)
 
         Returns:
             bool
@@ -185,7 +185,7 @@ class FetchParent(QObject):
 
         Args:
             item (dict): The item
-            db_map (DiffDatabaseMapping)
+            db_map (DatabaseMapping)
 
         Returns:
             bool
@@ -237,7 +237,7 @@ class FetchParent(QObject):
         Called by SpineDBWorker when items are added to the DB.
 
         Args:
-            db_map_data (dict): Mapping DiffDatabaseMapping instances to list of dict-items for which
+            db_map_data (dict): Mapping DatabaseMapping instances to list of dict-items for which
                 ``accepts_item()`` returns True.
         """
         raise NotImplementedError(self.fetch_item_type)
@@ -247,7 +247,7 @@ class FetchParent(QObject):
         Called by SpineDBWorker when items are removed from the DB.
 
         Args:
-            db_map_data (dict): Mapping DiffDatabaseMapping instances to list of dict-items for which
+            db_map_data (dict): Mapping DatabaseMapping instances to list of dict-items for which
                 ``accepts_item()`` returns True.
         """
         raise NotImplementedError(self.fetch_item_type)
@@ -257,7 +257,7 @@ class FetchParent(QObject):
         Called by SpineDBWorker when items are updated in the DB.
 
         Args:
-            db_map_data (dict): Mapping DiffDatabaseMapping instances to list of dict-items for which
+            db_map_data (dict): Mapping DatabaseMapping instances to list of dict-items for which
                 ``accepts_item()`` returns True.
         """
         raise NotImplementedError(self.fetch_item_type)

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -314,6 +314,8 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
             db_map_data (dict): list of added dict-items keyed by DatabaseMapping
         """
         for db_map, items in db_map_data.items():
+            if db_map not in self.db_maps:
+                continue
             db_map_single_models = [m for m in self.single_models if m.db_map is db_map]
             existing_ids = set().union(*(m.item_ids() for m in db_map_single_models))
             items_per_class = self._items_per_class(items)
@@ -372,6 +374,8 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
         Args:
             db_map_data (dict): list of updated dict-items keyed by DatabaseMapping
         """
+        if all(db_map not in self.db_maps for db_map in db_map_data):
+            return
         self.dataChanged.emit(
             self.index(0, 0), self.index(self.rowCount() - 1, self.columnCount() - 1), [Qt.ItemDataRole.DisplayRole]
         )
@@ -385,6 +389,8 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
         """
         self.layoutAboutToBeChanged.emit()
         for db_map, items in db_map_data.items():
+            if db_map not in self.db_maps:
+                continue
             items_per_class = self._items_per_class(items)
             emptied_single_model_indexes = []
             for model_index, model in enumerate(self.single_models):

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -814,7 +814,6 @@ class SpineDBEditorBase(QMainWindow):
     def save_window_state(self):
         """Saves window state parameters (size, position, state) via QSettings."""
         if not self.db_maps or len(self.db_urls) != 1:
-            print(9)
             # Only save window sates of single db tabs
             return
         self.qsettings.beginGroup(self.settings_group)

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -673,6 +673,7 @@ class SpineDBManager(QObject):
             db_map (DatabaseMapping): database map
             entity_class_id (int): entity class id
             for_group (bool): if True, return the group object icon instead
+            color (QColor, optional): icon color
 
         Returns:
             QSvgRenderer: requested renderer or None if no entity class was found


### PR DESCRIPTION
Compound table models (parameter value, parameter definition and entity alternative tables) now filter out fetched data from databases that are no longer relevant.

Fixes #2709

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
