### PR TITLE
Fix entity tree filtering in Parameter definition/value and Entity alternative tables

### DIFF
--- a/benchmarks/compound_model_filter_accepts_model.py
+++ b/benchmarks/compound_model_filter_accepts_model.py
@@ -1,0 +1,61 @@
+"""
+This script benchmarks CompoundModelBase.filter_accepts_model().
+"""
+import os
+import sys
+
+if sys.platform == "win32" and "HOMEPATH" not in os.environ:
+    import pathlib
+    os.environ["HOMEPATH"] = str(pathlib.Path(sys.executable).parent)
+
+import time
+from typing import Optional
+import pyperf
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication
+from benchmarks.utils import StdOutLogger
+from spinetoolbox.spine_db_manager import SpineDBManager
+from spinetoolbox.spine_db_editor.mvcmodels.compound_models import CompoundModelBase, CompoundParameterValueModel
+from spinetoolbox.spine_db_editor.mvcmodels.single_models import SingleModelBase
+
+
+def call_filter_accepts_model(
+    loops: int, compound_model: CompoundModelBase, single_model: SingleModelBase
+) -> float:
+    duration = 0.0
+    for _ in range(loops):
+        start = time.perf_counter()
+        compound_model.filter_accepts_model(single_model)
+        duration += time.perf_counter() - start
+    return duration
+
+
+def run_benchmark(output_file: Optional[str]):
+    if not QApplication.instance():
+        QApplication()
+    db_mngr = SpineDBManager(QSettings(), parent=None)
+    logger = StdOutLogger()
+    db_map = db_mngr.get_db_map("sqlite://", logger, create=True)
+    entity_class, error = db_map.add_entity_class_item(name="Object")
+    assert error is None
+    db_map.add_entity_class_item(name="Subject")
+    relationship_class, error = db_map.add_entity_class_item(name="Object__Subject", dimension_name_list=("Object", "Subject"))
+    assert error is None
+    compound_model = CompoundParameterValueModel(None, db_mngr, db_map)
+    compound_model.set_filter_class_ids({db_map: {entity_class["id"]}})
+    single_model = SingleModelBase(compound_model, db_map, relationship_class["id"], committed=False)
+    runner = pyperf.Runner()
+    benchmark = runner.bench_time_func(
+        "CompoundModelBase.filter_accepts_model[filter by class ids]",
+        call_filter_accepts_model,
+        compound_model,
+        single_model
+    )
+    if output_file:
+        pyperf.add_runs(output_file, benchmark)
+    db_mngr.close_all_sessions()
+    db_mngr.deleteLater()
+
+
+if __name__ == "__main__":
+    run_benchmark(output_file="")

--- a/benchmarks/db_mngr_get_item.py
+++ b/benchmarks/db_mngr_get_item.py
@@ -1,5 +1,5 @@
 """
-This script benchmarks SpineDBManager.get_value().
+This script benchmarks SpineDBManager.get_item().
 """
 import os
 import sys
@@ -11,22 +11,22 @@ if sys.platform == "win32" and "HOMEPATH" not in os.environ:
 import time
 from typing import Optional, Sequence
 import pyperf
-from PySide6.QtCore import QSettings, Qt
+from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
-from spinedb_api.db_mapping_base import PublicItem
-from spinedb_api import DatabaseMapping, to_database
+from spinedb_api import DatabaseMapping
+from spinedb_api.temp_id import TempId
 from spinetoolbox.spine_db_manager import SpineDBManager
 from benchmarks.utils import StdOutLogger
 
 
 def db_mngr_get_value(
-    loops: int, db_mngr: SpineDBManager, db_map: DatabaseMapping, items: Sequence[PublicItem], role: Qt.ItemDataRole
+    loops: int, db_mngr: SpineDBManager, db_map: DatabaseMapping, item_type, ids: Sequence[TempId]
 ) -> float:
     duration = 0.0
     for _ in range(loops):
-        for item in items:
+        for id_ in ids:
             start = time.perf_counter()
-            db_mngr.get_value(db_map, item, role)
+            db_mngr.get_item(db_map, item_type, id_)
             duration += time.perf_counter() - start
     return duration
 
@@ -37,33 +37,21 @@ def run_benchmark(output_file: Optional[str]):
     db_mngr = SpineDBManager(QSettings(), parent=None)
     logger = StdOutLogger()
     db_map = db_mngr.get_db_map("sqlite://", logger, create=True)
-    db_map.add_entity_class_item(name="Object")
-    db_map.add_parameter_definition_item(name="x", entity_class_name="Object")
-    db_map.add_entity_item(name="object", entity_class_name="Object")
-    value_items = []
-    for i in range(100):
-        alternative_name = str(i)
-        db_map.add_alternative_item(name=str(i))
-        value, value_type = to_database(i)
-        item, error = db_map.add_parameter_value_item(
-            entity_class_name="Object",
-            parameter_definition_name="x",
-            entity_byname=("object",),
-            alternative_name=alternative_name,
-            value=value,
-            type=value_type,
-        )
+    inner_loops = 10
+    ids = []
+    for i in range(inner_loops):
+        item, error = db_map.add_entity_class_item(name=str(i))
         assert error is None
-        value_items.append(item)
+        ids.append(item["id"])
     runner = pyperf.Runner()
     benchmark = runner.bench_time_func(
         "SpineDBManager.get_value[parameter_value, DisplayRole]",
         db_mngr_get_value,
         db_mngr,
         db_map,
-        value_items,
-        Qt.ItemDataRole.DisplayRole,
-        inner_loops=len(value_items),
+        "entity_class",
+        ids,
+        inner_loops=inner_loops,
     )
     if output_file:
         pyperf.add_runs(output_file, benchmark)

--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -293,7 +293,14 @@ class MinimalTreeModel(QAbstractItemModel):
             current = parent_item
 
     def item_from_index(self, index):
-        """Return the item corresponding to the given index."""
+        """Return the item corresponding to the given index.
+
+        Args:
+            index (QModelIndex): model index
+
+        Returns:
+            TreeItem: item at index
+        """
         if index.isValid():
             return index.internalPointer()
         return self._invisible_root_item

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -164,7 +164,7 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
         """Returns a boolean indicating whether the given model passes the filter for compound model.
 
         Args:
-            model (SingleParameterModel, EmptyParameterModel)
+            model (SingleModelBase or EmptyModelBase)
 
         Returns:
             bool
@@ -180,9 +180,8 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
     def _class_filter_accepts_model(self, model):
         if not self._filter_class_ids:
             return True
-        return model.entity_class_id in self._filter_class_ids.get(model.db_map, set()) or bool(
-            set(model.dimension_id_list) & self._filter_class_ids.get(model.db_map, set())
-        )
+        class_ids = self._filter_class_ids.get(model.db_map, set())
+        return model.entity_class_id in class_ids or bool(set(model.dimension_id_list) & class_ids)
 
     def _auto_filter_accepts_model(self, model):
         if None in self._auto_filter.values():

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -22,8 +22,7 @@ class EmptyModelBase(EmptyRowModel):
     """Base class for all empty models that go in a CompoundModelBase subclass."""
 
     def __init__(self, parent):
-        """Initialize class.
-
+        """
         Args:
             parent (CompoundModelBase): the parent model
         """

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_models.py
@@ -12,6 +12,7 @@
 
 """Models to represent entities in a tree."""
 from .entity_tree_item import EntityTreeRootItem
+from .multi_db_tree_item import MultiDBTreeItem
 from .multi_db_tree_model import MultiDBTreeModel
 
 
@@ -69,3 +70,25 @@ class EntityTreeModel(MultiDBTreeModel):
             return
         self._hide_empty_classes = hide_empty_classes
         self.root_item.refresh_child_map()
+
+
+def group_items_by_db_map(indexes):
+    """Groups items from given tree indexes by db map.
+
+    Args:
+        indexes (Iterable of QModelIndex): index to entity tree model
+
+    Returns:
+        dict: lists of dictionary items keyed by DatabaseMapping
+    """
+    d = {}
+    for index in indexes:
+        model = index.model()
+        if model is None:
+            continue
+        item = model.item_from_index(index)
+        if item.item_type == "root":
+            continue
+        for db_map in item.db_maps:
+            d.setdefault(db_map, []).append(item.db_map_data(db_map))
+    return d

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -45,8 +45,7 @@ class SingleModelBase(HalfSortedTableModel):
     """Base class for all single models that go in a CompoundModelBase subclass."""
 
     def __init__(self, parent, db_map, entity_class_id, committed, lazy=False):
-        """Init class.
-
+        """
         Args:
             parent (CompoundModelBase): the parent model
             db_map (DatabaseMapping)

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -704,6 +704,7 @@ class ManageElementsDialog(AddEntitiesOrManageElementsDialog):
             items = [QTreeWidgetItem([DB_ITEM_SEPARATOR.join(el["entity_byname"])]) for el in elements]
             tree_widget.addTopLevelItems(items)
             tree_widget.resizeColumnToContents(0)
+            tree_widget.setMinimumWidth(tree_widget.columnWidth(0) + 10)
             self.splitter.addWidget(tree_widget)
         sizes = [wg.columnWidth(0) for wg in self.splitter_widgets()]
         self.splitter.setSizes(sizes)

--- a/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
@@ -43,8 +43,7 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
     """A dialog to query user's preferences for updating entity classes."""
 
     def __init__(self, parent, db_mngr, selected):
-        """Init class.
-
+        """
         Args:
             parent (SpineDBEditor): data store widget
             db_mngr (SpineDBManager): the manager to do the update
@@ -124,8 +123,7 @@ class EditEntitiesDialog(GetEntityClassesMixin, GetEntitiesMixin, EditOrRemoveIt
     """A dialog to query user's preferences for updating entities."""
 
     def __init__(self, parent, db_mngr, selected, class_key):
-        """Init class.
-
+        """
         Args:
             parent (SpineDBEditor): data store widget
             db_mngr (SpineDBManager): the manager to do the update

--- a/spinetoolbox/spine_db_editor/widgets/element_name_list_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/element_name_list_editor.py
@@ -10,8 +10,8 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""Contains the ObjectNameListEditor class."""
-from PySide6.QtCore import Qt, Slot, Signal, QEvent, QCoreApplication
+"""Contains the ElementNameListEditor class."""
+from PySide6.QtCore import QModelIndex, Qt, Slot, Signal, QEvent, QCoreApplication
 from PySide6.QtWidgets import QItemDelegate
 from PySide6.QtGui import QStandardItemModel, QStandardItem
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
@@ -22,7 +22,7 @@ from spinetoolbox.spine_db_editor.widgets.custom_editors import SearchBarEditor
 class SearchBarDelegate(QItemDelegate):
     """A custom delegate to use with ElementNameListEditor."""
 
-    data_committed = Signal("QModelIndex", "QVariant")
+    data_committed = Signal(QModelIndex, object)
 
     def setModelData(self, editor, model, index):
         model.setData(index, editor.data())
@@ -53,8 +53,7 @@ class ElementNameListEditor(ManageItemsDialog):
     """A dialog to select the element name list for an entity using Google-like search bars."""
 
     def __init__(self, parent, index, entity_class_names, entity_byname_lists, current_element_byname_list):
-        """Initializes widget.
-
+        """
         Args:
             parent (SpineDBEditor)
             index (QModelIndex)

--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -10,7 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""Classes for custom QDialogs to add edit and remove database items."""
+"""Classes for custom QDialogs to add, edit and remove database items."""
 from functools import reduce, cached_property
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QGridLayout
 from PySide6.QtCore import Slot, Qt, QModelIndex

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -20,6 +20,7 @@ from ..mvcmodels.compound_models import (
     CompoundParameterDefinitionModel,
     CompoundEntityAlternativeModel,
 )
+from ..mvcmodels.entity_tree_models import group_items_by_db_map
 from ...helpers import preferred_row_height, DB_ITEM_SEPARATOR
 
 
@@ -159,14 +160,19 @@ class StackedViewMixin:
     @Slot(dict)
     def _handle_entity_tree_selection_changed_in_parameter_tables(self, selected_indexes):
         """Resets filter according to entity tree selection."""
-        ent_inds = set(selected_indexes.get("entity", {}).keys())
-        ent_cls_inds = set(selected_indexes.get("entity_class", {}).keys()) | {
+        entity_indexes = set(selected_indexes.get("entity", {}).keys())
+        entity_indexes |= {
+            parent
+            for parent in (i.parent() for i in entity_indexes)
+            if self.entity_tree_model.item_from_index(parent).item_type == "entity"
+        }
+        entity_class_indexes = set(selected_indexes.get("entity_class", {}).keys()) | {
             parent_ind
-            for parent_ind in (ind.parent() for ind in ent_inds)
+            for parent_ind in (ind.parent() for ind in entity_indexes)
             if self.entity_tree_model.item_from_index(parent_ind).item_type == "entity_class"
         }
-        self._filter_class_ids = self._db_map_ids(ent_cls_inds)
-        self._filter_entity_ids = self._db_map_class_ids(ent_inds)
+        self._filter_class_ids = self._db_map_ids(entity_class_indexes)
+        self._filter_entity_ids = self.db_mngr.db_map_class_ids(group_items_by_db_map(entity_indexes))
         if Qt.KeyboardModifier.ControlModifier not in QGuiApplication.keyboardModifiers():
             self._filter_alternative_ids.clear()
             self._clear_all_other_selections(self.ui.treeView_entity)

--- a/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tree_view_mixin.py
@@ -28,7 +28,7 @@ from .edit_or_remove_items_dialogs import (
 from ..mvcmodels.parameter_value_list_model import ParameterValueListModel
 from ..mvcmodels.alternative_model import AlternativeModel
 from ..mvcmodels.scenario_model import ScenarioModel
-from ..mvcmodels.entity_tree_models import EntityTreeModel
+from ..mvcmodels.entity_tree_models import EntityTreeModel, group_items_by_db_map
 from ...spine_db_parcel import SpineDBParcel
 
 
@@ -68,29 +68,8 @@ class TreeViewMixin:
                 index = view.model().index_from_item(item)
                 view.expand(index)
 
-    @staticmethod
-    def _db_map_items(indexes):
-        """Groups items from given tree indexes by db map.
-
-        Returns:
-            dict: lists of dictionary items keyed by DiffDatabaseMapping
-        """
-        d = {}
-        for index in indexes:
-            if index.model() is None:
-                continue
-            item = index.model().item_from_index(index)
-            if item.item_type == "root":
-                continue
-            for db_map in item.db_maps:
-                d.setdefault(db_map, []).append(item.db_map_data(db_map))
-        return d
-
     def _db_map_ids(self, indexes):
-        return self.db_mngr.db_map_ids(self._db_map_items(indexes))
-
-    def _db_map_class_ids(self, indexes):
-        return self.db_mngr.db_map_class_ids(self._db_map_items(indexes))
+        return self.db_mngr.db_map_ids(group_items_by_db_map(indexes))
 
     def export_selected(self, selected_indexes):
         """Exports data from given indexes in the entity tree."""

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -710,12 +710,13 @@ class SpineDBManager(QObject):
         Args:
             db_map (DatabaseMapping)
             item_type (str)
-            id_ (int)
+            id_ (TempId)
 
         Returns:
             PublicItem: the item
         """
-        return db_map.get_item(item_type, id=id_)
+        mapped_table = db_map.mapped_table(item_type)
+        return mapped_table.find_item_by_id(id_)
 
     def get_field(self, db_map, item_type, id_, field):
         return self.get_item(db_map, item_type, id_).get(field)


### PR DESCRIPTION
This PR fixes a bug where the Parameter value table (and perhaps Entity alternative table as well) showed unrelated entities when an entity was selected beyond the first level of entities.

Fixes #2719

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
