### PR TITLE
Add entities from parameter value and entity alternative tables

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
@@ -25,6 +25,7 @@ from spinetoolbox.spine_db_editor.widgets.custom_editors import (
     SearchBarEditor,
     CheckListEditor,
     ParameterValueLineEditor,
+    SearchBarEditorWithCreation,
 )
 from ...mvcmodels.shared import PARSED_ROLE, DB_MAP_ROLE
 from ...widgets.custom_delegates import CheckBoxDelegate, RankDelegate
@@ -452,7 +453,7 @@ class EntityBynameDelegate(TableDelegate):
             entities = self.db_mngr.get_items_by_field(db_map, "entity", "class_id", entity_class_id)
         else:
             entities = self.db_mngr.get_items(db_map, "entity")
-        editor = SearchBarEditor(self.parent(), parent)
+        editor = SearchBarEditorWithCreation(self.parent(), parent)
         name_list = list({x["name"]: None for x in entities})
         editor.set_data(index.data(Qt.ItemDataRole.EditRole), name_list)
         editor.data_committed.connect(lambda *_: self._close_editor(editor, index))

--- a/spinetoolbox/spine_db_editor/widgets/custom_editors.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_editors.py
@@ -334,6 +334,19 @@ class BooleanSearchBarEditor(SearchBarEditor):
         super().set_data(current, [TRUE_STRING, FALSE_STRING])
 
 
+class SearchBarEditorWithCreation(SearchBarEditor):
+    """Like SearchBarEditor, but also accepts input text that isn't part of the available data"""
+
+    def data(self):
+        """Returns editor's final data.
+
+        Returns:
+            str: editor data
+        """
+        data = super().data()
+        return data if data else self.first_index.data(Qt.ItemDataRole.EditRole)
+
+
 class CheckListEditor(QTableView):
     """A check list editor."""
 


### PR DESCRIPTION
If parameter values or entity alternatives are defined for entities that don't exist in the DB, they are automatically created. N-D -entities must have all the elements already present in the DB, or they won't be added. A popup window is shown that lists the newly added entities.

Re #2788

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
