### PR TITLE
Use "parsed_value" where appropriate

### DIFF
--- a/spinetoolbox/plotting.py
+++ b/spinetoolbox/plotting.py
@@ -707,7 +707,7 @@ def plot_db_mngr_items(items, db_maps, db_name_registry, plot_widget=None):
         raise PlottingError("Database maps don't match parameter values.")
     root_node = TreeNode("database")
     for item, db_map in zip(items, db_maps):
-        value = from_database(item["value"], item["type"])
+        value = item["parsed_value"]
         db_name = db_name_registry.display_name(db_map.sa_url)
         if value is None:
             continue

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -700,7 +700,7 @@ class GraphViewMixin:
         )
         if not pv:
             return None
-        return from_database(pv["value"], pv["type"])
+        return pv["parsed_value"]
 
     def get_item_name(self, db_map, entity_id):
         if not self.ui.graphicsView.name_parameter:


### PR DESCRIPTION
Get value from "parsed_value" avoiding possible call to from_database() in a few appropriate places.

Re spine-tools/Spine-Database-API#479

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
