### PR TITLE
Fix Execute project button enabled state at project loading

### DIFF
--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -594,7 +594,6 @@ class ToolboxUI(QMainWindow):
             logger=self,
         )
         self.specification_model.connect_to_project(self._project)
-        self._enable_project_actions()
         self.ui.actionSave.setDisabled(True)  # Save is disabled in a clean project
         self._connect_project_signals()
         self.update_window_title()
@@ -603,6 +602,7 @@ class ToolboxUI(QMainWindow):
         if not success:
             self.remove_path_from_recent_projects(self._project.project_dir)
             return False
+        self._enable_project_actions()
         self._plugin_manager.reload_plugins_with_local_data()
         # Reset zoom on Design View
         self.ui.graphicsView.reset_zoom()

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -11,6 +11,8 @@
 ######################################################################################################################
 
 """Unit tests for ToolboxUI class."""
+import json
+import pathlib
 from pathlib import Path
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
@@ -738,6 +740,21 @@ class TestToolboxUI(unittest.TestCase):
         self.assertIn("mainWindow/windowMaximized", saved_dict)
         self.assertIn("mainWindow/n_screens", saved_dict)
         self.assertIn("appSettings/toolbarIconOrdering", saved_dict)
+
+    def test_enable_execute_all_project_setting_is_respected(self):
+        with TemporaryDirectory() as temp_dir:
+            with mock.patch.object(self.toolbox, "_qsettings"):
+                self.toolbox.create_project(temp_dir)
+            self.toolbox.close_project(ask_confirmation=False)
+            project_json = pathlib.Path(temp_dir) / ".spinetoolbox" / "project.json"
+            self.assertTrue(project_json.is_file())
+            with open(project_json) as project_file:
+                project_data = json.load(project_file)
+            project_data["project"]["settings"]["enable_execute_all"] = False
+            with open(project_json, "w") as project_file:
+                json.dump(project_data, project_file)
+            self.toolbox.open_project(temp_dir)
+            self.assertFalse(self.toolbox.ui.actionExecute_project.isEnabled())
 
     @staticmethod
     def find_click_point_of_pi(pi, gv):


### PR DESCRIPTION
"Execute project" button now respects the `enable_execute_all` project setting.

Fixes #2734

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
~- [ ] Code has been formatted by black~ Cannot run `black` at the moment.
- [x] Unit tests pass
