### PR TITLE
Fix reloading and Traceback when entity is selected on reload.

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -259,9 +259,12 @@ class EntityItem(MultiDBTreeItem):
 
     def default_parameter_data(self):
         """Return data to put as default in a parameter table when this item is selected."""
+        item = self.db_map_data(self.first_db_map)
+        if not item:
+            return {"database": self.first_db_map.codename}
         return dict(
-            entity_class_name=self.db_map_data_field(self.first_db_map, "entity_class_name"),
-            entity_byname=DB_ITEM_SEPARATOR.join(self.db_map_data_field(self.first_db_map, "entity_byname")),
+            entity_class_name=item["entity_class_name"],
+            entity_byname=DB_ITEM_SEPARATOR.join(item["entity_byname"]),
             database=self.first_db_map.codename,
         )
 

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -245,8 +245,8 @@ class TestParameterValueTableView(TestBase):
             QApplication.processEvents()
         expected = [
             ["object_1_class", "an_object_1", "parameter_1", "Base", "a_value", self.db_codename],
-            ["object_1_class", "another_object_1", "parameter_1", "Base", "c_value", self.db_codename],
             ["object_2_class", "an_object_2", "parameter_2", "Base", "b_value", self.db_codename],
+            ["object_1_class", "another_object_1", "parameter_1", "Base", "c_value", self.db_codename],
             [None, None, None, None, None, self.db_codename],
         ]
         for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):


### PR DESCRIPTION
We do not reset anymore on reload because that way all pending changes are lost. Instead, the database is properly refreshed. Also, this PR includes a fix to a Traceback that could trigger during reload.

Fixes #2872

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
