### PR TITLE
Fix Traceback in Add entities dialog

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -608,9 +608,8 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
         created_entities = {}
         for db_map, data in db_map_data.items():
             for item in data:
-                created_entities.update(
-                    {item["name"]: db_map.get_entity_item(class_id=item["class_id"], name=item["name"])}
-                )
+                entity_name = item["name"]
+                created_entities[entity_name] = db_map.get_entity_item(class_id=item["class_id"], name=entity_name)
         entity_alternatives = self.make_entity_alternatives(created_entities)
         if entity_alternatives:  # If alternatives have been defined
             self.db_mngr.add_entity_alternatives(entity_alternatives)
@@ -630,9 +629,11 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
             alternative = row_data[alternative_column]
             if not alternative:
                 continue
-            alternative = alternative.split("@")[0]
             entity_name = row_data[name_column]
             entity = entities[entity_name]
+            if not entity:
+                continue
+            alternative = alternative.split("@")[0]
             db_names = row_data[db_column]
             for db_name in db_names.split(", "):
                 db_map = self.keyed_db_maps[db_name]

--- a/tests/spine_db_editor/widgets/helpers.py
+++ b/tests/spine_db_editor/widgets/helpers.py
@@ -110,7 +110,7 @@ def add_entity_tree_item(item_names, view, menu_action_text, dialog_class):
 
 def add_zero_dimension_entity_class(view, name):
     view._context_item = view.model().root_item
-    add_entity_tree_item({0: name}, view, "Add entity classes", AddEntityClassesDialog)
+    add_entity_tree_item({0: name}, view, "Add entity classes...", AddEntityClassesDialog)
 
 
 def add_entity(view, name, entity_class_index=0, alternative=None, group=None):
@@ -123,7 +123,7 @@ def add_entity(view, name, entity_class_index=0, alternative=None, group=None):
         data.update({1: alternative})
     if group:
         data.update({2: group})
-    add_entity_tree_item(data, view, "Add entities", AddEntitiesDialog)
+    add_entity_tree_item(data, view, "Add entities...", AddEntitiesDialog)
 
 
 def select_item_with_index(view, index, extend=False):

--- a/tests/spine_db_editor/widgets/test_custom_qtreeview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtreeview.py
@@ -324,7 +324,10 @@ class TestEntityTreeViewWithInitiallyEmptyDatabase(TestBase):
         entity_class_index = entity_model.index(0, 0, root_index)
         entity_tree_view._context_item = entity_model.item_from_index(entity_class_index)
         add_entity_tree_item(
-            {1: "my_first_dimension_is_an_entity_class"}, entity_tree_view, "Add entity classes", AddEntityClassesDialog
+            {1: "my_first_dimension_is_an_entity_class"},
+            entity_tree_view,
+            "Add entity classes...",
+            AddEntityClassesDialog,
         )
         view = self._db_editor.ui.treeView_entity
         model = view.model()
@@ -349,14 +352,14 @@ class TestEntityTreeViewWithInitiallyEmptyDatabase(TestBase):
         add_entity_tree_item(
             item_names,
             self._db_editor.ui.treeView_entity,
-            "Add entity classes",
+            "Add entity classes...",
             AddEntityClassesDialog,
         )
 
     def _add_multidimensional_entity(self, element_name, entity_names):
         item_names = dict(enumerate(entity_names))
         item_names[len(entity_names)] = element_name
-        add_entity_tree_item(item_names, self._db_editor.ui.treeView_entity, "Add entities", AddEntitiesDialog)
+        add_entity_tree_item(item_names, self._db_editor.ui.treeView_entity, "Add entities...", AddEntitiesDialog)
 
 
 class TestEntityTreeViewWithExistingZeroDimensionalEntities(TestBase):


### PR DESCRIPTION
If entity addition failed, we need not try to add an entity alternative.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
