### PR TITLE
Remove unneeded PyInstaller hooks

### DIFF
--- a/PyInstaller hooks/hook-datapackage.py
+++ b/PyInstaller hooks/hook-datapackage.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-datas = collect_data_files("datapackage")

--- a/PyInstaller hooks/hook-tabulator.py
+++ b/PyInstaller hooks/hook-tabulator.py
@@ -1,5 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-datas = collect_data_files("tabulator")
-datas += collect_data_files("tabulator", subdir="loaders", include_py_files=True)
-datas += collect_data_files("tabulator", subdir="parsers", include_py_files=True)

--- a/spinetoolbox.spec
+++ b/spinetoolbox.spec
@@ -35,7 +35,8 @@ Steps to bundle Spine Toolbox:
     pip install ipykernel
 11. Run
     pip install jill
-12. Finally, run
+12. cd to the directory where this file is
+13. Finally, run
     python -m PyInstaller spinetoolbox.spec -- --embedded-python=<path-to-embeddable-python>
 """
 


### PR DESCRIPTION
`datapackage` and `tabulator` are no more in our dependencies.

Re spine-tool/Spine-Database-API#491

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
