### PR TITLE
Fix SQLAlchemy deprecation warnings

### DIFF
--- a/execution_tests/parallel_importer/execution_test.py
+++ b/execution_tests/parallel_importer/execution_test.py
@@ -67,7 +67,7 @@ class ParallelImporter(unittest.TestCase):
         scenario_2_checked = False
         for value_row in value_rows:
             for key, expected_value in expected_common_data.items():
-                self.assertEqual(value_row[key], expected_value)
+                self.assertEqual(value_row._mapping[key], expected_value)
             value = from_database(value_row.value, value_row.type)
             if value == 11.0:
                 self.assertTrue(value_row.alternative_name.startswith("scenario_1__Import@"))
@@ -79,5 +79,5 @@ class ParallelImporter(unittest.TestCase):
         self.assertTrue(scenario_2_checked)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/parallel_importer_with_datapackage/execution_test.py
+++ b/execution_tests/parallel_importer_with_datapackage/execution_test.py
@@ -67,7 +67,7 @@ class ParallelImporterWithDatapackage(unittest.TestCase):
         scenario_2_checked = False
         for value_row in value_rows:
             for key, expected_value in expected_common_data.items():
-                self.assertEqual(value_row[key], expected_value)
+                self.assertEqual(value_row._mapping[key], expected_value)
             value = from_database(value_row.value, value_row.type)
             if value == 11.0:
                 self.assertTrue(value_row.alternative_name.startswith("scenario_1__Import@"))
@@ -79,5 +79,5 @@ class ParallelImporterWithDatapackage(unittest.TestCase):
         self.assertTrue(scenario_2_checked)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixed two minor warnings in the execution tests.

Re spine-tools/Spine-Database-API#477

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
