### PR TITLE
Fix traceback from delete in Select elements -dialog

### DIFF
--- a/spinetoolbox/widgets/custom_qtableview.py
+++ b/spinetoolbox/widgets/custom_qtableview.py
@@ -92,6 +92,8 @@ class CopyPasteTableView(QTableView):
     @Slot(bool)
     def delete_content(self, _=False):
         """Deletes content from editable indexes in current selection."""
+        if not hasattr(self.model(), "batch_set_data"):
+            return False
         selection = self.selectionModel().selection()
         if not selection:
             return False


### PR DESCRIPTION
No more traceback from pressing delete on Select elements -dialog.

Fixes #2758

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
