### PR TITLE
Exclude PySide6 6.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8.1"
 dependencies = [
-    "PySide6 >= 6.5.0, != 6.5.3, != 6.6.3, != 6.7.0",
+    "PySide6 >= 6.5.0, != 6.5.3, != 6.6.3, != 6.7.0, != 6.8.0",
     "jupyter_client >=6.0",
     "qtconsole >=5.1",
     "spinedb_api>=0.31.6",


### PR DESCRIPTION
This version of PySide6 makes Toolbox segfault on Windows.

Resolves #2978

## Checklist before merging
- [ ] Unit tests pass
