### PR TITLE
Update bundling action

### DIFF
--- a/.github/workflows/make_bundle.yml
+++ b/.github/workflows/make_bundle.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           mkdir embedded-python
           cd embedded-python
-          curl -o python.zip https://www.python.org/ftp/python/3.12.3/python-3.12.3-embed-amd64.zip
+          curl -o python.zip https://www.python.org/ftp/python/3.12.7/python-3.12.7-embed-amd64.zip
           tar xf python.zip
           del python.zip
       - name: Edit embedded Python search paths
@@ -65,7 +65,7 @@ jobs:
         run: |
           cd embedded-python/Scripts
           ./pip.exe --version
-          ./pip.exe install ipykernel jill
+          ./pip.exe install spinedb-api pandas ipykernel jill
       - name: List packages in embedded Python
         run: |
           cd embedded-python/Scripts
@@ -79,7 +79,7 @@ jobs:
         run: |
           python -c "from importlib.metadata import version; print('version=' + version('spinetoolbox'))" >> $GITHUB_OUTPUT
       - name: Upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Spine-Toolbox-win-${{ steps.toolbox-version.outputs.version }}
           path: "./dist/Spine Toolbox"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- [Bundled App] **Embedded Python** now includes spinedb-api and pandas 
+in addition to ipykernel and jill.
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
This PR updates make_bundle.yml with the following changes

- Use upload_artifact v4
- Include the newest Python 3.12  (3.12.7) as the embedded python
- Install spinedb_api and pandas for the embedded Python

Fixes #3000

## Checklist before merging
- [x] Release notes have been updated
- [x] Unit tests pass
