### PR TITLE
Add possibility to copy icon display id from class editor

### DIFF
--- a/docs/source/spine_db_editor/adding_data.rst
+++ b/docs/source/spine_db_editor/adding_data.rst
@@ -47,6 +47,10 @@ representation of the class can be modified:
 .. image:: img/entity_icon_editor.png
    :align: center
 
+This editor can also be opened by right clicking on the corresponding cell and selecting *Open display icon editor*.
+From the right click context menu, the display icon id can also be copied. This might be useful if there is a need
+to have multiple classes use the same icon, since the value can just be pasted into the cells.
+
 The boolean value of **active by default** will determine whether the entities created under the created class
 will have the value under entity alternative set as true or false by default. Finally, select the databases where
 you want to add the entity classes under **databases**.

--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -12,7 +12,7 @@
 
 """Classes for custom QDialogs to add, edit and remove database items."""
 from functools import reduce, cached_property
-from PySide6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QGridLayout
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QGridLayout, QMenu, QApplication
 from PySide6.QtCore import Slot, Qt, QModelIndex
 from PySide6.QtGui import QAction
 from ..mvcmodels.entity_tree_item import EntityClassItem
@@ -275,3 +275,19 @@ class ShowIconColorEditorMixin:
         editor.accepted.connect(lambda index=index, editor=editor: self.set_model_data(index, editor.data()))
         editor.reset_pressed.connect(self.reset_data)
         editor.show()
+
+    def contextMenuEvent(self, event):
+        """Shows the context menu for the display icon."""
+        pos = self.table_view.viewport().mapFromGlobal(event.globalPos())
+        index = self.table_view.indexAt(pos)
+        if not index.isValid():
+            return
+        if index.column() != 2:
+            super().contextMenuEvent(event)
+            return
+        menu = QMenu(self)
+        menu.addAction("Open display icon editor", lambda: self.show_icon_color_editor(index))
+        data = self.model.data(index)
+        menu.addAction("Copy display icon id", lambda: QApplication.clipboard().setText(str(data)))
+        menu.exec(event.globalPos())
+        super().contextMenuEvent(event)


### PR DESCRIPTION
Added a right click context menu to the entity class editor. From the context menu the icon editor can be opened, or the display icon id can be copied to the clipboard.

Fixes #2320

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
