### PR TITLE
Fix some warnings from unit tests

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_menus.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_menus.py
@@ -253,7 +253,7 @@ class RecentDatabasesPopupMenu(CustomPopupMenu):
             "Clear",
             self.clear_recents,
             enabled=self.has_recents(),
-            icon=QIcon(":icons/trash-alt.svg"),
+            icon=QIcon(":icons/menu_icons/trash-alt.svg"),
         )
 
     def has_recents(self):

--- a/spinetoolbox/widgets/custom_menus.py
+++ b/spinetoolbox/widgets/custom_menus.py
@@ -105,7 +105,7 @@ class RecentProjectsPopupMenu(CustomPopupMenu):
             "Clear",
             lambda checked=False: self.call_clear_recents(checked),
             enabled=self.has_recents(),
-            icon=QIcon(":icons/trash-alt.svg"),
+            icon=QIcon(":icons/menu_icons/trash-alt.svg"),
         )
 
     def has_recents(self):

--- a/tests/spine_db_editor/widgets/helpers.py
+++ b/tests/spine_db_editor/widgets/helpers.py
@@ -42,6 +42,7 @@ class EditorDelegateMocking:
         view.edit(index)
         if self._cell_editor is None:
             # Native editor widget is being used, fall back to setting value directly in model.
+            view.closeEditor()
             view.model().setData(index, value)
             return
         if isinstance(self._cell_editor, SearchBarEditor):
@@ -71,6 +72,8 @@ class EditorDelegateMocking:
         view.edit(index)
 
     def reset(self):
+        if self._cell_editor is not None:
+            self._cell_editor.deleteLater()
         self._cell_editor = None
 
 

--- a/tests/test_SpineToolboxProject.py
+++ b/tests/test_SpineToolboxProject.py
@@ -20,7 +20,7 @@ from unittest import mock
 import networkx as nx
 from PySide6.QtCore import QVariantAnimation
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QApplication, QMessageBox, QGraphicsRectItem
+from PySide6.QtWidgets import QApplication, QGraphicsRectItem, QMessageBox
 from spine_engine.project_item.executable_item_base import ExecutableItemBase
 from spine_engine.project_item.project_item_specification import ProjectItemSpecification
 from spine_engine.spine_engine import ItemExecutionFinishState

--- a/tests/test_SpineToolboxProject.py
+++ b/tests/test_SpineToolboxProject.py
@@ -20,7 +20,7 @@ from unittest import mock
 import networkx as nx
 from PySide6.QtCore import QVariantAnimation
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtWidgets import QApplication, QMessageBox, QGraphicsRectItem
 from spine_engine.project_item.executable_item_base import ExecutableItemBase
 from spine_engine.project_item.project_item_specification import ProjectItemSpecification
 from spine_engine.spine_engine import ItemExecutionFinishState
@@ -777,6 +777,9 @@ class _MockItemWithLocalData(ProjectItem):
 
     def set_icon(self, icon):
         return
+
+    def get_icon(self):
+        return QGraphicsRectItem(0.0, 0.0, 23.0, 23.0)
 
 
 class _MockItemFactoryForLocalDataTests(ProjectItemFactory):

--- a/tests/widgets/test_custom_combobox.py
+++ b/tests/widgets/test_custom_combobox.py
@@ -13,7 +13,7 @@
 """Unit tests for the classes in ``custom_combobox`` module.
 OpenProjectDialogComboBox is tested in test_open_project_dialog module."""
 import unittest
-from PySide6.QtGui import QPaintEvent
+from PySide6.QtGui import QPaintEvent, QImage, QColor
 from PySide6.QtWidgets import QWidget
 from spinetoolbox.widgets.custom_combobox import CustomQComboBox, ElidedCombobox
 from tests.mock_helpers import TestCaseWithQApplication
@@ -21,14 +21,15 @@ from tests.mock_helpers import TestCaseWithQApplication
 
 class TestCustomComboBoxes(TestCaseWithQApplication):
     def test_custom_combobox(self):
-        parent = QWidget()
-        cb = CustomQComboBox(parent)
+        cb = CustomQComboBox(None)
         cb.addItems(["a", "b", "c"])
         self.assertEqual("a", cb.itemText(0))
-        parent.deleteLater()
+        cb.deleteLater()
 
     def test_elided_combobox(self):
-        parent = QWidget()
-        cb = ElidedCombobox(parent)
+        cb = ElidedCombobox(None)
+        image = QImage(cb.size(), QImage.Format.Format_RGB32)
+        image.fill(QColor("white"))
+        cb.paintEngine = image.paintEngine
         cb.paintEvent(QPaintEvent(cb.rect()))
-        parent.deleteLater()
+        cb.deleteLater()

--- a/tests/widgets/test_custom_combobox.py
+++ b/tests/widgets/test_custom_combobox.py
@@ -13,7 +13,7 @@
 """Unit tests for the classes in ``custom_combobox`` module.
 OpenProjectDialogComboBox is tested in test_open_project_dialog module."""
 import unittest
-from PySide6.QtGui import QPaintEvent, QImage, QColor
+from PySide6.QtGui import QColor, QImage, QPaintEvent
 from PySide6.QtWidgets import QWidget
 from spinetoolbox.widgets.custom_combobox import CustomQComboBox, ElidedCombobox
 from tests.mock_helpers import TestCaseWithQApplication


### PR DESCRIPTION
We get a few warnings when running the unit tests on Ubuntu. This fixes some of those but unfortunately does not help with the segfaults.

Most notably, `CompoundModelBase.handle_items_removed()` has been largely rewritten. We now properly call `beginRemoveRows()` and `endRemoveRows()` instead of just recalculating the row and inverse row maps and emitting `layoutChanged` which left the table views in a somewhat confused state.

Re #2921

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
