### PR TITLE
Changes according to renamed display mode tables in spinedb_api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
+-e git+https://github.com/spine-tools/Spine-Database-API.git@442_rename_display_mode_tables#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
 -e git+https://github.com/spine-tools/spine-items.git#egg=spine_items
 -e .

--- a/spinetoolbox/widgets/select_database_items.py
+++ b/spinetoolbox/widgets/select_database_items.py
@@ -66,8 +66,8 @@ class SelectDatabaseItems(QWidget):
     _SCENARIO_ITEMS = ("alternative", "scenario", "scenario_alternative", "entity_alternative")
     _STRUCTURAL_ITEMS = (
         "entity_class",
+        "display_mode",
         "entity_class_display_mode",
-        "display_mode__entity_class",
         "superclass_subclass",
         "parameter_value_list",
         "list_value",

--- a/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
+++ b/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
@@ -60,8 +60,8 @@ class TestMassRemoveItemsDialog(TestCaseWithQApplication):
                 "scenario": False,
                 "scenario_alternative": False,
                 "superclass_subclass": False,
+                "display_mode": False,
                 "entity_class_display_mode": False,
-                "display_mode__entity_class": False,
             },
         )
         self.assertTrue(dialog._database_check_boxes_widget._check_boxes[self._db_map].isChecked())


### PR DESCRIPTION
`entity_class_display_mode` and `display_mode__entity_class` tables have been renamed to `display_mode` and `entity_class_display_mode` in `spinedb_api` which requires the changes introduced in this PR in Toolbox side.

(see PR spine-tools/Spine-Database-API#443)

Re spine-tools/Spine-Database-API#442

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
