### PR TITLE
Fix database reset

### DIFF
--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -11,6 +11,8 @@
 ######################################################################################################################
 
 """Models to represent items in a tree."""
+from __future__ import annotations
+from typing import Optional
 from PySide6.QtCore import QAbstractItemModel, QModelIndex, Qt
 
 
@@ -22,10 +24,9 @@ class TreeItem:
         Args:
             model (MinimalTreeModel): The model where the item belongs.
         """
-        super().__init__()
-        self._children = []
+        self._children: list[TreeItem] = []
         self._model = model
-        self._parent_item = None
+        self._parent_item: Optional[TreeItem] = None
         self._fetched = False
         self._set_up_once = False
         self._has_children_initially = False
@@ -38,33 +39,28 @@ class TreeItem:
         """Returns whether this item has or could have children."""
         if self._has_children_initially:
             return True
-        return bool(self.child_count())
+        return bool(self._children)
 
     @property
     def model(self):
         return self._model
 
     @property
-    def children(self):
+    def children(self) -> list[TreeItem]:
         return self._children
 
     @children.setter
-    def children(self, children):
-        bad_types = [type(child) for child in children if not isinstance(child, TreeItem)]
-        if bad_types:
-            raise TypeError(f"Can't set children of type {bad_types} for an item of type {type(self)}")
+    def children(self, children: list[TreeItem]) -> None:
         for child in children:
             child.parent_item = self
         self._children = children
 
     @property
-    def parent_item(self):
+    def parent_item(self) -> TreeItem:
         return self._parent_item
 
     @parent_item.setter
-    def parent_item(self, parent_item):
-        if not isinstance(parent_item, TreeItem) and parent_item is not None:
-            raise ValueError("Parent must be instance of TreeItem or None")
+    def parent_item(self, parent_item: Optional[TreeItem]) -> None:
         self._parent_item = parent_item
 
     def is_valid(self):
@@ -78,12 +74,12 @@ class TreeItem:
     def child(self, row):
         """Returns the child at given row or None if out of bounds."""
         if 0 <= row < len(self._children):
-            return self.children[row]
+            return self._children[row]
         return None
 
     def last_child(self):
         """Returns the last child."""
-        return self.child(self.child_count() - 1)
+        return self.child(len(self._children) - 1)
 
     def child_count(self):
         """Returns the number of children."""

--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -139,7 +139,8 @@ class UpdateItemsCommand(SpineDBCommand):
             self.setObsolete(True)
         self.item_type = item_type
         self.redo_data = data
-        self.undo_data = [self.db_mngr.get_item(self.db_map, item_type, item["id"])._asdict() for item in data]
+        table = db_map.mapped_table(item_type)
+        self.undo_data = [table[item["id"]]._asdict() for item in data]
         if self.redo_data == self.undo_data:
             self.setObsolete(True)
         self._check = check

--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -175,7 +175,8 @@ class AddUpdateItemsCommand(SpineDBCommand):
             self.setObsolete(True)
         self.item_type = item_type
         self.new_data = data
-        old_data = [x._asdict() for item in data if (x := self.db_map.get_item(item_type, **item))]
+        table = db_map.mapped_table(item_type)
+        old_data = [x._asdict() for item in data if (x := table.find_item(item))]
         if self.new_data == old_data:
             self.setObsolete(True)
         self.old_data = {x["id"]: x for x in old_data}

--- a/spinetoolbox/spine_db_editor/graphics_items.py
+++ b/spinetoolbox/spine_db_editor/graphics_items.py
@@ -125,7 +125,8 @@ class EntityItem(QGraphicsRectItem):
 
     @property
     def byname(self):
-        return self.db_mngr.get_item(self.first_db_map, "entity", self.first_id).get("entity_byname", ())
+        table = self.first_db_map.mapped_table("entity")
+        return table[self.first_id].get("entity_byname", ())
 
     @property
     def element_name_list(self):
@@ -173,7 +174,10 @@ class EntityItem(QGraphicsRectItem):
         }
 
     def entity_id(self, db_map):
-        return dict(self.db_map_ids).get(db_map)
+        for db_map_id in self._db_map_ids:
+            if db_map is db_map_id[0]:
+                return db_map_id[1] if db_map_id not in self._removed_db_map_ids else None
+        return None
 
     def db_map_data(self, db_map):
         # NOTE: Needed by EditEntitiesDialog

--- a/spinetoolbox/spine_db_editor/graphics_items.py
+++ b/spinetoolbox/spine_db_editor/graphics_items.py
@@ -137,7 +137,6 @@ class EntityItem(QGraphicsRectItem):
 
     @property
     def element_byname_list(self):
-        # NOTE: Needed by EditEntitiesDialog
         return self.db_mngr.get_item(self.first_db_map, "entity", self.first_id).get("element_byname_list", ())
 
     @property
@@ -180,11 +179,9 @@ class EntityItem(QGraphicsRectItem):
         return None
 
     def db_map_data(self, db_map):
-        # NOTE: Needed by EditEntitiesDialog
         return self.db_mngr.get_item(db_map, "entity", self.entity_id(db_map))
 
     def db_map_id(self, db_map):
-        # NOTE: Needed by EditEntitiesDialog
         return self.entity_id(db_map)
 
     def db_items(self, db_map):

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -54,7 +54,7 @@ class EntityTreeRootItem(MultiDBTreeItem):
 
     @property
     def visible_children(self):
-        return [x for x in self.children if not x.is_hidden()]
+        return [x for x in self._children if not x.is_hidden()]
 
     @property
     def display_id(self):
@@ -286,15 +286,10 @@ class EntityItem(MultiDBTreeItem):
         return self.parent_item.name in self.element_name_list
 
     def _can_fetch_more_entity_groups(self):
-        result = False
-        for db_map in self.db_maps:
-            result |= self.db_mngr.can_fetch_more(db_map, self._entity_group_fetch_parent)
-        return result
+        return any(self.db_mngr.can_fetch_more(db_map, self._entity_group_fetch_parent) for db_map in self.db_maps)
 
     def can_fetch_more(self):
-        result = self._can_fetch_more_entity_groups()
-        result |= super().can_fetch_more()
-        return result
+        return self._can_fetch_more_entity_groups() or super().can_fetch_more()
 
     def _fetch_more_entity_groups(self):
         for db_map in self.db_maps:

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -103,6 +103,12 @@ class SpineDBManager(QObject):
         object: database mapping
         bool: True if database has become clean, False if it became dirty
     """
+    database_reset = Signal(object)
+    """Emitted whenever database is reset.
+
+    Args:
+        object: database mapping
+    """
 
     def __init__(self, settings, parent, synchronous=False):
         """
@@ -579,6 +585,7 @@ class SpineDBManager(QObject):
             worker.reset_session()
             self.undo_stack[db_map].clear()
             reset_db_maps.add(db_map)
+            self.database_reset.emit(db_map)
         return reset_db_maps
 
     def commit_session(self, commit_msg, *dirty_db_maps, cookie=None):

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -1512,63 +1512,78 @@ class SpineDBManager(QObject):
         """Finds and returns cascading entity classes for the given dimension ids."""
         db_map_cascading_data = {}
         for db_map, dimension_ids in db_map_ids.items():
-            for item in self.get_items(db_map, "entity_class"):
-                if set(item["dimension_id_list"]) & set(dimension_ids):
-                    db_map_cascading_data.setdefault(db_map, []).append(item)
+            dimension_ids = set(dimension_ids)
+            with self.get_lock(db_map):
+                class_table = db_map.mapped_table("entity_class")
+                db_map.do_fetch_all(class_table)
+                for item in class_table.values():
+                    if item.is_valid() and not dimension_ids.isdisjoint(item["dimension_id_list"]):
+                        db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
     def find_cascading_entities(self, db_map_ids):
         """Finds and returns cascading entities for the given element ids."""
         db_map_cascading_data = {}
         for db_map, element_ids in db_map_ids.items():
-            for item in self.get_items(db_map, "entity"):
-                if set(item["element_id_list"]) & set(element_ids):
-                    db_map_cascading_data.setdefault(db_map, []).append(item)
+            element_ids = set(element_ids)
+            with self.get_lock(db_map):
+                entity_table = db_map.mapped_table("entity")
+                db_map.do_fetch_all(entity_table)
+                for item in entity_table.values():
+                    if item.is_valid() and not element_ids.isdisjoint(item["element_id_list"]):
+                        db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
-    def find_cascading_parameter_data(self, db_map_ids, item_type):
+    def find_cascading_parameter_definitions(self, db_map_ids):
         """Finds and returns cascading parameter definitions or values for the given entity_class ids."""
         db_map_cascading_data = {}
         for db_map, entity_class_ids in db_map_ids.items():
-            for item in self.get_items(db_map, item_type):
-                if item["entity_class_id"] in entity_class_ids:
-                    db_map_cascading_data.setdefault(db_map, []).append(item)
+            entity_class_ids = set(entity_class_ids)
+            with self.get_lock(db_map):
+                definition_table = db_map.mapped_table("parameter_definition")
+                db_map.do_fetch_all(definition_table)
+                for item in definition_table.values():
+                    if item.is_valid() and item["entity_class_id"] in entity_class_ids:
+                        db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
     def find_cascading_parameter_values_by_entity(self, db_map_ids):
         """Finds and returns cascading parameter values for the given entity ids."""
         db_map_cascading_data = {}
         for db_map, entity_ids in db_map_ids.items():
-            for item in self.get_items(db_map, "parameter_value"):
-                if item["entity_id"] in entity_ids:
-                    db_map_cascading_data.setdefault(db_map, []).append(item)
-        return db_map_cascading_data
-
-    def find_cascading_parameter_values_by_definition(self, db_map_ids):
-        """Finds and returns cascading parameter values for the given parameter_definition ids."""
-        db_map_cascading_data = {}
-        for db_map, param_def_ids in db_map_ids.items():
-            for item in self.get_items(db_map, "parameter_value"):
-                if item["parameter_id"] in param_def_ids:
-                    db_map_cascading_data.setdefault(db_map, []).append(item)
+            entity_ids = set(entity_ids)
+            with self.get_lock(db_map):
+                parameter_table = db_map.mapped_table("parameter_value")
+                db_map.do_fetch_all(parameter_table)
+                for item in parameter_table.values():
+                    if item.is_valid() and item["entity_id"] in entity_ids:
+                        db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
     def find_cascading_scenario_alternatives_by_scenario(self, db_map_ids):
         """Finds and returns cascading scenario alternatives for the given scenario ids."""
         db_map_cascading_data = {}
         for db_map, ids in db_map_ids.items():
-            for item in self.get_items(db_map, "scenario_alternative"):
-                if item["scenario_id"] in ids:
-                    db_map_cascading_data.setdefault(db_map, []).append(item)
+            ids = set(ids)
+            with self.get_lock(db_map):
+                scenario_alternative_table = db_map.mapped_table("scenario_alternative")
+                db_map.do_fetch_all(scenario_alternative_table)
+                for item in scenario_alternative_table.values():
+                    if item.is_valid() and item["scenario_id"] in ids:
+                        db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
     def find_groups_by_entity(self, db_map_ids):
         """Finds and returns groups for the given entity ids."""
         db_map_group_data = {}
         for db_map, entity_ids in db_map_ids.items():
-            for item in self.get_items(db_map, "entity_group"):
-                if item["entity_id"] in entity_ids:
-                    db_map_group_data.setdefault(db_map, []).append(item)
+            entity_ids = set(entity_ids)
+            with self.get_lock(db_map):
+                entity_group_table = db_map.mapped_table("entity_group")
+                db_map.do_fetch_all(entity_group_table)
+                for item in entity_group_table.values():
+                    if item.is_valid() and item["entity_id"] in entity_ids:
+                        db_map_group_data.setdefault(db_map, []).append(item.public_item)
         return db_map_group_data
 
     def duplicate_scenario(self, scen_data, dup_name, db_map):

--- a/spinetoolbox/spine_db_parcel.py
+++ b/spinetoolbox/spine_db_parcel.py
@@ -162,9 +162,7 @@ class SpineDBParcel:
         """Pushes parameter definitions associated with given entity classes.
         This essentially full_pushes the entity classes, their parameter definitions, and their member entity classes.
         """
-        param_def_ids = self.db_mngr.db_map_ids(
-            self.db_mngr.find_cascading_parameter_data(db_map_ids, "parameter_definition")
-        )
+        param_def_ids = self.db_mngr.db_map_ids(self.db_mngr.find_cascading_parameter_definitions(db_map_ids))
         self.push_parameter_definition_ids(param_def_ids)
         db_map_ids = {db_map: ids - param_def_ids.get(db_map, set()) for db_map, ids in db_map_ids.items()}
         self.push_entity_class_ids(db_map_ids)

--- a/spinetoolbox/spine_db_parcel.py
+++ b/spinetoolbox/spine_db_parcel.py
@@ -42,7 +42,7 @@ class SpineDBParcel:
         if ids is Asterisk:
             fields = {x.get(field) for x in self.db_mngr.get_items(db_map, item_type)}
         else:
-            fields = {self.db_mngr.get_field(db_map, item_type, id_, field) for id_ in ids}
+            fields = {self.db_mngr.get_item(db_map, item_type, id_).get(field) for id_ in ids}
         fields.discard(None)
         return fields
 

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -294,14 +294,18 @@ class SpineDBWorker(QObject):
     def refresh_session(self):
         """Refreshes session."""
         self._db_map.refresh_session()
+        self._reset_fetching()
+
+    def reset_session(self):
+        """Resets session."""
+        self._db_map.reset()
+        self.commit_cache.clear()
+        self._reset_fetching()
+
+    def _reset_fetching(self):
         for parent_type in self._parents_by_type:
             for parent in self._get_parents(parent_type):
                 parent.reset()
         self._offsets.clear()
         self._fetched_item_types.clear()
         self._parents_fetching.clear()
-
-    def reset_session(self):
-        """Resets session."""
-        self._db_map.reset()
-        self.refresh_session()

--- a/tests/spine_db_editor/mvcmodels/test_alternative_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_alternative_model.py
@@ -78,8 +78,9 @@ class TestAlternativeModel(TestCaseWithQApplication):
         model = AlternativeModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         _fetch_all_recursively(model)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1", "id": 2}]})
-        self._db_mngr.update_alternatives({self._db_map: [{"id": 2, "name": "renamed"}]})
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        alternative_id = self._db_map.alternative(name="alternative_1")["id"]
+        self._db_mngr.update_alternatives({self._db_map: [{"id": alternative_id, "name": "renamed"}]})
         data = model_data_to_dict(model)
         expected = [
             [
@@ -99,8 +100,9 @@ class TestAlternativeModel(TestCaseWithQApplication):
         model = AlternativeModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         _fetch_all_recursively(model)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1", "id": 2}]})
-        self._db_mngr.remove_items({self._db_map: {"alternative": {2}}})
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        alternative_id = self._db_map.alternative(name="alternative_1")["id"]
+        self._db_mngr.remove_items({self._db_map: {"alternative": {alternative_id}}})
         data = model_data_to_dict(model)
         expected = [
             [{self.db_codename: [["Base", "Base alternative"], ["Type new alternative name here...", ""]]}, None]

--- a/tests/spine_db_editor/mvcmodels/test_frozen_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_frozen_table_model.py
@@ -66,7 +66,8 @@ class TestFrozenTableModel(TestCaseWithQApplication):
 
     def test_add_values(self):
         self._model.set_headers(["alternative", "database"])
-        self._model.add_values({((self._db_map, 1), self._db_map)})
+        alternative_id = self._db_map.alternative(name="Base")["id"]
+        self._model.add_values({((self._db_map, alternative_id), self._db_map)})
         self.assertEqual(self._model.rowCount(), 2)
         self.assertEqual(self._model.columnCount(), 2)
         self.assertEqual(self._model.index(0, 0).data(), "alternative")
@@ -134,7 +135,8 @@ class TestFrozenTableModel(TestCaseWithQApplication):
         self.assertEqual(self._model.get_frozen_value(), ((self._db_map, 1), self._db_map))
 
     def test_insert_column_data_to_empty_model(self):
-        self._model.insert_column_data("alternative", {(self._db_map, 1)}, 0)
+        alternative_id = self._db_map.alternative(name="Base")["id"]
+        self._model.insert_column_data("alternative", {(self._db_map, alternative_id)}, 0)
         self.assertEqual(self._model.columnCount(), 1)
         self.assertEqual(self._model.rowCount(), 2)
         self.assertEqual(self._model.index(0, 0).data(), "alternative")
@@ -228,9 +230,16 @@ class TestFrozenTableModel(TestCaseWithQApplication):
 
     def test_table_stays_sorted(self):
         self._model.insert_column_data("database", {self._db_map}, 0)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1", "id": 2}]})
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Gadget", "id": 1}]})
-        self._db_mngr.add_entities({self._db_map: [{"class_id": 1, "name": "fork"}, {"class_id": 1, "name": "spoon"}]})
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Gadget"}]})
+        self._db_mngr.add_entities(
+            {
+                self._db_map: [
+                    {"entity_class_name": "Gadget", "name": "fork"},
+                    {"entity_class_name": "Gadget", "name": "spoon"},
+                ]
+            }
+        )
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.insert_column_data("alternative", {(self._db_map, id_) for id_ in ids}, 0)
@@ -258,7 +267,8 @@ class TestFrozenTableModel(TestCaseWithQApplication):
 
     def test_tooltips_work_when_no_data_is_available(self):
         self._model.insert_column_data("database", {self._db_map}, 0)
-        self._db_mngr.remove_items({self._db_map: {"alternative": [1]}})
+        alternative_id = self._db_map.alternative(name="Base")["id"]
+        self._db_mngr.remove_items({self._db_map: {"alternative": [alternative_id]}})
         self._model.insert_column_data("alternative", {(self._db_map, None)}, 1)
         self.assertEqual(self._model.headers, ["database", "alternative"])
         model_data = model_data_to_table(self._model)

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -89,9 +89,10 @@ class TestScenarioModel(_TestBase):
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test.", "id": 1}]})
+        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
+        scenario_id = self._db_map.scenario(name="scenario_1")["id"]
         self._db_mngr.update_scenarios(
-            {self._db_map: [{"name": "scenario_2.0", "description": "More than just a test.", "id": 1}]}
+            {self._db_map: [{"name": "scenario_2.0", "description": "More than just a test.", "id": scenario_id}]}
         )
         data = model_data_to_dict(model)
         expected = [
@@ -111,8 +112,9 @@ class TestScenarioModel(_TestBase):
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test.", "id": 1}]})
-        self._db_mngr.remove_items({self._db_map: {"scenario": {1}}})
+        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
+        scenario_id = self._db_map.scenario(name="scenario_1")["id"]
+        self._db_mngr.remove_items({self._db_map: {"scenario": {scenario_id}}})
         data = model_data_to_dict(model)
         expected = [[{self.db_codename: [["Type new scenario name here...", ""]]}, None]]
         self.assertEqual(data, expected)
@@ -381,11 +383,14 @@ class TestScenarioModel(_TestBase):
         self.assertEqual(model_data, expected)
 
     def test_duplicate_scenario(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1", "id": 2}]})
-        self._db_mngr.add_scenarios(
-            {self._db_map: [{"name": "my_scenario", "description": "My test scenario", "id": 1}]}
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_scenarios({self._db_map: [{"name": "my_scenario", "description": "My test scenario"}]})
+        scenario_id = self._db_map.scenario(name="my_scenario")["id"]
+        base_alternative_id = self._db_map.alternative(name="Base")["id"]
+        alternative_1_id = self._db_map.alternative(name="alternative_1")["id"]
+        self._db_mngr.set_scenario_alternatives(
+            {self._db_map: [{"id": scenario_id, "alternative_id_list": [alternative_1_id, base_alternative_id]}]}
         )
-        self._db_mngr.set_scenario_alternatives({self._db_map: [{"id": 1, "alternative_id_list": [2, 1]}]})
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
@@ -490,7 +495,7 @@ class TestScenarioModelWithTwoDatabases(_TestBase):
     def test_paste_scenario_mime_data(self):
         self._db_mngr.add_scenarios({self._db_map1: [{"name": "my_scenario"}]})
         self._db_mngr.add_alternatives({self._db_map1: [{"name": "alternative_1"}]})
-        scenario_id = self._db_map1.get_scenario_item(name="my_scenario")["id"]
+        scenario_id = self._db_map1.scenario(name="my_scenario")["id"]
         self._db_mngr.set_scenario_alternatives(
             {self._db_map1: [{"id": scenario_id, "alternative_name_list": ["alternative_1", "Base"]}]}
         )

--- a/tests/spine_db_editor/test_graphics_items.py
+++ b/tests/spine_db_editor/test_graphics_items.py
@@ -36,24 +36,23 @@ class TestEntityItem(TestCaseWithQApplication):
             self._db_mngr.name_registry.register(self._db_map.sa_url, "database")
             self._spine_db_editor = SpineDBEditor(self._db_mngr, {"sqlite://": "database"})
             self._spine_db_editor.pivot_table_model = mock.MagicMock()
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc", "id": 1}]})
-        self._db_mngr.add_entities({self._db_map: [{"name": "o", "class_id": 1, "id": 1}]})
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "rc", "id": 2, "dimension_id_list": [1]}]})
+        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc"}]})
+        self._db_mngr.add_entities({self._db_map: [{"name": "o", "entity_class_name": "oc"}]})
+        self._db_mngr.add_entity_classes({self._db_map: [{"name": "rc", "dimension_name_list": ["oc"]}]})
         self._db_mngr.add_entities(
             {
                 self._db_map: [
                     {
                         "name": "r",
-                        "id": 2,
-                        "class_id": 2,
                         "entity_class_name": "rc",
-                        "element_id_list": [1],
+                        "element_name_list": ["o"],
                     }
                 ]
             }
         )
+        entity_id = self._db_map.entity(entity_class_name="rc", name="r")["id"]
         with mock.patch.object(EntityItem, "refresh_icon"):
-            self._item = EntityItem(self._spine_db_editor, 0.0, 0.0, 0, ((self._db_map, 2),))
+            self._item = EntityItem(self._spine_db_editor, 0.0, 0.0, 0, ((self._db_map, entity_id),))
 
     @classmethod
     def tearDownClass(cls):
@@ -78,7 +77,7 @@ class TestEntityItem(TestCaseWithQApplication):
         self.assertEqual(self._item.name, "r")
 
     def test_entity_class_id(self):
-        self.assertEqual(self._item.entity_class_id(self._db_map), self._db_map.get_entity_class_item(id=2)["id"])
+        self.assertEqual(self._item.entity_class_id(self._db_map), self._db_map.entity_class(name="rc")["id"])
 
     def test_entity_class_name(self):
         self.assertEqual(self._item.entity_class_name, "rc")
@@ -87,7 +86,9 @@ class TestEntityItem(TestCaseWithQApplication):
         self.assertIs(self._item.first_db_map, self._db_map)
 
     def test_entity_id(self):
-        self.assertEqual(self._item.entity_id(self._db_map), 2)
+        self.assertEqual(
+            self._item.entity_id(self._db_map), self._db_map.entity(entity_class_name="rc", name="r")["id"]
+        )
 
     def test_first_db_map(self):
         self.assertIs(self._item.first_db_map, self._db_map)
@@ -103,15 +104,8 @@ class TestEntityItem(TestCaseWithQApplication):
 
     def test_db_map_data(self):
         self.assertEqual(
-            self._item.db_map_data(self._db_map).resolve(),
-            {
-                "name": "r",
-                "id": 2,
-                "class_id": 2,
-                "entity_class_name": "rc",
-                "element_id_list": (1,),
-                "description": None,
-            },
+            self._item.db_map_data(self._db_map)._asdict(),
+            self._db_map.entity(entity_class_name="rc", name="r"),
         )
 
     def test_db_map_id_equals_entity_id(self):

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
@@ -16,8 +16,8 @@ from PySide6.QtCore import QItemSelectionModel, Qt
 from PySide6.QtGui import QColor, QPen
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
-from .helpers import select_item_with_index
-from .spine_db_editor_test_base import DBEditorTestBase
+from tests.spine_db_editor.widgets.helpers import select_item_with_index
+from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
 class TestSpineDBEditorStackedFilter(DBEditorTestBase):

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -568,5 +568,241 @@ class TestRemoveScenarioAlternative(TestCaseWithQApplication):
         self._db_mngr.error_msg.emit.assert_not_called()
 
 
+class TestFindCascadingItems(TestCaseWithQApplication):
+    def setUp(self):
+        mock_settings = MagicMock()
+        mock_settings.value.side_effect = lambda *args, **kwargs: 0
+        self._db_mngr = SpineDBManager(mock_settings, None)
+        self._logger = MagicMock()
+        self._db_map = self._db_mngr.get_db_map("sqlite://", self._logger, create=True)
+        self._db_mngr.name_registry.register(self._db_map.sa_url, "test_database")
+
+    def tearDown(self):
+        self._db_mngr.close_all_sessions()
+        while not self._db_map.closed:
+            QApplication.processEvents()
+        self._db_mngr.clean_up()
+
+    def test_find_cascading_entity_classes(self):
+        self._db_mngr.add_entity_classes(
+            {
+                self._db_map: [
+                    {"name": "O1"},
+                    {"name": "O2"},
+                    {"name": "O3"},
+                    {"name": "O4"},
+                    {"dimension_name_list": ["O1"]},
+                    {"dimension_name_list": ["O2"]},
+                    {"dimension_name_list": ["O3"]},
+                    {"dimension_name_list": ["O1", "O2"]},
+                    {"dimension_name_list": ["O1", "O3"]},
+                    {"dimension_name_list": ["O2", "O3"]},
+                    {"dimension_name_list": ["O1", "O2", "O3"]},
+                ]
+            }
+        )
+        o1_id = self._db_map.entity_class(name="O1")["id"]
+        data = {
+            db_map: [c["name"] for c in values]
+            for db_map, values in self._db_mngr.find_cascading_entity_classes({self._db_map: [o1_id]}).items()
+        }
+        self.assertEqual(len(data), 1)
+        self.assertCountEqual(data[self._db_map], ["O1__", "O1__O2", "O1__O3", "O1__O2__O3"])
+        o4_id = self._db_map.entity_class(name="O4")["id"]
+        self.assertEqual(self._db_mngr.find_cascading_entity_classes({self._db_map: [o4_id]}), {})
+        o1__o2_id = self._db_map.entity_class(name="O1__O2")["id"]
+        self.assertEqual(self._db_mngr.find_cascading_entity_classes({self._db_map: [o1__o2_id]}), {})
+        self._db_mngr.remove_items({self._db_map: {"entity_class": {o1__o2_id}}})
+        data = {
+            db_map: [c["name"] for c in values]
+            for db_map, values in self._db_mngr.find_cascading_entity_classes({self._db_map: [o1_id]}).items()
+        }
+        self.assertEqual(len(data), 1)
+        self.assertCountEqual(data[self._db_map], ["O1__", "O1__O3", "O1__O2__O3"])
+
+    def test_find_cascading_entities(self):
+        self._db_mngr.add_entity_classes(
+            {
+                self._db_map: [
+                    {"name": "O1"},
+                    {"name": "O2"},
+                    {"name": "O3"},
+                    {"name": "O4"},
+                    {"dimension_name_list": ["O1"]},
+                    {"dimension_name_list": ["O2"]},
+                    {"dimension_name_list": ["O3"]},
+                    {"dimension_name_list": ["O1", "O2"]},
+                    {"dimension_name_list": ["O1", "O3"]},
+                    {"dimension_name_list": ["O2", "O3"]},
+                    {"dimension_name_list": ["O1", "O2", "O3"]},
+                ]
+            }
+        )
+        self._db_mngr.add_entities(
+            {
+                self._db_map: [
+                    {"entity_class_name": "O1", "name": "o11"},
+                    {"entity_class_name": "O1", "name": "o12"},
+                    {"entity_class_name": "O1", "name": "o13"},
+                    {"entity_class_name": "O2", "name": "o21"},
+                    {"entity_class_name": "O3", "name": "o31"},
+                    {"entity_class_name": "O1__O2", "element_name_list": ("o11", "o21")},
+                    {"entity_class_name": "O1__O2", "element_name_list": ("o12", "o21")},
+                    {"entity_class_name": "O2__O3", "element_name_list": ("o21", "o31")},
+                ]
+            }
+        )
+        o13_id = self._db_map.entity(entity_class_name="O1", name="o13")["id"]
+        self.assertEqual(self._db_mngr.find_cascading_entities({self._db_map: [o13_id]}), {})
+        o11_id = self._db_map.entity(entity_class_name="O1", name="o11")["id"]
+        data = {
+            db_map: [c["name"] for c in values]
+            for db_map, values in self._db_mngr.find_cascading_entities({self._db_map: [o11_id]}).items()
+        }
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[self._db_map], ["o11__o21"])
+        o11__o21_id = self._db_map.entity(entity_class_name="O1__O2", entity_byname=("o11", "o21"))["id"]
+        self._db_mngr.remove_items({self._db_map: {"entity": {o11__o21_id}}})
+        self.assertEqual(self._db_mngr.find_cascading_entities({self._db_map: [o11_id]}), {})
+
+    def test_find_cascading_parameter_definitions(self):
+        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}, {"name": "O2"}, {"name": "O3"}]})
+        self._db_mngr.add_parameter_definitions(
+            {self._db_map: [{"entity_class_name": "O1", "name": "p11"}, {"entity_class_name": "O2", "name": "p21"}]}
+        )
+        o3_id = self._db_map.entity_class(name="O3")["id"]
+        self.assertEqual(self._db_mngr.find_cascading_parameter_definitions({self._db_map: [o3_id]}), {})
+        o1_id = self._db_map.entity_class(name="O1")["id"]
+        data = {
+            db_map: [d["name"] for d in definitions]
+            for db_map, definitions in self._db_mngr.find_cascading_parameter_definitions(
+                {self._db_map: [o1_id]}
+            ).items()
+        }
+        self.assertEqual(len(data), 1)
+        self.assertCountEqual(data[self._db_map], ["p11"])
+        p11_id = self._db_map.parameter_definition(entity_class_name="O1", name="p11")["id"]
+        self._db_mngr.remove_items({self._db_map: {"parameter_definition": [p11_id]}})
+        self.assertEqual(self._db_mngr.find_cascading_parameter_definitions({self._db_map: [o1_id]}), {})
+
+    def test_find_cascading_parameter_values_by_entity(self):
+        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}, {"name": "O2"}, {"name": "O3"}]})
+        self._db_mngr.add_parameter_definitions(
+            {
+                self._db_map: [
+                    {"entity_class_name": "O1", "name": "p11"},
+                    {"entity_class_name": "O2", "name": "p21"},
+                    {"entity_class_name": "O3", "name": "p31"},
+                ]
+            }
+        )
+        self._db_mngr.add_entities(
+            {
+                self._db_map: [
+                    {"entity_class_name": "O1", "name": "o11"},
+                    {"entity_class_name": "O1", "name": "o12"},
+                    {"entity_class_name": "O2", "name": "o21"},
+                    {"entity_class_name": "O3", "name": "o31"},
+                ]
+            }
+        )
+        self._db_mngr.add_parameter_values(
+            {
+                self._db_map: [
+                    {
+                        "entity_class_name": "O1",
+                        "entity_byname": ("o11",),
+                        "parameter_definition_name": "p11",
+                        "alternative_name": "Base",
+                        "parsed_value": 2.3,
+                    },
+                    {
+                        "entity_class_name": "O1",
+                        "entity_byname": ("o12",),
+                        "parameter_definition_name": "p11",
+                        "alternative_name": "Base",
+                        "parsed_value": -2.3,
+                    },
+                    {
+                        "entity_class_name": "O2",
+                        "entity_byname": ("o21",),
+                        "parameter_definition_name": "p21",
+                        "alternative_name": "Base",
+                        "parsed_value": "yes",
+                    },
+                ]
+            }
+        )
+        o31_id = self._db_map.entity(entity_class_name="O3", name="o31")["id"]
+        self.assertEqual(self._db_mngr.find_cascading_parameter_values_by_entity({self._db_map: [o31_id]}), {})
+        o11_id = self._db_map.entity(entity_class_name="O1", name="o11")["id"]
+        data = {
+            db_map: [
+                (
+                    value["entity_class_name"],
+                    value["entity_byname"],
+                    value["parameter_definition_name"],
+                    value["alternative_name"],
+                    value["parsed_value"],
+                )
+                for value in values
+            ]
+            for db_map, values in self._db_mngr.find_cascading_parameter_values_by_entity(
+                {self._db_map: [o11_id]}
+            ).items()
+        }
+        self.assertEqual(data, {self._db_map: [("O1", ("o11",), "p11", "Base", 2.3)]})
+        value_id = self._db_map.parameter_value(
+            entity_class_name="O1", entity_byname=("o11",), parameter_definition_name="p11", alternative_name="Base"
+        )["id"]
+        self._db_mngr.remove_items({self._db_map: {"parameter_value": [value_id]}})
+        self.assertEqual(self._db_mngr.find_cascading_parameter_values_by_entity({self._db_map: [o11_id]}), {})
+
+    def test_find_cascading_scenario_alternatives_by_scenario(self):
+        self._db_mngr.add_scenarios({self._db_map: [{"name": "S1"}, {"name": "S2"}]})
+        s1_id = self._db_map.scenario(name="S1")["id"]
+        self._db_mngr.add_alternatives({self._db_map: [{"name": "a1"}]})
+        a1_id = self._db_map.alternative(name="a1")["id"]
+        self._db_mngr.set_scenario_alternatives({self._db_map: [{"id": s1_id, "alternative_id_list": [a1_id]}]})
+        s2_id = self._db_map.scenario(name="S2")["id"]
+        self.assertEqual(self._db_mngr.find_cascading_scenario_alternatives_by_scenario({self._db_map: [s2_id]}), {})
+        data = {
+            db_map: [(sa["scenario_name"], sa["alternative_name"]) for sa in sas]
+            for db_map, sas in self._db_mngr.find_cascading_scenario_alternatives_by_scenario(
+                {self._db_map: [s1_id]}
+            ).items()
+        }
+        self.assertEqual(data, {self._db_map: [("S1", "a1")]})
+        sa_id = self._db_map.scenario_alternative(scenario_name="S1", alternative_name="a1", rank=0)["id"]
+        self._db_mngr.remove_items({self._db_map: {"scenario_alternative": [sa_id]}})
+        self.assertEqual(self._db_mngr.find_cascading_scenario_alternatives_by_scenario({self._db_map: [s1_id]}), {})
+
+    def test_find_groups_by_entity(self):
+        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}]})
+        self._db_mngr.add_entities(
+            {
+                self._db_map: [
+                    {"entity_class_name": "O1", "name": "o1"},
+                    {"entity_class_name": "O1", "name": "o2"},
+                    {"entity_class_name": "O1", "name": "o3"},
+                ]
+            }
+        )
+        self._db_mngr.add_entity_groups(
+            {self._db_map: [{"entity_class_name": "O1", "group_name": "o1", "member_name": "o2"}]}
+        )
+        o3_id = self._db_map.entity(entity_class_name="O1", name="o3")["id"]
+        self.assertEqual(self._db_mngr.find_groups_by_entity({self._db_map: [o3_id]}), {})
+        o1_id = self._db_map.entity(entity_class_name="O1", name="o1")["id"]
+        data = {
+            db_map: [(g["group_name"], g["member_name"]) for g in groups]
+            for db_map, groups in self._db_mngr.find_groups_by_entity({self._db_map: [o1_id]}).items()
+        }
+        self.assertEqual(data, {self._db_map: [("o1", "o2")]})
+        group_id = self._db_map.entity_group(group_name="o1", member_name="o2", entity_class_name="O1")["id"]
+        self._db_mngr.remove_items({self._db_map: {"entity_group": [group_id]}})
+        self.assertEqual(self._db_mngr.find_groups_by_entity({self._db_map: [o1_id]}), {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We must reset fetch indexes on database reset. Otherwise fetching will not find new items.

Fixes #3059 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
