### PR TITLE
Show Python 3.8 deprecation warning on Toolbox startup

### DIFF
--- a/spinetoolbox/main.py
+++ b/spinetoolbox/main.py
@@ -62,7 +62,7 @@ def main():
         logging.warning("Could not load fonts from resources file. Some icons may not render properly.")
     window = ToolboxUI()
     window.show()
-    QTimer.singleShot(0, lambda: window.init_project(args.project))
+    QTimer.singleShot(0, lambda: window.init_tasks(args.project))
     # Enter main event loop and wait until exit() is called
     return_code = app.exec()
     return return_code

--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -326,7 +326,6 @@ class SpineToolboxProject(MetaObject):
         Returns:
             bool: True if the operation was successful, False otherwise
         """
-        self._toolbox.ui.textBrowser_eventlog.clear()
         project_dict = load_project_dict(self.config_dir, self._logger)
         if project_dict is None:
             return False

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -22,11 +22,9 @@ from spinetoolbox.ui_main import ToolboxUI
 
 def create_toolboxui():
     """Returns ToolboxUI, where QSettings among others has been mocked."""
-    with mock.patch(
-            "spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, mock.patch(
-        "spinetoolbox.ui_main.ToolboxUI.set_app_style") as mock_set_app_style, mock.patch(
-        "spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"
-    ):
+    with mock.patch("spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, mock.patch(
+        "spinetoolbox.ui_main.ToolboxUI.set_app_style"
+    ) as mock_set_app_style, mock.patch("spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"):
         mock_qsettings_value.side_effect = qsettings_value_side_effect
         mock_set_app_style.return_value = True
         toolbox = ToolboxUI()
@@ -45,12 +43,16 @@ def create_toolboxui_with_project(project_dir):
     """Returns ToolboxUI with a project instance where
     QSettings among others has been mocked."""
     with mock.patch("spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, mock.patch(
-            "spinetoolbox.ui_main.ToolboxUI.set_app_style") as mock_set_app_style, mock.patch(
-            "spinetoolbox.ui_main.ToolboxUI.save_project"), mock.patch(
-            "spinetoolbox.ui_main.QSettings.setValue"), mock.patch(
-            "spinetoolbox.ui_main.QSettings.sync"), mock.patch(
-            "spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"), mock.patch(
-            "spinetoolbox.ui_main.QScrollArea.setWidget"):
+        "spinetoolbox.ui_main.ToolboxUI.set_app_style"
+    ) as mock_set_app_style, mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"), mock.patch(
+        "spinetoolbox.ui_main.QSettings.setValue"
+    ), mock.patch(
+        "spinetoolbox.ui_main.QSettings.sync"
+    ), mock.patch(
+        "spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"
+    ), mock.patch(
+        "spinetoolbox.ui_main.QScrollArea.setWidget"
+    ):
         mock_qsettings_value.side_effect = qsettings_value_side_effect
         mock_set_app_style.return_value = True
         toolbox = ToolboxUI()


### PR DESCRIPTION
At least we can tell users that we have warned them...

Re #2904

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
