### PR TITLE
Fix database locking issues in DB editor

### DIFF
--- a/spinetoolbox/parameter_type_validation.py
+++ b/spinetoolbox/parameter_type_validation.py
@@ -70,7 +70,8 @@ class ParameterTypeValidator(QObject):
         if not self._process.is_alive():
             self._process.start()
         for item_id in value_item_ids:
-            item = db_mngr.get_item(db_map, item_id.item_type, item_id)
+            with db_mngr.get_lock(db_map):
+                item = db_mngr.get_item(db_map, item_id.item_type, item_id)
             args = type_check_args(item)
             self._task_queue.append(
                 ValidatableValue(ValidationKey(item_id.item_type, id(db_map), item_id.private_id), args)

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -342,8 +342,9 @@ class ParameterMixin:
             PARAMETER_TYPE_VALIDATION_ROLE,
         }:
             id_ = self._main_data[index.row()]
-            item = self.db_mngr.get_item(self.db_map, self.item_type, id_)
-            return self.db_mngr.get_value(self.db_map, item, role)
+            with self.db_mngr.get_lock(self.db_map):
+                item = self.db_mngr.get_item(self.db_map, self.item_type, id_)
+                return self.db_mngr.get_value(self.db_map, item, role)
         return super().data(index, role)
 
     def add_rows(self, ids):


### PR DESCRIPTION
This PR fixes two cases of `SQLite objects created in a thread can only be used in that same thread.`

No associated issue

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
