### PR TITLE
Changes needed to accommodate entity_location

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/mass_select_items_dialogs.py
@@ -116,7 +116,7 @@ class MassRemoveItemsDialog(MassSelectItemsDialog):
         Args:
             parent (SpineDBEditor)
             db_mngr (SpineDBManager)
-            db_maps (DiffDatabaseMapping): the dbs to select items from
+            db_maps (DatabaseMapping): the dbs to select items from
             stored_state (dict, Optional): widget's previous state
         """
         super().__init__(parent, db_mngr, *db_maps, stored_state=stored_state, ok_button_text="Purge")
@@ -145,7 +145,7 @@ class MassExportItemsDialog(MassSelectItemsDialog):
         Args:
             parent (SpineDBEditor)
             db_mngr (SpineDBManager)
-            db_maps (DiffDatabaseMapping): the dbs to select items from
+            db_maps (DatabaseMapping): the dbs to select items from
             stored_state (dict, Optional): widget's previous state
         """
         super().__init__(parent, db_mngr, *db_maps, stored_state=stored_state, ok_button_text="Export")

--- a/spinetoolbox/widgets/select_database_items.py
+++ b/spinetoolbox/widgets/select_database_items.py
@@ -60,6 +60,7 @@ class SelectDatabaseItems(QWidget):
         "entity_group",
         "parameter_value",
         "entity_metadata",
+        "entity_location",
         "parameter_value_metadata",
         "metadata",
     )

--- a/tests/spine_db_editor/test_graphics_items.py
+++ b/tests/spine_db_editor/test_graphics_items.py
@@ -14,8 +14,8 @@
 import unittest
 from unittest import mock
 from PySide6.QtCore import QPointF
-from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.graphics_items import EntityItem
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
 from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
@@ -105,7 +105,7 @@ class TestEntityItem(TestCaseWithQApplication):
 
     def test_db_map_data(self):
         self.assertEqual(
-            self._item.db_map_data(self._db_map)._asdict(),
+            self._item.db_map_data(self._db_map),
             self._db_map.entity(entity_class_name="rc", name="r"),
         )
 

--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -344,7 +344,15 @@ class TestManageElementsDialog(TestBase):
         relationships = [x.resolve() for x in self._db_map.get_items("entity") if x["element_id_list"]]
         self.assertEqual(
             relationships,
-            [{"class_id": None, "description": None, "id": None, "name": "r21", "element_id_list": (None, None)}],
+            [
+                {
+                    "class_id": None,
+                    "description": None,
+                    "id": None,
+                    "name": "r21",
+                    "element_id_list": (None, None),
+                }
+            ],
         )
 
 

--- a/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
+++ b/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
@@ -63,6 +63,7 @@ class TestMassRemoveItemsDialog(TestCaseWithQApplication):
                 "superclass_subclass": False,
                 "display_mode": False,
                 "entity_class_display_mode": False,
+                "entity_location": False,
             },
         )
         self.assertTrue(dialog._database_check_boxes_widget._check_boxes[self._db_map].isChecked())
@@ -84,6 +85,11 @@ class TestMassRemoveItemsDialog(TestCaseWithQApplication):
                     "id": entity_id,
                     "name": "my_object",
                     "element_id_list": (),
+                    "lat": None,
+                    "lon": None,
+                    "alt": None,
+                    "shape_name": None,
+                    "shape_blob": None,
                 }
             ],
         )


### PR DESCRIPTION
Added entity_location to mass select items dialogs and fixed unit tests. No real integration included.

Re #2975 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
~- [ ] Unit tests pass~
