### PR TITLE
Show native kernel in kernel lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Entity group -column in *Add entities* -dialog. If filled, the created entity will be added to the specified group.
   If the group doesn't yet exist, it will be created.
-- [Bundled App] Embedded Python now includes pip, jill, and ipykernel
+- Native kernel (i.e. python3 for Python) can now be used in the Detached Console or in Tool execution.
+- [Bundled App] **Embedded Python** now includes pip.
 
 ### Changed
 
@@ -22,8 +23,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-
-- Plugin manager widget now correctly shows the plugin names
+- [Bundled App] Fixed execution in Jupyter Console and opening Detached Consoles by adding jupyter-client and 
+  qtconsole packages to the bundle.
+- [Bundled App] Fixed creating new kernel specs in Settings->Tools by adding ipykernel package to the 
+  **embedded Python**.
+- [Bundled App] Fixed 'Install Julia' button in Settings->Tools by adding the jill package to the **embedded Python**.
 
 ### Security
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
--e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
+-e git+https://github.com/spine-tools/spine-engine.git@toolbox_issue_2824#egg=spine_engine
+-e git+https://github.com/spine-tools/spine-items.git@toolbox_issue_2824#egg=spine_items
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
--e git+https://github.com/spine-tools/spine-engine.git@toolbox_issue_2824#egg=spine_engine
+-e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git@toolbox_issue_2824#egg=spine_items
 -e .

--- a/spinetoolbox/kernel_fetcher.py
+++ b/spinetoolbox/kernel_fetcher.py
@@ -15,8 +15,7 @@ import os
 import json
 from PySide6.QtCore import Signal, Slot, QThread
 from PySide6.QtGui import QIcon
-from jupyter_client.kernelspec import find_kernel_specs
-from spine_engine.utils.helpers import resolve_conda_executable
+from spine_engine.utils.helpers import resolve_conda_executable, custom_find_kernel_specs
 from spine_engine.execution_managers.conda_kernel_spec_manager import CondaKernelSpecManager
 
 
@@ -50,9 +49,9 @@ class KernelFetcher(QThread):
 
     def get_all_regular_kernels(self):
         """Finds all kernel specs as quickly as possible."""
-        for kernel_name, resource_dir in find_kernel_specs().items():  # Find regular Kernels
-            if not os.path.exists(resource_dir):
-                continue
+        for kernel_name, resource_dir in custom_find_kernel_specs().items():  # Find regular Kernels
+            # if not os.path.exists(resource_dir):
+            #     continue
             icon = self.get_icon(resource_dir)
             self.kernel_found.emit(kernel_name, resource_dir, False, icon, {})
             if not self.keep_going:
@@ -79,7 +78,7 @@ class KernelFetcher(QThread):
             self.get_all_conda_kernels()
             return
         # To find just a subset of kernels, we need to open kernel.json file and check the language
-        for kernel_name, resource_dir in find_kernel_specs().items():
+        for kernel_name, resource_dir in custom_find_kernel_specs().items():
             d = self.get_kernel_deats(resource_dir)
             icon = self.get_icon(resource_dir)
             if d["language"].lower().strip() == "python":  # Regular Python kernel found

--- a/spinetoolbox/widgets/kernel_editor.py
+++ b/spinetoolbox/widgets/kernel_editor.py
@@ -15,7 +15,11 @@ import subprocess
 from PySide6.QtWidgets import QDialog, QMessageBox, QDialogButtonBox, QWidget
 from PySide6.QtCore import Slot, Qt, QTimer
 from PySide6.QtGui import QGuiApplication, QIcon
-from spine_engine.utils.helpers import resolve_current_python_interpreter, resolve_default_julia_executable, custom_find_kernel_specs
+from spine_engine.utils.helpers import (
+    resolve_current_python_interpreter,
+    resolve_default_julia_executable,
+    custom_find_kernel_specs,
+)
 from spinetoolbox.execution_managers import QProcessExecutionManager
 from spinetoolbox.helpers import (
     busy_effect,

--- a/spinetoolbox/widgets/kernel_editor.py
+++ b/spinetoolbox/widgets/kernel_editor.py
@@ -15,8 +15,7 @@ import subprocess
 from PySide6.QtWidgets import QDialog, QMessageBox, QDialogButtonBox, QWidget
 from PySide6.QtCore import Slot, Qt, QTimer
 from PySide6.QtGui import QGuiApplication, QIcon
-from jupyter_client.kernelspec import find_kernel_specs
-from spine_engine.utils.helpers import resolve_current_python_interpreter, resolve_default_julia_executable
+from spine_engine.utils.helpers import resolve_current_python_interpreter, resolve_default_julia_executable, custom_find_kernel_specs
 from spinetoolbox.execution_managers import QProcessExecutionManager
 from spinetoolbox.helpers import (
     busy_effect,
@@ -56,7 +55,7 @@ class KernelEditorBase(QDialog):
         self._rebuild_ijulia_process = None
         self._install_julia_kernel_process = None
         self._ready_to_install_kernel = False
-        self.kernel_names_before = find_kernel_specs().keys()
+        self.kernel_names_before = custom_find_kernel_specs().keys()
         self._new_kernel_name = ""
         self.setAttribute(Qt.WA_DeleteOnClose)
         self._cursors = {w: w.cursor() for w in self.findChildren(QWidget)}
@@ -93,7 +92,7 @@ class KernelEditorBase(QDialog):
 
     def _solve_new_kernel_name(self):
         """Finds out the new kernel name after a new kernel has been created."""
-        kernel_names_after = find_kernel_specs().keys()
+        kernel_names_after = custom_find_kernel_specs().keys()
         try:
             self._new_kernel_name = list(set(kernel_names_after) - set(self.kernel_names_before))[0]
         except IndexError:


### PR DESCRIPTION
This should enable the 'python3' kernel in the bundled app even if the user has no Pythons installed nor have they created any kernels in Settings->Tools.

Re #2824

## Checklist before merging
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
