### PR TITLE
Fix (nearly) endless database upgrade dialogs

### DIFF
--- a/spinetoolbox/project_item/logging_connection.py
+++ b/spinetoolbox/project_item/logging_connection.py
@@ -171,7 +171,7 @@ class LoggingConnection(LogMixin, HeadlessConnection):
             url = resource.url
             if not url:
                 continue
-            db_map = self._get_db_map(url, ignore_version_error=True)
+            db_map = self._get_db_map(url)
             if db_map is None:
                 continue
             known_filters = self._filter_settings.known_filters.get(resource.label, {})
@@ -184,9 +184,9 @@ class LoggingConnection(LogMixin, HeadlessConnection):
                     return True
         return False
 
-    def _get_db_map(self, url, ignore_version_error=False):
+    def _get_db_map(self, url):
         if url not in self._db_maps:
-            db_map = self._toolbox.db_mngr.get_db_map(url, self._toolbox, ignore_version_error=ignore_version_error)
+            db_map = self._toolbox.db_mngr.get_db_map(url, self._toolbox)
             if db_map is None:
                 return None
             self._db_maps[url] = db_map

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -162,7 +162,9 @@ class SpineDBEditorBase(QMainWindow):
         self._changelog.clear()
         self._purge_change_notifiers()
         for url, codename in db_url_codenames.items():
-            db_map = self.db_mngr.get_db_map(url, self, codename=codename, create=create, window=window)
+            db_map = self.db_mngr.get_db_map(
+                url, self, codename=codename, create=create, window=window, force_upgrade_prompt=True
+            )
             if db_map is not None:
                 self.db_maps.append(db_map)
         if not self.db_maps:


### PR DESCRIPTION
This PR fixes a bug where multiple database upgrade dialogs would pop up for a single Data store if user kept cancelling the dialogs. We now ask just once if an upgrade is desirable, though users are given a second chance if they try to open the DB in the editor.

Fixes #2915

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
