### PR TITLE
Order tables by class dimension

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1825,3 +1825,11 @@ class CustomPopupMenu(QMenu):
         action.setEnabled(enabled)
         if tooltip is not None:
             action.setToolTip(tooltip)
+
+
+def order_key(name):
+    """Splits the given string into a list of its substrings and digits
+
+    example: "David_1946_Gilmour" -> ["David_", 1946, "_Gilmour"]
+    """
+    return [int(text) if text.isdigit() else text for text in re.split(r"(\d+)", name) if text]

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -12,7 +12,7 @@
 
 """Single models for parameter definitions and values (as 'for a single entity')."""
 from PySide6.QtCore import Qt
-from spinetoolbox.helpers import DB_ITEM_SEPARATOR, plain_to_rich
+from spinetoolbox.helpers import DB_ITEM_SEPARATOR, plain_to_rich, order_key
 from ...mvcmodels.minimal_table_model import MinimalTableModel
 from ..mvcmodels.single_and_empty_model_mixins import SplitValueAndTypeMixin, MakeEntityOnTheFlyMixin
 from ...mvcmodels.shared import PARSED_ROLE, DB_MAP_ROLE
@@ -62,7 +62,12 @@ class SingleModelBase(HalfSortedTableModel):
     def __lt__(self, other):
         if self.entity_class_name == other.entity_class_name:
             return self.db_map.codename < other.db_map.codename
-        return self.entity_class_name < other.entity_class_name
+        keys = []
+        for model in (self, other):
+            dim = model.dimension_id_list
+            class_name = model.entity_class_name
+            keys.append((dim, class_name))
+        return keys[0] < keys[1]
 
     @property
     def item_type(self):
@@ -365,7 +370,7 @@ class SingleParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, Sin
 
     def _sort_key(self, element):
         item = self.db_item_from_id(element)
-        return item.get("name", "")
+        return order_key(item.get("name", ""))
 
     def _do_update_items_in_db(self, db_map_data):
         self.db_mngr.update_parameter_definitions(db_map_data)
@@ -387,7 +392,10 @@ class SingleParameterValueModel(
 
     def _sort_key(self, element):
         item = self.db_item_from_id(element)
-        return (item.get("entity_byname", ()), item.get("parameter_name", ""), item.get("alternative_name", ""))
+        byname = order_key("".join(item.get("entity_byname", ())))
+        param_name = order_key(item.get("parameter_name", ""))
+        alt_name = order_key(item.get("alternative_name", ""))
+        return byname, param_name, alt_name
 
     def _do_update_items_in_db(self, db_map_data):
         self.db_mngr.update_parameter_values(db_map_data)
@@ -402,7 +410,9 @@ class SingleEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, FilterE
 
     def _sort_key(self, element):
         item = self.db_item_from_id(element)
-        return (item.get("entity_byname", ()), item.get("alternative_name", ""))
+        byname = order_key("".join(item.get("entity_byname", ())))
+        alt_name = order_key("".join(item.get("alternative_name", "")))
+        return byname, alt_name
 
     @property
     def _references(self):

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -319,7 +319,18 @@ class TestParameterValueTableWithExistingData(TestBase):
         # 2-D entity class
         self._n_ND_entities = 2
         self._n_ND_parameters = 2
-        import_functions.import_entity_classes(db_map, (('multi_d_class', ('object_class', 'object_class',)),))
+        import_functions.import_entity_classes(
+            db_map,
+            (
+                (
+                    "multi_d_class",
+                    (
+                        "object_class",
+                        "object_class",
+                    ),
+                ),
+            ),
+        )
         nd_entity_names = [
             (f"object_{i}", f"object_{j}") for i, j in itertools.permutations(range(self._n_ND_entities), 2)
         ]
@@ -328,7 +339,12 @@ class TestParameterValueTableWithExistingData(TestBase):
         parameter_definition_data = (("multi_d_class", f"parameter_{n}") for n in range(self._n_ND_parameters))
         import_functions.import_object_parameters(db_map, parameter_definition_data)
         parameter_value_data = [
-            ("multi_d_class", byname, f"parameter_{parameter_n}", "a_value",)
+            (
+                "multi_d_class",
+                byname,
+                f"parameter_{parameter_n}",
+                "a_value",
+            )
             for byname, parameter_n in itertools.product(nd_entity_names, range(self._n_ND_parameters))
         ]
         import_functions.import_parameter_values(db_map, parameter_value_data)
@@ -394,10 +410,7 @@ class TestParameterValueTableWithExistingData(TestBase):
             ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
             for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
         ]
-        entity_names = (
-            f"object_{n} ǀ object_{1 - n}"
-            for n in range(self._n_ND_entities)
-        )
+        entity_names = (f"object_{n} ǀ object_{1 - n}" for n in range(self._n_ND_entities))
         expected.extend(
             [
                 ["multi_d_class", entity_name, f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
@@ -427,14 +440,9 @@ class TestParameterValueTableWithExistingData(TestBase):
             QApplication.processEvents()
         expected = [
             ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
-            for object_n, parameter_n in itertools.product(
-                range(self._n_entities), range(self._n_parameters)
-            )
+            for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
         ]
-        entity_names = (
-            f"object_{n} ǀ object_{1-n}"
-            for n in range(self._n_ND_entities)
-        )
+        entity_names = (f"object_{n} ǀ object_{1-n}" for n in range(self._n_ND_entities))
         expected.extend(
             [
                 ["multi_d_class", entity_name, f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
@@ -458,10 +466,7 @@ class TestParameterValueTableWithExistingData(TestBase):
             ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
             for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
         ]
-        entity_names = (
-            f"object_{n} ǀ object_{1 - n}"
-            for n in range(self._n_ND_entities)
-        )
+        entity_names = (f"object_{n} ǀ object_{1 - n}" for n in range(self._n_ND_entities))
         expected.extend(
             [
                 ["multi_d_class", entity_name, f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -303,18 +303,35 @@ class TestParameterValueTableWithExistingData(TestBase):
         self._temp_dir = TemporaryDirectory()
         url = "sqlite:///" + os.path.join(self._temp_dir.name, "test_database.sqlite")
         db_map = DatabaseMapping(url, create=True)
-        import_functions.import_object_classes(db_map, ("object_class",))
-        self._n_objects = 12
-        object_data = (("object_class", f"object_{n}") for n in range(self._n_objects))
-        import_functions.import_objects(db_map, object_data)
+        # 1-D entity class
+        self._n_entities = 12
         self._n_parameters = 12
+        import_functions.import_entity_classes(db_map, (("object_class",),))
+        object_data = [("object_class", f"object_{n}") for n in range(self._n_entities)]
+        import_functions.import_entities(db_map, object_data)
         parameter_definition_data = (("object_class", f"parameter_{n}") for n in range(self._n_parameters))
         import_functions.import_object_parameters(db_map, parameter_definition_data)
         parameter_value_data = (
             ("object_class", f"object_{object_n}", f"parameter_{parameter_n}", "a_value")
-            for object_n, parameter_n in itertools.product(range(self._n_objects), range(self._n_parameters))
+            for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
         )
         import_functions.import_object_parameter_values(db_map, parameter_value_data)
+        # 2-D entity class
+        self._n_ND_entities = 2
+        self._n_ND_parameters = 2
+        import_functions.import_entity_classes(db_map, (('multi_d_class', ('object_class', 'object_class',)),))
+        nd_entity_names = [
+            (f"object_{i}", f"object_{j}") for i, j in itertools.permutations(range(self._n_ND_entities), 2)
+        ]
+        object_data = [("multi_d_class", byname) for byname in nd_entity_names]
+        import_functions.import_entities(db_map, object_data)
+        parameter_definition_data = (("multi_d_class", f"parameter_{n}") for n in range(self._n_ND_parameters))
+        import_functions.import_object_parameters(db_map, parameter_definition_data)
+        parameter_value_data = [
+            ("multi_d_class", byname, f"parameter_{parameter_n}", "a_value",)
+            for byname, parameter_n in itertools.product(nd_entity_names, range(self._n_ND_parameters))
+        ]
+        import_functions.import_parameter_values(db_map, parameter_value_data)
         db_map.commit_session("Add test data.")
         db_map.close()
         self._common_setup(url, create=False)
@@ -326,6 +343,9 @@ class TestParameterValueTableWithExistingData(TestBase):
     def tearDown(self):
         self._common_tear_down()
         self._temp_dir.cleanup()
+
+    def _whole_model_rowcount(self):
+        return self._n_entities * self._n_parameters + self._n_ND_entities * self._n_ND_parameters + 1
 
     def test_purging_value_data_removes_all_rows(self):
         table_view = self._db_editor.ui.tableView_parameter_value
@@ -355,9 +375,9 @@ class TestParameterValueTableWithExistingData(TestBase):
         table_view = self._db_editor.ui.tableView_parameter_value
         model = table_view.model()
         self.assertEqual(model.rowCount(), self._CHUNK_SIZE + 1)
-        n_values = self._n_parameters * self._n_objects
+        n_values = self._whole_model_rowcount() - 1
         self._db_mngr.remove_items({self._db_map: {"parameter_value": set(range(1, n_values, 2))}})
-        self.assertEqual(model.rowCount(), (self._CHUNK_SIZE) / 2 + 1)
+        self.assertEqual(model.rowCount(), self._CHUNK_SIZE / 2 + 1)
 
     def test_undoing_purge(self):
         table_view = self._db_editor.ui.tableView_parameter_value
@@ -366,19 +386,26 @@ class TestParameterValueTableWithExistingData(TestBase):
         self._db_mngr.purge_items({self._db_map: ["parameter_value"]})
         self.assertEqual(model.rowCount(), 1)
         self._db_editor.undo_action.trigger()
-        while model.rowCount() != self._n_objects * self._n_parameters + 1:
+        while model.rowCount() != self._whole_model_rowcount():
             # Fetch the entire model, because we want to validate all the data.
             model.fetchMore(QModelIndex())
             QApplication.processEvents()
-        expected = sorted(
+        expected = [
+            ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
+            for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
+        ]
+        entity_names = (
+            f"object_{n} ǀ object_{1 - n}"
+            for n in range(self._n_ND_entities)
+        )
+        expected.extend(
             [
-                ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
-                for object_n, parameter_n in itertools.product(range(self._n_objects), range(self._n_parameters))
-            ],
-            key=lambda x: (x[1], x[2]),
+                ["multi_d_class", entity_name, f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
+                for entity_name, parameter_n in itertools.product(entity_names, range(self._n_ND_parameters))
+            ]
         )
         expected.append([None, None, None, None, None, self.db_codename])
-        self.assertEqual(model.rowCount(), self._n_objects * self._n_parameters + 1)
+        self.assertEqual(model.rowCount(), self._whole_model_rowcount())
         for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
             self.assertEqual(model.index(row, column).data(), expected[row][column])
 
@@ -394,20 +421,55 @@ class TestParameterValueTableWithExistingData(TestBase):
             instance.exec.return_value = QMessageBox.StandardButton.Ok
             self._db_editor.ui.actionRollback.trigger()
             self._db_editor.rollback_session()
-        while model.rowCount() != self._n_objects * self._n_parameters + 1:
+        while model.rowCount() != self._whole_model_rowcount():
             # Fetch the entire model, because we want to validate all the data.
             model.fetchMore(QModelIndex())
             QApplication.processEvents()
-        expected = sorted(
+        expected = [
+            ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
+            for object_n, parameter_n in itertools.product(
+                range(self._n_entities), range(self._n_parameters)
+            )
+        ]
+        entity_names = (
+            f"object_{n} ǀ object_{1-n}"
+            for n in range(self._n_ND_entities)
+        )
+        expected.extend(
             [
-                ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
-                for object_n, parameter_n in itertools.product(range(self._n_objects), range(self._n_parameters))
-            ],
-            key=lambda x: (x[1], x[2]),
+                ["multi_d_class", entity_name, f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
+                for entity_name, parameter_n in itertools.product(entity_names, range(self._n_ND_parameters))
+            ]
         )
         QApplication.processEvents()
         expected.append([None, None, None, None, None, self.db_codename])
-        self.assertEqual(model.rowCount(), self._n_objects * self._n_parameters + 1)
+        self.assertEqual(model.rowCount(), self._whole_model_rowcount())
+        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
+            self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_sorting(self):
+        table_view = self._db_editor.ui.tableView_parameter_value
+        model = table_view.model()
+        self.assertEqual(model.rowCount(), self._CHUNK_SIZE + 1)
+        while model.rowCount() != self._whole_model_rowcount():
+            model.fetchMore(QModelIndex())
+            QApplication.processEvents()
+        expected = [
+            ["object_class", f"object_{object_n}", f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
+            for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
+        ]
+        entity_names = (
+            f"object_{n} ǀ object_{1 - n}"
+            for n in range(self._n_ND_entities)
+        )
+        expected.extend(
+            [
+                ["multi_d_class", entity_name, f"parameter_{parameter_n}", "Base", "a_value", self.db_codename]
+                for entity_name, parameter_n in itertools.product(entity_names, range(self._n_ND_parameters))
+            ]
+        )
+        expected.append([None, None, None, None, None, self.db_codename])
+        self.assertEqual(model.rowCount(), self._whole_model_rowcount())
         for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
             self.assertEqual(model.index(row, column).data(), expected[row][column])
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -52,6 +52,7 @@ from spinetoolbox.helpers import (
     merge_dicts,
     HTMLTagFilter,
     home_dir,
+    order_key,
 )
 
 
@@ -418,6 +419,11 @@ class TestHelpers(unittest.TestCase):
         target = {"a": {"b": 1}}
         merge_dicts({"a": {"b": 2}}, target)
         self.assertEqual(target, {"a": {"b": 2}})
+
+    def test_order_key(self):
+        self.assertEqual(["Humphrey_Bogart"], order_key("Humphrey_Bogart"))
+        self.assertEqual(["Wes_", 1969, "_Anderson"], order_key("Wes_1969_Anderson"))
+        self.assertEqual([1899, "_Alfred-", 1980, "Hitchcock"], order_key("1899_Alfred-1980Hitchcock"))
 
 
 class TestHTMLTagFilter(unittest.TestCase):


### PR DESCRIPTION
- Rows in tables are sorted by ascending dimension count
- Switch from lexicographical to natural ordering.
  -> Now parameter2 belongs above parameter10.


Fixes #2711

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
