### PR TITLE
Hide the DB column in Entity Tree and stacked tables

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -227,6 +227,10 @@ class StackedTableView(AutoFilterCopyPasteTableView):
             width = self._initial_column_size(column)
             self.horizontalHeader().resizeSection(column, width)
 
+    def set_db_column_visibility(self, visible):
+        """Sets the visibility of the db column"""
+        self.setColumnHidden(self._EXPECTED_COLUMN_COUNT - 1, not visible)
+
 
 class ParameterTableView(StackedTableView):
     value_column_header: str = NotImplemented

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtreeview.py
@@ -61,8 +61,8 @@ class EntityTreeView(CopyPasteTreeView):
         self._find_next_action = None
         self._hide_empty_classes_action = None
         self._entity_index = None
-        header = self.header()
-        header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self._header = self.header()
+        self._header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
 
     def reset(self):
         super().reset()
@@ -77,6 +77,13 @@ class EntityTreeView(CopyPasteTreeView):
         self._spine_db_editor = spine_db_editor
         self._create_context_menu()
         self.connect_signals()
+
+    def set_db_column_visibility(self, visible):
+        """Sets the visibility of the db column"""
+        if visible:
+            self._header.showSection(1)
+        else:
+            self._header.hideSection(1)
 
     def _add_middle_actions(self):
         self._add_entity_classes_action = self._menu.addAction(

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -186,6 +186,8 @@ class SpineDBEditorBase(QMainWindow):
         self.update_last_view()
         self.restore_ui(self.last_view, fresh=True)
         self.update_commit_enabled()
+        db_column_visible = True if len(self.db_maps) > 1 else False
+        self.set_db_column_visibility(db_column_visible)
         return True
 
     def init_add_undo_redo_actions(self):
@@ -983,8 +985,19 @@ class SpineDBEditor(TabularViewMixin, GraphViewMixin, StackedViewMixin, TreeView
         self.connect_signals()
         self.last_view = None
         self.apply_stacked_style()
+        self.set_db_column_visibility(False)
         if db_url_codenames is not None:
             self.load_db_urls(db_url_codenames)
+
+    def set_db_column_visibility(self, visible):
+        """Set the visibility of the database -column in all the views it is present"""
+        for view in [
+            self.ui.tableView_entity_alternative,
+            self.ui.tableView_parameter_value,
+            self.ui.tableView_parameter_definition,
+            self.ui.treeView_entity,
+        ]:
+            view.set_db_column_visibility(visible)
 
     def emit_pinned_values_updated(self):
         self.pinned_values_updated.emit(self.ui.tableView_parameter_value.pinned_values)

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -55,6 +55,12 @@ class TestParameterDefinitionTableView(TestBase):
         finally:
             plot_widget.deleteLater()
 
+    def test_set_db_column_visible(self):
+        table_view = self._db_editor.ui.tableView_parameter_definition
+        self.assertTrue(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
+        self._db_editor.ui.tableView_parameter_definition.set_db_column_visibility(True)
+        self.assertFalse(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
+
 
 class TestParameterValueTableView(TestBase):
     def test_paste_empty_string_to_entity_byname_column(self):
@@ -282,6 +288,12 @@ class TestParameterValueTableView(TestBase):
         finally:
             plot_widget.deleteLater()
 
+    def test_set_db_column_visible(self):
+        table_view = self._db_editor.ui.tableView_parameter_definition
+        self.assertTrue(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
+        self._db_editor.ui.tableView_parameter_definition.set_db_column_visibility(True)
+        self.assertFalse(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
+
 
 class TestParameterValueTableWithExistingData(TestBase):
     _CHUNK_SIZE = 100  # This has to be large enough, so the chunk won't 'fit' into the table view.
@@ -422,6 +434,12 @@ class TestEntityAlternativeTableView(TestBase):
             for column in range(model.columnCount()):
                 with self.subTest(row=row, column=column):
                     self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_set_db_column_visible(self):
+        table_view = self._db_editor.ui.tableView_parameter_definition
+        self.assertTrue(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
+        self._db_editor.ui.tableView_parameter_definition.set_db_column_visibility(True)
+        self.assertFalse(table_view.isColumnHidden(table_view._EXPECTED_COLUMN_COUNT - 1))
 
 
 def _set_row_data(view, model, row, data, delegate_mock):

--- a/tests/spine_db_editor/widgets/test_custom_qtreeview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtreeview.py
@@ -398,6 +398,12 @@ class TestEntityTreeViewWithExistingZeroDimensionalEntities(TestBase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].name, "entity_2")
 
+    def test_set_db_column_visibility(self):
+        view = self._db_editor.ui.treeView_entity
+        self.assertTrue(view._header.isSectionHidden(1))
+        view.set_db_column_visibility(True)
+        self.assertFalse(view._header.isSectionHidden(1))
+
     def _rename_entity_class(self, class_name):
         view = self._db_editor.ui.treeView_entity
         _edit_entity_tree_item({0: class_name}, view, "Edit...", EditEntityClassesDialog)


### PR DESCRIPTION
If there is only one db open in the editor, the db column will not be visible in the Entity Tree, parameter-, or Entity Alterative tables.

Re #2773

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
