### PR TITLE
Fix empty rows on DB editor tables not reacting to entity/entity class renames

### DIFF
--- a/spinetoolbox/mvcmodels/compound_table_model.py
+++ b/spinetoolbox/mvcmodels/compound_table_model.py
@@ -19,8 +19,6 @@ from ..mvcmodels.minimal_table_model import MinimalTableModel
 class CompoundTableModel(MinimalTableModel):
     """A model that concatenates several sub table models vertically."""
 
-    refreshed = Signal()
-
     def __init__(self, parent=None, header=None):
         """Initializes model.
 
@@ -119,7 +117,6 @@ class CompoundTableModel(MinimalTableModel):
         for model in self.sub_models:
             row_map = self._row_map_for_model(model)
             self._append_row_map(row_map)
-        self.refreshed.emit()
 
     def _append_row_map(self, row_map):
         """Appends given row map to the tail of the model.

--- a/tests/spine_db_editor/widgets/spine_db_editor_test_base.py
+++ b/tests/spine_db_editor/widgets/spine_db_editor_test_base.py
@@ -125,6 +125,8 @@ class DBEditorTestBase(unittest.TestCase):
             None,
         )
 
+    db_codename = "database"
+
     def setUp(self):
         """Makes instances of SpineDBEditor classes."""
         with mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"), mock.patch(
@@ -134,8 +136,8 @@ class DBEditorTestBase(unittest.TestCase):
             mock_settings.value.side_effect = lambda *args, **kwargs: 0
             self.db_mngr = TestSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()
-            self.mock_db_map = self.db_mngr.get_db_map("sqlite://", logger, codename="database", create=True)
-            self.spine_db_editor = SpineDBEditor(self.db_mngr, {"sqlite://": "database"})
+            self.mock_db_map = self.db_mngr.get_db_map("sqlite://", logger, codename=self.db_codename, create=True)
+            self.spine_db_editor = SpineDBEditor(self.db_mngr, {"sqlite://": self.db_codename})
             self.spine_db_editor.pivot_table_model = mock.MagicMock()
             self.spine_db_editor.entity_tree_model.hide_empty_classes = False
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -82,7 +82,7 @@ class TestPlotPivotTableSelection(TestBase):
         self.assertEqual(object_tree_model.rowCount(root_index), 1)
         class_index = object_tree_model.index(0, 0, root_index)
         refreshing_models = [self._db_editor.parameter_value_model, self._db_editor.parameter_definition_model]
-        with multi_signal_waiter([model.refreshed for model in refreshing_models]) as at_filter_refresh:
+        with multi_signal_waiter([model.layoutChanged for model in refreshing_models]) as at_filter_refresh:
             self._db_editor.ui.treeView_entity.selectionModel().setCurrentIndex(
                 class_index, QItemSelectionModel.ClearAndSelect
             )


### PR DESCRIPTION
This PR fixes a bug where the empty rows on Parameter definition, Parameter value and Entity alternative tables would still show old names after the selected entity or class was renamed.

Fixes #2722

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
