### PR TITLE
Improve add entities/classes dialog name field

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -352,6 +352,8 @@ class EmptyAddEntityOrClassRowModel(EmptyRowModel):
                 self._main_data[row][column] = value
             rows.append(row)
             columns.append(column)
+        if not (rows and columns):
+            return False
         # Find square envelope of indexes to emit dataChanged
         top = min(rows)
         bottom = max(rows)

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -10,7 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""Empty models for parameter definitions and values."""
+"""Empty models for dialogs as well as parameter definitions and values."""
 from PySide6.QtCore import Qt
 from ...mvcmodels.empty_row_model import EmptyRowModel
 from .single_and_empty_model_mixins import SplitValueAndTypeMixin, MakeEntityOnTheFlyMixin
@@ -326,3 +326,50 @@ class EmptyEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, EmptyMod
 
     def _entity_class_name_candidates(self, db_map, item):
         return self._entity_class_name_candidates_by_entity(db_map, item)
+
+
+class EmptyAddEntityOrClassRowModel(EmptyRowModel):
+    """A table model with a last empty row."""
+    def __init__(self, parent=None, header=None):
+        super().__init__(parent, header=header)
+        self._entity_name_user_defined = False
+
+    def batch_set_data(self, indexes, data):
+        """Reimplemented to fill the entity class name automatically if its data is removed via pressing del."""
+        if not indexes or not data:
+            return False
+        rows = []
+        columns = []
+        for index, value in zip(indexes, data):
+            if not index.isValid():
+                continue
+            row = index.row()
+            column = index.column()
+            if column == self.header.index(self._parent.dialog_item_name()) and not value:
+                self._entity_name_user_defined = False
+                self._main_data[row][column] = self._parent.construct_composite_class_name(index.row())
+            else:
+                self._main_data[row][column] = value
+            rows.append(row)
+            columns.append(column)
+        # Find square envelope of indexes to emit dataChanged
+        top = min(rows)
+        bottom = max(rows)
+        left = min(columns)
+        right = max(columns)
+        self.dataChanged.emit(
+            self.index(top, left), self.index(bottom, right), [Qt.ItemDataRole.EditRole, Qt.ItemDataRole.DisplayRole]
+        )
+        return True
+
+    def setData(self, index, value, role=Qt.ItemDataRole.EditRole):
+        """Reimplemented to not overwrite user defined entity/class names with automatic composite names."""
+        if index.column() != self.header.index(self._parent.dialog_item_name()):
+            return super().setData(index, value, role)
+        if role == Qt.ItemDataRole.UserRole:
+            if self._entity_name_user_defined:
+                return False
+            role = Qt.ItemDataRole.EditRole
+        else:
+            self._entity_name_user_defined = True if value else False
+        return super().setData(index, value, role)

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -11,7 +11,6 @@
 ######################################################################################################################
 
 """ Classes for custom QDialogs to add items to databases. """
-from contextlib import suppress
 from itertools import product
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -36,7 +35,7 @@ from PySide6.QtCore import Slot, Qt, QSize, QModelIndex
 from PySide6.QtGui import QIcon
 from spinedb_api.helpers import name_from_elements, name_from_dimensions
 from ..helpers import string_to_bool, string_to_display_icon
-from ...mvcmodels.empty_row_model import EmptyRowModel
+from ..mvcmodels.empty_models import EmptyAddEntityOrClassRowModel
 from ...mvcmodels.compound_table_model import CompoundTableModel
 from ...mvcmodels.minimal_table_model import MinimalTableModel
 from ...helpers import DB_ITEM_SEPARATOR
@@ -193,7 +192,7 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
         self.setWindowTitle("Add entity classes")
         self.table_view.set_column_converter_for_pasting("display icon", string_to_display_icon)
         self.table_view.set_column_converter_for_pasting("active by default", string_to_bool)
-        self.model = EmptyRowModel(self)
+        self.model = EmptyAddEntityOrClassRowModel(self)
         self.model.force_default = force_default
         self.table_view.setModel(self.model)
         self.dimension_count_widget = QWidget(self)
@@ -276,11 +275,10 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
         top = top_left.row()
         bottom = bottom_right.row()
         for row in range(top, bottom + 1):
-            obj_cls_names = [
-                name for j in range(self.number_of_dimensions) if (name := self.model.index(row, j).data())
-            ]
-            relationship_class_name = name_from_dimensions(obj_cls_names)
-            self.model.setData(self.model.index(row, self.number_of_dimensions), relationship_class_name)
+            relationship_class_name = self.construct_composite_class_name(row)
+            self.model.setData(
+                self.model.index(row, self.number_of_dimensions), relationship_class_name, role=Qt.ItemDataRole.UserRole
+            )
 
     @Slot()
     def accept(self):
@@ -336,6 +334,22 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
             return
         self.db_mngr.add_entity_classes(db_map_data)
         super().accept()
+
+    def construct_composite_class_name(self, row):
+        """Returns a ND entity class name from all the currently selected dimension names.
+
+        Args:
+            row (int): The index of the row.
+
+        Returns:
+            str: The ND entity class name
+        """
+        class_names = [name for j in range(self.number_of_dimensions) if (name := self.model.index(row, j).data())]
+        return name_from_dimensions(class_names)
+
+    @staticmethod
+    def dialog_item_name():
+        return "entity class name"
 
 
 class AddEntitiesOrManageElementsDialog(GetEntityClassesMixin, GetEntitiesMixin, AddItemsDialog):
@@ -483,7 +497,7 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
         return self.entity_class["name"] in set(ent_cls["dimension_name_list"]) | {ent_cls["name"]}
 
     def make_model(self):
-        return EmptyRowModel(self)
+        return EmptyAddEntityOrClassRowModel(self)
 
     def _do_reset_model(self):
         header = self.dimension_name_list + ("entity name", "alternative", "entity group", "databases")
@@ -641,6 +655,10 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
                     (class_name, entity_group, entity["name"])
                 )
         return db_map_data
+
+    @staticmethod
+    def dialog_item_name():
+        return "entity name"
 
 
 class ManageElementsDialog(AddEntitiesOrManageElementsDialog):

--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -180,6 +180,16 @@ class TestAddItemsDialog(unittest.TestCase):
         expected = ["Start", "one", None, None, True, "mock_db"]
         result = [model.index(0, column).data() for column in range(model.columnCount())]
         self.assertEqual(expected, result)
+        value = ["not valid"]
+        model.batch_set_data([model.index(-1, -1)], value)
+        expected = ["Start", "one", None, None, True, "mock_db"]
+        result = [model.index(0, column).data() for column in range(model.columnCount())]
+        self.assertEqual(expected, result)
+        value = []
+        model.batch_set_data(indexes[1], value)
+        expected = ["Start", "one", None, None, True, "mock_db"]
+        result = [model.index(0, column).data() for column in range(model.columnCount())]
+        self.assertEqual(expected, result)
         value = ""
         model.setData(indexes[1], value)
         expected = ["Start", "Start__", None, None, True, "mock_db"]


### PR DESCRIPTION
The class name/entity name field will no longer be overwritten by an automatically generated name when the dimensions/elements are changed. If the user defined entry is deleted or empty, the name will be automatically generated.

Fixes #2874

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
