### PR TITLE
Random improvements to DB editor UX

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_editors.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_editors.py
@@ -212,7 +212,7 @@ class SearchBarEditor(QTableView):
         for item in sorted(items, key=lambda x: order_key(x.casefold())):
             qitem = QStandardItem(item)
             item_list.append(qitem)
-            qitem.setFlags(~Qt.ItemIsEditable)
+            qitem.setFlags(~Qt.ItemFlag.ItemIsEditable)
         self._model.invisibleRootItem().appendRows(item_list)
         self.first_index = self.proxy_model.mapFromSource(self._model.index(0, 0))
 
@@ -277,7 +277,7 @@ class SearchBarEditor(QTableView):
             text (str): text the user has entered on the first row
         """
         self._original_text = text
-        self.proxy_model.setFilterRegularExpression("^" + text)
+        self.proxy_model.setFilterRegularExpression(text)
         self.proxy_model.setData(self.first_index, text)
         self.refit()
 


### PR DESCRIPTION
- The search bar editor used e.g. in Parameter value table now matches the search string to any position, not just the beginning. Parameters should now be a lot more discoverable as you can just type in 'cost' to get all parameters with 'cost' in their name.
- The down key now adds a new row to some tables in DB editor making it faster to e.g. add new entities using the keyboard alone.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
