### PR TITLE
Issue 2009 annotate column filtering

### DIFF
--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -44,3 +44,12 @@ def string_to_bool(x):
         bool: boolean value
     """
     return x.casefold() == GENERIC_TRUE
+
+
+def table_name_from_item_type(item_type):
+    """Returns the dock widgets headers text for the given item type"""
+    return {
+        "parameter_value": "Parameter value",
+        "parameter_definition": "Parameter definition",
+        "entity_alternative": "Entity alternative",
+    }.get(item_type)

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -51,9 +51,15 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
             handle_items_updated=self.handle_items_updated,
             owner=self,
         )
+        self.dock = None
+        self._column_filters = {self.header[column]: False for column in range(self.columnCount())}
 
     def _make_header(self):
         raise NotImplementedError()
+
+    @property
+    def column_filters(self):
+        return self._column_filters
 
     @property
     def field_map(self):
@@ -233,6 +239,11 @@ class CompoundModelBase(CompoundWithEmptyTableModel):
         self._set_compound_auto_filter(field, values)
         for model in self.accepted_single_models():
             self._set_single_auto_filter(model, field)
+        if values is None or any(bool(i) for i in values.values()):
+            self._column_filters[field] = True
+        else:
+            self._column_filters[field] = False
+        self._parent.handle_column_filters(self)
 
     def _set_compound_auto_filter(self, field, values):
         """Sets the auto filter for given column in the compound model.

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -25,7 +25,7 @@ from PySide6.QtWidgets import (
     QDialog,
 )
 from PySide6.QtCore import QModelIndex, Qt, Signal, Slot, QTimer, QCoreApplication
-from PySide6.QtGui import QGuiApplication, QKeySequence
+from PySide6.QtGui import QGuiApplication, QKeySequence, QPalette, QColor
 from spinedb_api import export_data, DatabaseMapping, SpineDBAPIError, SpineDBVersionError, Asterisk
 from spinedb_api.spine_io.importers.excel_reader import get_mapped_data_from_xlsx
 from spinedb_api.helpers import vacuum
@@ -39,6 +39,7 @@ from .tabular_view_mixin import TabularViewMixin
 from .toolbar import DBEditorToolBar
 from .metadata_editor import MetadataEditor
 from .item_metadata_editor import ItemMetadataEditor
+from ..helpers import table_name_from_item_type
 from ...widgets.notification import ChangeNotifier, Notification
 from ...widgets.parameter_value_editor import ParameterValueEditor
 from ...widgets.commit_dialog import CommitDialog
@@ -873,6 +874,29 @@ class SpineDBEditorBase(QMainWindow):
     @staticmethod
     def _get_base_dir():
         return APPLICATION_PATH
+
+    @staticmethod
+    def set_dock_tab_color(dock, color):
+        """Colors the header of a dock widget"""
+        palette = QPalette()
+        if color:
+            palette.setColor(QPalette.Window, color)
+        dock.setPalette(palette)
+
+    def handle_column_filters(self, model):
+        if not model.dock:
+            return
+        if not any(model.column_filters.values()):
+            # Back to defaults
+            model.dock.setWindowTitle(table_name_from_item_type(model.item_type))
+            self.set_dock_tab_color(model.dock, None)
+            return
+        self.set_dock_tab_color(model.dock, QColor("paleturquoise"))
+        table_name = table_name_from_item_type(model.item_type)
+        table_name += (
+            f" [COLUMN FILTERS: {', '.join([name for name, active in model.column_filters.items() if active])}]"
+        )
+        model.dock.setWindowTitle(table_name)
 
 
 class SpineDBEditor(TabularViewMixin, GraphViewMixin, StackedViewMixin, TreeViewMixin, SpineDBEditorBase):

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -44,6 +44,8 @@ class StackedViewMixin:
         }
         for model, view in self._all_stacked_models.items():
             view.setModel(model)
+            dock = view.parent().parent()
+            model.dock = dock
             view.verticalHeader().setDefaultSectionSize(preferred_row_height(self))
             horizontal_header = view.horizontalHeader()
             horizontal_header.setSectionsMovable(True)


### PR DESCRIPTION
Now when there are active column filters in a table view, the header of that table changes color and a text is added after the table name to indicate which filters are active.

Re #2009

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
