### PR TITLE
Spine Toolbox changes related to ditching Dagster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Many parts of the Spine data structure have been redesigned.
 
 ### Removed
 - Project dock widget
+- Dependency on Dagster
 
 ### Fixed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@jumpster#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git@0.8-dev#egg=spine_items
+-e git+https://github.com/spine-tools/spine-items.git@issue_2523#egg=spine_items
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
--e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
+-e git+https://github.com/spine-tools/spine-engine.git@jumpster#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git@0.8-dev#egg=spine_items
 -e .

--- a/spinetoolbox/headless.py
+++ b/spinetoolbox/headless.py
@@ -23,7 +23,7 @@ from spine_engine import SpineEngineState
 from spine_engine.exception import EngineInitFailed
 from spine_engine.load_project_items import load_item_specification_factories
 from spine_engine.utils.serialization import deserialize_path
-from spine_engine.utils.helpers import get_file_size
+from spine_engine.utils.helpers import get_file_size, ExecutionDirection
 from spine_engine.server.util.zip_handler import ZipHandler
 from .server.engine_client import EngineClient, RemoteEngineInitFailed, ClientSecurityModel
 from .project_item.logging_connection import HeadlessConnection
@@ -424,7 +424,7 @@ class ActionsWithProject(QObject):
         Args:
             data (dict): execution start data
         """
-        if data["direction"] == "BACKWARD":
+        if data["direction"] == ExecutionDirection.BACKWARD:
             # Currently there are no interesting messages when executing backwards.
             return
         self._node_messages[data["item_name"]] = dict()

--- a/spinetoolbox/project_item/project_item.py
+++ b/spinetoolbox/project_item/project_item.py
@@ -221,7 +221,7 @@ class ProjectItem(LogMixin, MetaObject):
         """Performs item dependent actions after the execution item has finished successfully.
 
         Args:
-            execution_direction (str): "FORWARD" or "BACKWARD"
+            execution_direction (ExecutionDirection): ExecutionDirection.FORWARD or ExecutionDirection.BACKWARD
             engine_state: engine state after item's execution
         """
 

--- a/spinetoolbox/spine_engine_worker.py
+++ b/spinetoolbox/spine_engine_worker.py
@@ -15,6 +15,7 @@ import copy
 from PySide6.QtCore import Signal, Slot, QObject, QThread
 from spine_engine.exception import EngineInitFailed, RemoteEngineInitFailed
 from spine_engine.spine_engine import ItemExecutionFinishState, SpineEngineState
+from spine_engine.utils.helpers import ExecutionDirection
 from .widgets.options_dialog import OptionsDialog
 from .spine_engine_manager import make_engine_manager, LocalSpineEngineManager
 
@@ -34,7 +35,7 @@ def _handle_node_execution_ignored(project_items):
 @Slot(object, object)
 def _handle_node_execution_started(item, direction):
     icon = item.get_icon()
-    if direction == "FORWARD":
+    if direction == ExecutionDirection.FORWARD:
         icon.execution_icon.mark_execution_started()
         if hasattr(icon, "animation_signaller"):
             icon.animation_signaller.animation_started.emit()
@@ -43,7 +44,7 @@ def _handle_node_execution_started(item, direction):
 @Slot(object, object, object, object)
 def _handle_node_execution_finished(item, direction, item_state):
     icon = item.get_icon()
-    if direction == "FORWARD":
+    if direction == ExecutionDirection.FORWARD:
         icon.execution_icon.mark_execution_finished(item_state)
         if hasattr(icon, "animation_signaller"):
             icon.animation_signaller.animation_stopped.emit()

--- a/tests/server/test_RemoteSpineEngineManager.py
+++ b/tests/server/test_RemoteSpineEngineManager.py
@@ -16,6 +16,7 @@ from unittest import mock
 from spinetoolbox.spine_engine_manager import RemoteSpineEngineManager
 from spine_engine import ItemExecutionFinishState
 from spine_engine.server.util.event_data_converter import EventDataConverter
+from spine_engine.utils.helpers import ExecutionDirection
 
 
 class TestRemoteSpineEngineManager(unittest.TestCase):
@@ -62,17 +63,17 @@ class TestRemoteSpineEngineManager(unittest.TestCase):
         # Convert some events fresh from SpineEngine first into
         # (bytes) json strings to simulate events that arrive to EngineClient
         engine_events = [
-            ("exec_started", {"item_name": "Data Connection 1", "direction": "BACKWARD"}),
+            ("exec_started", {"item_name": "Data Connection 1", "direction": ExecutionDirection.BACKWARD}),
             (
                 "exec_finished",
                 {
                     "item_name": "Data Connection 1",
-                    "direction": "BACKWARD",
+                    "direction": ExecutionDirection.BACKWARD,
                     "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.SUCCESS,
                 },
             ),
-            ("exec_started", {"item_name": "Data Connection 1", "direction": "FORWARD"}),
+            ("exec_started", {"item_name": "Data Connection 1", "direction": ExecutionDirection.FORWARD}),
             (
                 "event_msg",
                 {
@@ -86,7 +87,7 @@ class TestRemoteSpineEngineManager(unittest.TestCase):
                 "exec_finished",
                 {
                     "item_name": "Data Connection 1",
-                    "direction": "FORWARD",
+                    "direction": ExecutionDirection.FORWARD,
                     "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.SUCCESS,
                 },
@@ -104,17 +105,17 @@ class TestRemoteSpineEngineManager(unittest.TestCase):
     def yield_events_dag_fails():
         """Received event generator. Yields events that look like they were PULLed from server."""
         engine_events = [
-            ("exec_started", {"item_name": "Data Connection 1", "direction": "BACKWARD"}),
+            ("exec_started", {"item_name": "Data Connection 1", "direction": ExecutionDirection.BACKWARD}),
             (
                 "exec_finished",
                 {
                     "item_name": "Data Connection 1",
-                    "direction": "BACKWARD",
+                    "direction": ExecutionDirection.BACKWARD,
                     "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.FAILURE,
                 },
             ),
-            ("exec_started", {"item_name": "Data Connection 1", "direction": "FORWARD"}),
+            ("exec_started", {"item_name": "Data Connection 1", "direction": ExecutionDirection.FORWARD}),
             (
                 "event_msg",
                 {
@@ -128,7 +129,7 @@ class TestRemoteSpineEngineManager(unittest.TestCase):
                 "exec_finished",
                 {
                     "item_name": "Data Connection 1",
-                    "direction": "FORWARD",
+                    "direction": ExecutionDirection.FORWARD,
                     "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.FAILURE,
                 },


### PR DESCRIPTION
As per title.

To test Spine Toolbox without dagster, checkout branch `issue_2523`, make a fresh conda env and do `pip install -r requirements.txt`.

Re Issue #2523

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
