### PR TITLE
Fix RunTimeWarning

### DIFF
--- a/spinetoolbox/main.py
+++ b/spinetoolbox/main.py
@@ -13,6 +13,7 @@
 """Provides the main() function."""
 import multiprocessing
 import os
+import asyncio
 import PySide6
 
 dirname = os.path.dirname(PySide6.__file__)
@@ -38,6 +39,7 @@ from spine_items import resources_icons_rc  # pylint: disable=unused-import  # i
 
 def main():
     """Creates main window GUI and starts main event loop."""
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     multiprocessing.freeze_support()
     logging.basicConfig(
         stream=sys.stderr,

--- a/spinetoolbox/main.py
+++ b/spinetoolbox/main.py
@@ -39,8 +39,9 @@ from spine_items import resources_icons_rc  # pylint: disable=unused-import  # i
 
 def main():
     """Creates main window GUI and starts main event loop."""
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     multiprocessing.freeze_support()
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     logging.basicConfig(
         stream=sys.stderr,
         level=logging.DEBUG,


### PR DESCRIPTION
Set default event loop policy for asyncio.

Fixes #3027

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
