### PR TITLE
Restrict numpy<2 for bundled app

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install "numpy<2"  # See issue #2852. Remove when PyInstaller supports numpy 2.0+
           python -m pip install -r requirements.txt
       - name: Run tests
         run: |
@@ -36,6 +37,9 @@ jobs:
       - name: Install PyInstaller
         run: |
           python -m pip install PyInstaller
+      - name: List packages
+        run:
+          python -m pip list
       - name: Download embeddable Python
         run: |
           mkdir embedded-python

--- a/PyInstaller hooks/hook-jupyter_client.py
+++ b/PyInstaller hooks/hook-jupyter_client.py
@@ -1,4 +1,3 @@
 from PyInstaller.utils.hooks import collect_all
 
-
 datas, binaries, hiddenimports = collect_all("jupyter_client")

--- a/PyInstaller hooks/hook-numpy.py
+++ b/PyInstaller hooks/hook-numpy.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_all
+
+datas, binaries, hiddenimports = collect_all("numpy")

--- a/PyInstaller hooks/hook-numpy.py
+++ b/PyInstaller hooks/hook-numpy.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import collect_all
-
-datas, binaries, hiddenimports = collect_all("numpy")

--- a/PyInstaller hooks/hook-qtconsole.py
+++ b/PyInstaller hooks/hook-qtconsole.py
@@ -1,4 +1,3 @@
 from PyInstaller.utils.hooks import collect_all
 
-
 datas, binaries, hiddenimports = collect_all("qtconsole")


### PR DESCRIPTION
Fixes an issue in bundle regarding missing numpy files. Happened with Spine-Toolbox-win-0.9.0.dev5+g64a369a5.zip

Re #2852

## Checklist before merging
- [x] Unit tests pass
