### PR TITLE
Add GitHub Action to manually bundle specific Git tag

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -1,54 +1,12 @@
-name: PyInstaller Bundle
+name: Scheduled PyInstaller Bundle
 
 on:
   schedule:
     - cron: "15 9 * * 2"
 
 jobs:
-  bundle:
-    name: Bundle
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-      - name: Run tests
-        run: |
-          python -m unittest discover --verbose
-      - name: Install PyInstaller
-        run: |
-          python -m pip install PyInstaller
-      - name: Download embeddable Python
-        run: |
-          mkdir embedded-python
-          cd embedded-python
-          curl -o python.zip https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip
-          tar xf python.zip
-          del python.zip
-      - name: Build bundle
-        run: |
-          python -m PyInstaller spinetoolbox.spec -- --embedded-python=embedded-python
-      - name: Get Toolbox version
-        id: toolbox-version
-        shell: bash
-        run: |
-          python -c "from importlib.metadata import version; print('version=' + version('spinetoolbox'))" >> $GITHUB_OUTPUT
-      - name: Upload archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: Spine Toolbox ${{ steps.toolbox-version.outputs.version }}
-          path: dist
-          if-no-files-found: error
-          overwrite: true
+  call-make-bundle:
+    uses: ./.github/workflows/make_bundle.yml
   update-downloads-page:
     name: Trigger Downloads page generation
     needs: bundle

--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -1,0 +1,57 @@
+name: Make PyInstaller Bundle
+
+on:
+  workflow_call:
+    inputs:
+      git-ref:
+        description: "Git branch, tag or SHA to bundle."
+        required: true
+        type: string
+        default: ""
+
+jobs:
+  bundle:
+    name: Bundle
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-ref }}
+          fetch-depth: 0
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          python -m unittest discover --verbose
+      - name: Install PyInstaller
+        run: |
+          python -m pip install PyInstaller
+      - name: Download embeddable Python
+        run: |
+          mkdir embedded-python
+          cd embedded-python
+          curl -o python.zip https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip
+          tar xf python.zip
+          del python.zip
+      - name: Build bundle
+        run: |
+          python -m PyInstaller spinetoolbox.spec -- --embedded-python=embedded-python
+      - name: Get Toolbox version
+        id: toolbox-version
+        shell: bash
+        run: |
+          python -c "from importlib.metadata import version; print('version=' + version('spinetoolbox'))" >> $GITHUB_OUTPUT
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: Spine Toolbox ${{ steps.toolbox-version.outputs.version }}
+          path: dist
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/manual_bundling.yml
+++ b/.github/workflows/manual_bundling.yml
@@ -1,0 +1,15 @@
+name: PyInstaller Bundle of Specific Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to bundle"
+        required: true
+        type: string
+
+jobs:
+  call-make-bundle:
+    uses: ./.github/workflows/make_bundle.yml
+    with:
+      git-ref: ${{ inputs.tag }}


### PR DESCRIPTION
This allows bundling version tags so we can attach the resulting artifact to a release in GitHub.

No associated issue
