### PR TITLE
Make pasting into tables faster

### DIFF
--- a/spinetoolbox/mvcmodels/minimal_table_model.py
+++ b/spinetoolbox/mvcmodels/minimal_table_model.py
@@ -31,6 +31,7 @@ class MinimalTableModel(QAbstractTableModel):
         self.header = header
         self._main_data = list()
         self._fetched = not lazy
+        self._paste = False
 
     def clear(self):
         """Clear all data in model."""
@@ -277,3 +278,11 @@ class MinimalTableModel(QAbstractTableModel):
         self.beginResetModel()
         self._main_data = main_data
         self.endResetModel()
+
+    def begin_paste(self):
+        """Marks that data pasting has begun."""
+        self._paste = True
+
+    def end_paste(self):
+        """Marks that data pasting has ended."""
+        self._paste = False

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -134,6 +134,12 @@ class EmptyModelBase(EmptyRowModel):
 
     def _autocomplete_row(self, db_map, item):
         """Fills in entity_class_name whenever other selections make it obvious."""
+        if self._paste and item.get("entity_class_name"):
+            # If the data is pasted and the entity class column is already filled,
+            # trust that the user knows what they are doing. This makes pasting large
+            # amounts of data significantly faster.
+            del item["row"]
+            return
         candidates = self._entity_class_name_candidates(db_map, item)
         row = item.pop("row", None)
         if len(candidates) == 1:

--- a/spinetoolbox/widgets/custom_qtableview.py
+++ b/spinetoolbox/widgets/custom_qtableview.py
@@ -294,7 +294,15 @@ class CopyPasteTableView(QTableView):
                             values.append(convert(value))
                             continue
                     values.append(value)
+        if hasattr(model, "empty_model"):
+            begin_paste = model.empty_model.begin_paste
+            end_paste = model.empty_model.end_paste
+        else:
+            begin_paste = model.begin_paste
+            end_paste = model.end_paste
+        begin_paste()
         model.batch_set_data(indexes, values)
+        end_paste()
         return True
 
     def set_column_converter_for_pasting(self, header, converter):

--- a/tests/widgets/test_CopyPasteTableView.py
+++ b/tests/widgets/test_CopyPasteTableView.py
@@ -69,6 +69,12 @@ class _MockModel(QAbstractTableModel):
     def rowCount(self, parent=QModelIndex()):
         return len(self._data)
 
+    def begin_paste(self):
+        pass
+
+    def end_paste(self):
+        pass
+
 
 def delocalize_comma_decimal_separator(x):
     return x.replace(",", ".")


### PR DESCRIPTION
The row autocompletion is now disabled when data is pasted into a table. Pasting large amounts of data took a long time if the db had a lot of items in it already, because fetching the candidate entity classes from the db_map got slow. Now instead it is assumed that the user knows what they are doing and therefore when pasting data, the entity classes are correctly defined.

Re #2867

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
