### PR TITLE
Fix scenario alternatives not removed correctly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/spine-tools/Spine-Database-API.git@issue_2830_removing_scen_alts_errors#egg=spinedb_api
+-e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
+-e git+https://github.com/spine-tools/Spine-Database-API.git@issue_2830_removing_scen_alts_errors#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
 -e .


### PR DESCRIPTION
When deletions were made in a scenario so that the rank order changed, all the scenario alternatives were not removed. This caused an error when the updated scen alt with the new rank number was attempted to be added back to the db.

Fixes #2830

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
- [x] Use default requirements
