### PR TITLE
Fix setting fetch parents obsolete on DB editor close

### DIFF
--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -241,8 +241,7 @@ class MinimalTreeModel(QAbstractItemModel):
     """Base class for all tree models."""
 
     def __init__(self, parent):
-        """Init class.
-
+        """
         Args:
             parent (SpineDBEditor)
         """

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_model_base.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_model_base.py
@@ -11,7 +11,7 @@
 ######################################################################################################################
 
 """Models to represent things in a tree."""
-from PySide6.QtCore import QObject, Qt, QModelIndex, Slot
+from PySide6.QtCore import Qt, QModelIndex
 from spinetoolbox.mvcmodels.minimal_tree_model import MinimalTreeModel
 from .tree_item_utility import StandardTreeItem
 
@@ -30,7 +30,7 @@ class TreeModelBase(MinimalTreeModel):
         self.db_editor = db_editor
         self.db_mngr = db_mngr
         self.db_maps = db_maps
-        self.destroyed.connect(self._tear_down_tree)
+        self.destroyed.connect(lambda _: self._tear_down_tree)
 
     def columnCount(self, parent=QModelIndex()):
         """Returns the number of columns under the given parent. Always 2.
@@ -67,7 +67,6 @@ class TreeModelBase(MinimalTreeModel):
     def db_row(self, item):
         return self.db_item(item).child_number()
 
-    @Slot(QObject)
-    def _tear_down_tree(self, obj=None):
+    def _tear_down_tree(self):
         """Tears down tree items recursively"""
         self._invisible_root_item.tear_down_recursively()

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -36,7 +36,7 @@ class _TestBase(unittest.TestCase):
         for item in model.visit_all():
             while item.can_fetch_more():
                 item.fetch_more()
-                qApp.processEvents()
+                QApplication.processEvents()
 
 
 class TestScenarioModel(_TestBase):


### PR DESCRIPTION
This fixes a bug where the fetch parents of Alternative and Scenario models were not properly set as obsolete on DB editor close.

Fixes #2742

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
