### PR TITLE
Fix sort_key()

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1828,12 +1828,12 @@ class CustomPopupMenu(QMenu):
 
 
 def order_key(name):
-    """Splits the given string into a list of its substrings and digits
-    example: "David_1946_Gilmour" -> ["David_", 1946, "_Gilmour"]
-    If given a string that starts with a digit, a 'big' string (in comparisons) will be added to the start
-    of the order key that makes sure that every key starts with a str and alternates with int after that.
+    """Splits the given string into a list of its substrings and fills digits with '0'
+    to ensure that e.g. 1 and 11 get sorted correctly.
+
+    Example: "David_1946_Gilmour" -> ["David_", "000000001946", "_Gilmour"]
     """
-    key_list = [int(text) if text.isdigit() else text for text in re.split(r"(\d+|__)", name) if text]
-    if len(key_list) and isinstance(key_list[0], int):
+    key_list = [f"{int(text):#012}" if text.isdigit() else text for text in re.split(r"(\d+|__)", name) if text]
+    if key_list and key_list[0].isdigit():
         key_list.insert(0, "\U0010FFFF")
     return key_list

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -302,54 +302,53 @@ class TestParameterValueTableWithExistingData(TestBase):
     def setUp(self):
         self._temp_dir = TemporaryDirectory()
         url = "sqlite:///" + os.path.join(self._temp_dir.name, "test_database.sqlite")
-        db_map = DatabaseMapping(url, create=True)
-        # 1-D entity class
-        self._n_entities = 12
-        self._n_parameters = 12
-        import_functions.import_entity_classes(db_map, (("object_class",),))
-        object_data = [("object_class", f"object_{n}") for n in range(self._n_entities)]
-        import_functions.import_entities(db_map, object_data)
-        parameter_definition_data = (("object_class", f"parameter_{n}") for n in range(self._n_parameters))
-        import_functions.import_object_parameters(db_map, parameter_definition_data)
-        parameter_value_data = (
-            ("object_class", f"object_{object_n}", f"parameter_{parameter_n}", "a_value")
-            for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
-        )
-        import_functions.import_object_parameter_values(db_map, parameter_value_data)
-        # 2-D entity class
-        self._n_ND_entities = 2
-        self._n_ND_parameters = 2
-        import_functions.import_entity_classes(
-            db_map,
-            (
+        with DatabaseMapping(url, create=True) as db_map:
+            # 1-D entity class
+            self._n_entities = 12
+            self._n_parameters = 12
+            import_functions.import_entity_classes(db_map, (("object_class",),))
+            object_data = [("object_class", f"object_{n}") for n in range(self._n_entities)]
+            import_functions.import_entities(db_map, object_data)
+            parameter_definition_data = (("object_class", f"parameter_{n}") for n in range(self._n_parameters))
+            import_functions.import_object_parameters(db_map, parameter_definition_data)
+            parameter_value_data = (
+                ("object_class", f"object_{object_n}", f"parameter_{parameter_n}", "a_value")
+                for object_n, parameter_n in itertools.product(range(self._n_entities), range(self._n_parameters))
+            )
+            import_functions.import_object_parameter_values(db_map, parameter_value_data)
+            # 2-D entity class
+            self._n_ND_entities = 2
+            self._n_ND_parameters = 2
+            import_functions.import_entity_classes(
+                db_map,
                 (
-                    "multi_d_class",
                     (
-                        "object_class",
-                        "object_class",
+                        "multi_d_class",
+                        (
+                            "object_class",
+                            "object_class",
+                        ),
                     ),
                 ),
-            ),
-        )
-        nd_entity_names = [
-            (f"object_{i}", f"object_{j}") for i, j in itertools.permutations(range(self._n_ND_entities), 2)
-        ]
-        object_data = [("multi_d_class", byname) for byname in nd_entity_names]
-        import_functions.import_entities(db_map, object_data)
-        parameter_definition_data = (("multi_d_class", f"parameter_{n}") for n in range(self._n_ND_parameters))
-        import_functions.import_object_parameters(db_map, parameter_definition_data)
-        parameter_value_data = [
-            (
-                "multi_d_class",
-                byname,
-                f"parameter_{parameter_n}",
-                "a_value",
             )
-            for byname, parameter_n in itertools.product(nd_entity_names, range(self._n_ND_parameters))
-        ]
-        import_functions.import_parameter_values(db_map, parameter_value_data)
-        db_map.commit_session("Add test data.")
-        db_map.close()
+            nd_entity_names = [
+                (f"object_{i}", f"object_{j}") for i, j in itertools.permutations(range(self._n_ND_entities), 2)
+            ]
+            object_data = [("multi_d_class", byname) for byname in nd_entity_names]
+            import_functions.import_entities(db_map, object_data)
+            parameter_definition_data = (("multi_d_class", f"parameter_{n}") for n in range(self._n_ND_parameters))
+            import_functions.import_object_parameters(db_map, parameter_definition_data)
+            parameter_value_data = [
+                (
+                    "multi_d_class",
+                    byname,
+                    f"parameter_{parameter_n}",
+                    "a_value",
+                )
+                for byname, parameter_n in itertools.product(nd_entity_names, range(self._n_ND_parameters))
+            ]
+            import_functions.import_parameter_values(db_map, parameter_value_data)
+            db_map.commit_session("Add test data.")
         self._common_setup(url, create=False)
         model = self._db_editor.ui.tableView_parameter_value.model()
         while model.rowCount() != self._CHUNK_SIZE + 1:
@@ -458,21 +457,20 @@ class TestParameterValueTableWithExistingData(TestBase):
     def test_sorting(self):
         """Test that the parameter value table sorts in an expected order."""
         url = "sqlite:///" + os.path.join(self._temp_dir.name, "test_database.sqlite")
-        db_map = DatabaseMapping(url)
-        parameter_definition_data = (
-            ("object_class", f"0parameter_"),
-            ("object_class", f"1parameter_"),
-        )
-        import_functions.import_object_parameters(db_map, parameter_definition_data)
-        parameter_value_data = (
-            ("object_class", f"object_0", f"0parameter_", "a_value"),
-            ("object_class", f"object_0", f"1parameter_", "a_value"),
-            ("object_class", f"object_1", f"0parameter_", "a_value"),
-            ("object_class", f"object_1", f"1parameter_", "a_value"),
-        )
-        import_functions.import_object_parameter_values(db_map, parameter_value_data)
-        db_map.commit_session("Add test data.")
-        db_map.close()
+        with DatabaseMapping(url) as db_map:
+            parameter_definition_data = (
+                ("object_class", f"0parameter_"),
+                ("object_class", f"1parameter_"),
+            )
+            import_functions.import_object_parameters(db_map, parameter_definition_data)
+            parameter_value_data = (
+                ("object_class", f"object_0", f"0parameter_", "a_value"),
+                ("object_class", f"object_0", f"1parameter_", "a_value"),
+                ("object_class", f"object_1", f"0parameter_", "a_value"),
+                ("object_class", f"object_1", f"1parameter_", "a_value"),
+            )
+            import_functions.import_object_parameter_values(db_map, parameter_value_data)
+            db_map.commit_session("Add test data.")
         table_view = self._db_editor.ui.tableView_parameter_value
         model = table_view.model()
         self.assertEqual(model.rowCount(), self._CHUNK_SIZE + 1)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -422,8 +422,11 @@ class TestHelpers(unittest.TestCase):
 
     def test_order_key(self):
         self.assertEqual(["Humphrey_Bogart"], order_key("Humphrey_Bogart"))
-        self.assertEqual(["Wes_", 1969, "_Anderson"], order_key("Wes_1969_Anderson"))
-        self.assertEqual(["\U0010ffff", 1899, "_Alfred-", 1980, "Hitchcock"], order_key("1899_Alfred-1980Hitchcock"))
+        self.assertEqual(["Wes_", "000000001969", "_Anderson"], order_key("Wes_1969_Anderson"))
+        self.assertEqual(
+            ["\U0010FFFF", "000000001899", "_Alfred-", "000000001980", "Hitchcock"],
+            order_key("1899_Alfred-1980Hitchcock"),
+        )
         self.assertEqual([], order_key(""))
 
 


### PR DESCRIPTION
The sort_key() function must return lists that have elements of the same type, otherwise comparison while sorting may fail.

Fixes irena-flextool/flextool#216

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
