### PR TITLE
Fix N-D entity class icons always using default icons

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -610,7 +610,7 @@ def interpret_icon_id(display_icon):
         tuple: icon's code, color code
     """
     if not isinstance(display_icon, int) or display_icon < 0:
-        return 0xF1B2, 0
+        return 0xF1B2, 0xFF000000
     icon_code = display_icon & 65535
     try:
         color_code = display_icon >> 16

--- a/spinetoolbox/spine_db_editor/widgets/custom_editors.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_editors.py
@@ -453,6 +453,8 @@ class _IconPainterDelegate(QStyledItemDelegate):
 class IconColorEditor(QDialog):
     """An editor to let the user select an icon and a color for an object_class."""
 
+    reset_pressed = Signal(object)
+
     def __init__(self, parent):
         """
         Args:
@@ -482,13 +484,20 @@ class IconColorEditor(QDialog):
         self.color_dialog.setOption(QColorDialog.DontUseNativeDialog, True)
         self.button_box = QDialogButtonBox(self)
         self.button_box.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        self.button_box_reset = QDialogButtonBox(self)
+        self.button_box_reset.setStandardButtons(QDialogButtonBox.StandardButton.Reset)
+        self.button_box_reset.setToolTip("Resets to default icon and closes the window.")
         top_widget = QWidget(self)
         top_layout = QHBoxLayout(top_widget)
         top_layout.addWidget(self.icon_widget)
         top_layout.addWidget(self.color_dialog)
+        bottom_widget = QWidget(self)
+        bottom_layout = QHBoxLayout(bottom_widget)
+        bottom_layout.addWidget(self.button_box_reset)
+        bottom_layout.addWidget(self.button_box)
         layout = QVBoxLayout(self)
         layout.addWidget(top_widget)
-        layout.addWidget(self.button_box)
+        layout.addWidget(bottom_widget)
         self.proxy_model = QSortFilterProxyModel(self)
         self.proxy_model.setSourceModel(self.icon_mngr.model)
         self.proxy_model.filterAcceptsRow = self._proxy_model_filter_accepts_row
@@ -517,6 +526,7 @@ class IconColorEditor(QDialog):
         self.line_edit.textEdited.connect(self.proxy_model.invalidateFilter)
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
+        self.button_box_reset.clicked.connect(lambda: self.reset_pressed.emit(self))
 
     def set_data(self, data):
         """Sets current icon data.

--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -262,9 +262,16 @@ class GetEntitiesMixin:
 class ShowIconColorEditorMixin:
     """Provides methods to show an `IconColorEditor` upon request."""
 
+    @Slot(object)
+    def reset_data(self, editor):
+        """Resets the editors selections to the default state and closes the editor"""
+        editor.set_data(None)
+        editor.accept()
+
     @busy_effect
     def show_icon_color_editor(self, index):
         editor = IconColorEditor(self)
         editor.set_data(index.data(Qt.ItemDataRole.DisplayRole))
         editor.accepted.connect(lambda index=index, editor=editor: self.set_model_data(index, editor.data()))
+        editor.reset_pressed.connect(self.reset_data)
         editor.show()

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -266,6 +266,7 @@ class SpineDBWorker(QObject):
         items, errors = self._db_map.remove_items(item_type, *ids, check=check)
         if errors:
             self._db_mngr.error_msg.emit({self._db_map: errors})
+        self._db_mngr.update_icons(self._db_map, item_type, items)
         self._db_mngr.items_removed.emit(item_type, {self._db_map: items})
         return items
 

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -266,7 +266,6 @@ class SpineDBWorker(QObject):
         items, errors = self._db_map.remove_items(item_type, *ids, check=check)
         if errors:
             self._db_mngr.error_msg.emit({self._db_map: errors})
-        self._db_mngr.update_icons(self._db_map, item_type, items)
         self._db_mngr.items_removed.emit(item_type, {self._db_map: items})
         return items
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -85,7 +85,7 @@ class TestHelpers(unittest.TestCase):
     def test_interpret_icon_id(self):
         icon_code, color_code = interpret_icon_id(None)
         self.assertEqual(icon_code, 0xF1B2)
-        self.assertEqual(color_code, 0)
+        self.assertEqual(color_code, 0xFF000000)
         icon_code, color_code = interpret_icon_id(3 + (7 << 16))
         self.assertEqual(icon_code, 3)
         self.assertEqual(color_code, 7)


### PR DESCRIPTION
Second try for #2729.

- N-D entity classes can now again have user defined icons.
- Added a reset button to the icon editor. It resets the selections to the defaults and closes the editor. The button allows N-D entity classes to go back to using the composite icon.

Fixes #2582

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
