### PR TITLE
Print error on logs if Specification loading fails

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1207,7 +1207,10 @@ def load_specification_from_file(spec_path, local_data_dict, spec_factories, app
     if spec_dict is None:
         return None
     spec_dict["definition_file_path"] = spec_path
-    spec = specification_from_dict(spec_dict, local_data_dict, spec_factories, app_settings, logger)
+    try:
+        spec = specification_from_dict(spec_dict, local_data_dict, spec_factories, app_settings, logger)
+    except KeyError:
+        spec = None
     if spec is not None:
         spec.definition_file_path = spec_path
     return spec

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -1063,6 +1063,7 @@ class ToolboxUI(QMainWindow):
             def_file, local_data, self._item_specification_factories, self._qsettings, self
         )
         if not specification:
+            self.msg_error.emit("Failed to load specification.")
             return
         self.undo_stack.push(AddSpecificationCommand(self._project, specification, save_to_disk=False))
 


### PR DESCRIPTION
Instead of Tracebacking, we now print an error message to the logs at least.

Re #2760

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
