### PR TITLE
Fix opening DB editor tab when editor window has a empty tab only

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/multi_spine_db_editor.py
@@ -213,7 +213,7 @@ def _get_existing_spine_db_editor(db_urls):
     for multi_db_editor in db_editor_registry.windows():
         for k in range(multi_db_editor.tab_widget.count()):
             db_editor = multi_db_editor.tab_widget.widget(k)
-            if all(url in db_urls for url in db_editor.db_urls):
+            if db_editor.db_urls and all(url in db_urls for url in db_editor.db_urls):
                 return multi_db_editor, db_editor
     return None
 

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -1329,7 +1329,7 @@ class ToolboxUI(QMainWindow):
 
     @Slot(bool)
     def new_db_editor(self):
-        editor = MultiSpineDBEditor(self.db_mngr, {})
+        editor = MultiSpineDBEditor(self.db_mngr, [])
         editor.show()
 
     @Slot()

--- a/tests/spine_db_editor/widgets/test_multi_spine_db_editor.py
+++ b/tests/spine_db_editor/widgets/test_multi_spine_db_editor.py
@@ -13,10 +13,10 @@
 """Unit tests for SpineDBEditor classes."""
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from PySide6.QtCore import QPoint, QSettings
 from PySide6.QtWidgets import QApplication
-from spinetoolbox.spine_db_editor.editors import db_editor_registry
+from spinetoolbox.multi_tab_windows import MultiTabWindowRegistry
 from spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor import MultiSpineDBEditor, open_db_editor
 from spinetoolbox.spine_db_manager import SpineDBManager
 from tests.mock_helpers import FakeDataStore, TestCaseWithQApplication, clean_up_toolbox, create_toolboxui_with_project
@@ -54,6 +54,7 @@ class TestOpenDBEditor(TestCaseWithQApplication):
         self._db_url = "sqlite:///" + str(db_path)
         self._db_mngr = SpineDBManager(QSettings(), None)
         self._logger = MagicMock()
+        self._db_editor_registry = MultiTabWindowRegistry()
 
     def tearDown(self):
         self._db_mngr.close_all_sessions()
@@ -69,14 +70,45 @@ class TestOpenDBEditor(TestCaseWithQApplication):
             else:
                 running = False
 
-    def test_open_db_editor(self):
-        self.assertFalse(db_editor_registry.has_windows())
-        open_db_editor([self._db_url], self._db_mngr, reuse_existing_editor=True)
-        self.assertEqual(len(db_editor_registry.windows()), 1)
-        open_db_editor([self._db_url], self._db_mngr, reuse_existing_editor=True)
-        self.assertEqual(len(db_editor_registry.windows()), 1)
-        editor = db_editor_registry.windows()[0]
-        self.assertEqual(editor.tab_widget.count(), 1)
-        for editor in db_editor_registry.windows():
+    def _close_windows(self):
+        for editor in self._db_editor_registry.windows():
             QApplication.processEvents()
             editor.close()
+        self.assertFalse(self._db_editor_registry.has_windows())
+
+    def test_open_db_editor(self):
+        with (
+            patch(
+                "spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.db_editor_registry",
+                self._db_editor_registry,
+            ),
+            patch("spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.MultiSpineDBEditor.show") as mock_show,
+        ):
+            self.assertFalse(self._db_editor_registry.has_windows())
+            open_db_editor([self._db_url], self._db_mngr, reuse_existing_editor=True)
+            mock_show.assert_called_once()
+            self.assertEqual(len(self._db_editor_registry.windows()), 1)
+            open_db_editor([self._db_url], self._db_mngr, reuse_existing_editor=True)
+            self.assertEqual(len(self._db_editor_registry.windows()), 1)
+            editor = self._db_editor_registry.windows()[0]
+            self.assertEqual(editor.tab_widget.count(), 1)
+            self._close_windows()
+
+    def test_open_db_in_tab_when_editor_has_an_empty_tab(self):
+        with (
+            patch(
+                "spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.db_editor_registry",
+                self._db_editor_registry,
+            ),
+            patch("spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor.MultiSpineDBEditor.show") as mock_show,
+        ):
+            self.assertFalse(self._db_editor_registry.has_windows())
+            window = MultiSpineDBEditor(self._db_mngr, [])
+            self.assertEqual(window.tab_widget.count(), 1)
+            tab = window.tab_widget.widget(0)
+            self.assertEqual(tab.db_urls, [])
+            open_db_editor([self._db_url], self._db_mngr, reuse_existing_editor=True)
+            self.assertEqual(window.tab_widget.count(), 2)
+            tab = window.tab_widget.widget(1)
+            self.assertEqual(tab.db_urls, [self._db_url])
+            self._close_windows()


### PR DESCRIPTION
No associated issue

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
