### PR TITLE
Enable support for Python 3.12

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -21,8 +21,11 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -37,7 +40,7 @@ jobs:
         run: |
           mkdir embedded-python
           cd embedded-python
-          curl -o python.zip https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip
+          curl -o python.zip https://www.python.org/ftp/python/3.12.3/python-3.12.3-embed-amd64.zip
           tar xf python.zip
           del python.zip
       - name: Build bundle

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [windows-latest, ubuntu-22.04]
     steps:
     - uses: actions/checkout@v4
@@ -32,8 +32,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
-          requirements.txt
           pyproject.toml
+          requirements.txt
+          dev-requirements.txt
     - name: Display Python version
       run:
          python -c "import sys; print(sys.version)"
@@ -48,16 +49,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
     - name: List packages
       run:
         python -m pip list
-    - name: Install python3 kernelspecs
-      run: |
-        python -m pip install ipykernel
-        python -m ipykernel install --user
-    - name: Install coverage
-      run:
-        python -m pip install coverage[toml]
     - name: Run tests
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then
@@ -75,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [windows-latest, ubuntu-22.04]
 #    needs: unit-tests
     steps:
@@ -86,8 +81,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
-          requirements.txt
           pyproject.toml
+          requirements.txt
+          dev-requirements.txt
     - name: Install additional packages for Linux
       if: runner.os == 'Linux'
       run: |
@@ -99,6 +95,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
     - name: List packages
       run: 
         python -m pip list

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spine Toolbox
 Link to the documentation: [https://spine-toolbox.readthedocs.io/en/latest/?badge=latest](https://spine-toolbox.readthedocs.io/en/latest/?badge=latest)
 
-[![Python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11-blue.svg)](https://www.python.org/downloads/release/python-379/)
+[![Python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11|%203.12-blue.svg)](https://www.python.org/downloads/release/python-379/)
 [![Documentation Status](https://readthedocs.org/projects/spine-toolbox/badge/?version=latest)](https://spine-toolbox.readthedocs.io/en/latest/?badge=latest)
 [![Test suite](https://github.com/spine-tools/Spine-Toolbox/actions/workflows/test_runner.yml/badge.svg)](https://github.com/spine-tools/Spine-Toolbox/actions/workflows/test_runner.yml)
 [![codecov](https://codecov.io/gh/spine-tools/Spine-Toolbox/branch/master/graph/badge.svg)](https://codecov.io/gh/spine-tools/Spine-Toolbox)
@@ -17,15 +17,6 @@ You can have your local workflow, but work as a team through version control and
     <img alt="Spine Toolbox" src="./fig/spinetoolbox_on_wht.svg" width="50%">
   </picture>
 </p>
-
-## Programming language
-
-- Python 3.8*
-- Python 3.9
-- Python 3.10
-- Python 3.11
-
-*Python 3.8.0 is not supported (use Python 3.8.1 or later).<br>
 
 ## License
 
@@ -58,8 +49,8 @@ the Pre-installation steps**:
 These steps apply to both [Python/pipx](#installation-with-python-and-pipx) option and to 
 [From source files](#installation-from-sources-using-git) option.
 
-1. If you don't have Python installed, please install e.g. **Python 3.11** from 
-[Python.org](https://www.python.org/downloads/release/python-3117/).
+1. If you don't have Python installed, please install it e.g. from 
+[Python.org](https://www.python.org/downloads/).
 
 2. Test that python is now in your PATH. Open a new terminal (e.g. Command Prompt) window and type 
 
@@ -249,7 +240,7 @@ run it, and follow the instructions to install Spine Toolbox.
 
 ### About requirements
 
-Python 3.8.1-3.11 is required. Python 3.8.0 is not supported due to problems in DLL loading on Windows.
+Python 3.8.1 or later is required. Python 3.8.0 is not supported due to problems in DLL loading on Windows.
 
 See the files `pyproject.toml` and `requirements.txt` for packages required to run Spine Toolbox.
 (Additional packages needed for development are listed in `dev-requirements.txt`.)
@@ -263,13 +254,13 @@ The requirements include three packages ([`spinedb_api`](https://github.com/spin
 You can find the latest documentation on [readthedocs](https://spine-toolbox.readthedocs.io/en/latest/index.html).
 If you want to build the documentation yourself,
 source files for the User Guide can be found in `docs/source` directory. In order to 
-build the HTML docs, you need to install the *optional requirements* (see section 
-'Installing requirements' above). This installs Sphinx (among other things), which 
+build the HTML docs, you need to install the *development requirements* (see section 
+'About requirements' above). This installs Sphinx (among other things), which 
 is required in building the documentation. When Sphinx is installed, you can build the 
 HTML pages from the user guide source files by using the `bin/build_doc.bat` script on 
-Windows or the `bin/build_doc.sh` script on Linux and Mac. After running the script, the 
+Windows or the `bin/build_doc.py` script on Linux and Mac. After running the script, the 
 index page can be found in `docs/build/html/index.html`. The User Guide can also 
-be opened from Spine Toolbox menu Help->User Guide (F2).
+be opened from Spine Toolbox menu Help->User Guide (F1).
 
 ### Troubleshooting
 
@@ -282,7 +273,7 @@ also [Problems in starting the application](#problems-in-starting-the-applicatio
 
 #### Installation fails
 
-Please make sure you are using Python 3.8, 3.9, 3.10, or 3.11 to install the requirements.
+Please make sure you are using Python 3.8.1 or later to install the requirements.
 
 #### 'No Python' error when installing with pipx
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,9 @@
-black == 24.4.2
-pre-commit == 2.0.1
-PyYAML >= 5.4
-pylint >= 2.3.0
-setuptools >=64
-setuptools_scm[toml] >= 6.2
-build
-wheel >=0.36.2
-twine >= 3.4.1
 coverage[toml]
+black == 21.12b0
+pre-commit == 2.0.1
+pylint
 pyperf
--r "docs/requirements.txt"
+sphinx
+sphinx_rtd_theme
+sphinx-autoapi
+recommonmark

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,0 @@
-markupsafe < 2.1  # Jinja2<3.0 tries to import soft_unicode, which has been removed in markupsafe 2.1
-jinja2 < 3.0  # Dagster 0.12.8 requires Jinja2<3.0
-docutils < 0.17
-sphinx < 5.2
-sphinx_rtd_theme
-recommonmark
-astroid < 3.0  # sphinx-autoapi installs the latest astroid. We are not compatible with astroid v3.0
-sphinx-autoapi < 2.1  # 2.1 removed support for sphinx < 5.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,11 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8.1, <3.12"
+requires-python = ">=3.8.1"
 dependencies = [
-    "pyside6 >= 6.5.0, != 6.5.3, != 6.6.3",
+    "pyside6 >= 6.5.0, != 6.5.3, != 6.6.3, != 6.7.0",
     "jupyter-client >=6.0",
     "qtconsole >=5.1",
-    "sqlalchemy >=1.3",
     "spinedb_api>=0.31.1",
     "spine_engine>=0.24.0",
     "numpy >=1.20.2",

--- a/spinetoolbox/ui/settings.py
+++ b/spinetoolbox/ui/settings.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'settings.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.0
+## Created by: Qt User Interface Compiler version 6.6.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -406,8 +406,8 @@ class Ui_SettingsForm(object):
 
         self.line_3 = QFrame(self.groupBox_julia)
         self.line_3.setObjectName(u"line_3")
-        self.line_3.setFrameShape(QFrame.Shape.VLine)
-        self.line_3.setFrameShadow(QFrame.Shadow.Sunken)
+        self.line_3.setFrameShape(QFrame.VLine)
+        self.line_3.setFrameShadow(QFrame.Sunken)
 
         self.horizontalLayout_14.addWidget(self.line_3)
 
@@ -489,8 +489,8 @@ class Ui_SettingsForm(object):
 
         self.line = QFrame(self.groupBox_julia)
         self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.Shape.HLine)
-        self.line.setFrameShadow(QFrame.Shadow.Sunken)
+        self.line.setFrameShape(QFrame.HLine)
+        self.line.setFrameShadow(QFrame.Sunken)
 
         self.verticalLayout_10.addWidget(self.line)
 
@@ -543,8 +543,8 @@ class Ui_SettingsForm(object):
 
         self.line_2 = QFrame(self.groupBox_python)
         self.line_2.setObjectName(u"line_2")
-        self.line_2.setFrameShape(QFrame.Shape.VLine)
-        self.line_2.setFrameShadow(QFrame.Shadow.Sunken)
+        self.line_2.setFrameShape(QFrame.VLine)
+        self.line_2.setFrameShadow(QFrame.Sunken)
 
         self.horizontalLayout_5.addWidget(self.line_2)
 


### PR DESCRIPTION
This PR enables support for Python 3.12 and higher and removes dependencies no longer required since we dropped Dagster.

All developer requirements are now in `dev-requirements.txt` including the ones needed to build the documentation.

Re #2522

## Checklist before merging
- [x] Unit tests pass
