### PR TITLE
Update REQUIRED_SPINE_OPT_VERSION

### DIFF
--- a/spinetoolbox/config.py
+++ b/spinetoolbox/config.py
@@ -18,7 +18,7 @@ import sys
 LATEST_PROJECT_VERSION = 13
 
 # For the Add/Update SpineOpt wizard
-REQUIRED_SPINE_OPT_VERSION = "0.9.0"
+REQUIRED_SPINE_OPT_VERSION = "0.10.0"
 
 # Invalid characters for directory names
 # NOTE: "." is actually valid in a directory name but this is


### PR DESCRIPTION
SpineOpt v0.10.0 has been released, which means that the constant in config.py needs to be updated, so that users of SpineOpt v0.9.x will be able to update SpineOpt to the latest one using the SpineOpt Add/Update widget in File->Settings.

No related issue

## Checklist before merging
- [ ] Unit tests pass
