### PR TITLE
Add PyInstaller hook for frictionless to fix ZIP bundle

### DIFF
--- a/PyInstaller hooks/hook-frictionless.py
+++ b/PyInstaller hooks/hook-frictionless.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("frictionless", subdir="assets")


### PR DESCRIPTION
Attached the new Bundle to 0.9.3 release.

Fixes #3053

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
