### PR TITLE
Make GitHub unit/execution test actions callable

### DIFF
--- a/.github/workflows/execution_tests.yml
+++ b/.github/workflows/execution_tests.yml
@@ -1,0 +1,59 @@
+name: Execution tests
+
+on:
+  workflow_call:
+    inputs:
+      host-os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      repository:
+        required: false
+        type: string
+        default: ${{ github.repository }}
+      post-installation-command:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
+jobs:
+  execution-tests:
+    name: Run execution tests
+    runs-on: ${{ inputs.host-os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            dev-requirements.txt
+      - name: Install additional packages for Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libegl1
+      - name: Install dependencies
+        env:
+          PYTHONUTF8: 1
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -r dev-requirements.txt
+      - name: Run post-install command
+        if: ${{ inputs.post-installation-command }}
+        run:
+          ${{ inputs.post-installation-command }}
+      - name: Run tests
+        run:
+          python -m unittest discover --pattern execution_test.py --verbose

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -12,93 +12,27 @@ on:
       - "execution_tests/**"
 
 jobs:
-  unit-tests:
+  call-unit-tests:
     name: Unit tests
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [windows-latest, ubuntu-22.04]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Version from Git tags
-      run: git describe --tags
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: |
-          pyproject.toml
-          requirements.txt
-          dev-requirements.txt
-    - name: Display Python version
-      run:
-         python -c "import sys; print(sys.version)"
-    - name: Install additional packages for Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libegl1
-    - name: Install dependencies
-      env:
-        PYTHONUTF8: 1
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        python -m pip install -r dev-requirements.txt
-    - name: List packages
-      run:
-        python -m pip list
-    - name: Run tests
-      run: |
-        if [ "$RUNNER_OS" != "Windows" ]; then
-          export QT_QPA_PLATFORM=offscreen
-        fi
-        coverage run -m unittest discover --verbose
-      shell: bash
-    - name: Upload coverage report to Codecov
-      uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  execution-tests:
+    uses: ./.github/workflows/unit_tests.yml
+    with:
+      host-os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+    secrets: inherit
+  call-execution-tests:
     name: Execution tests
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [windows-latest, ubuntu-22.04]
-#    needs: unit-tests
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: |
-          pyproject.toml
-          requirements.txt
-          dev-requirements.txt
-    - name: Install additional packages for Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libegl1
-    - name: Install dependencies
-      env:
-        PYTHONUTF8: 1
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        python -m pip install -r dev-requirements.txt
-    - name: List packages
-      run: 
-        python -m pip list
-    - name: Run tests
-      run:
-        python -m unittest discover --pattern execution_test.py --verbose
+    uses: ./.github/workflows/execution_tests.yml
+    with:
+      host-os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+    secrets: inherit

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,75 @@
+name: Unit tests
+
+on:
+  workflow_call:
+    inputs:
+      host-os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      repository:
+        required: false
+        type: string
+        default: ${{ github.repository }}
+      coverage:
+        required: false
+        type: boolean
+        default: true
+      post-installation-command:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
+jobs:
+  unit-tests:
+    name: Run unit tests
+    runs-on: ${{ inputs.host-os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
+        fetch-depth: 0
+    - name: Version from Git tags
+      run: git describe --tags
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          requirements.txt
+          dev-requirements.txt
+    - name: Install additional packages for Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libegl1
+    - name: Install dependencies
+      env:
+        PYTHONUTF8: 1
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
+    - name: Run post-install command
+      if: ${{ inputs.post-installation-command }}
+      run:
+        ${{ inputs.post-installation-command }}
+    - name: Run tests
+      run: |
+        if [ "$RUNNER_OS" != "Windows" ]; then
+          export QT_QPA_PLATFORM=offscreen
+        fi
+        ${{ inputs.coverage && 'coverage run' || 'python' }} -m unittest discover --verbose
+      shell: bash
+    - name: Upload coverage report to Codecov
+      if: ${{ inputs.coverage }}
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Unit and execution test actions are now separate YAML files that can be called from other repositories. In particular, Spine-Database-API can now reuse the callable actions to run Toolbox unit tests.

No associated issue

## Checklist before merging
- [ ] Unit tests pass
