### PR TITLE
Clear crosshairs in Graph view when the view loses focus

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_qgraphicsviews.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qgraphicsviews.py
@@ -453,7 +453,7 @@ class EntityQGraphicsView(CustomQGraphicsView):
 
     @Slot(QAction)
     def _prune_class(self, action):
-        """Prunnes some class."""
+        """Prunes some class."""
         key = action.text()
         self._spine_db_editor.prune_graph(
             key,
@@ -877,6 +877,11 @@ class EntityQGraphicsView(CustomQGraphicsView):
         if event.key() == Qt.Key_Escape and self.cross_hairs_items:
             self._spine_db_editor.msg.emit("Relationship creation aborted.")
             self.clear_cross_hairs_items()
+
+    def focusOutEvent(self, event):
+        if self.cross_hairs_items:
+            self.clear_cross_hairs_items()
+        super().focusOutEvent(event)
 
     def contextMenuEvent(self, e):
         """Shows context menu.


### PR DESCRIPTION
Cancel the connection operation when a mouse button is pressed anywhere outside the Graph view. This is the behavior I would expect and it fixes bugs like #2778.

Fixes #2778

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
