### PR TITLE
Adjustments to changes in spinedb_api

### DIFF
--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -11,8 +11,10 @@
 ######################################################################################################################
 
 """QUndoCommand subclasses for modifying the db."""
+from contextlib import suppress
 import time
 from PySide6.QtGui import QUndoCommand, QUndoStack
+from spinedb_api import SpineDBAPIError
 
 
 class AgedUndoStack(QUndoStack):
@@ -177,7 +179,10 @@ class AddUpdateItemsCommand(SpineDBCommand):
         self.item_type = item_type
         self.new_data = data
         table = db_map.mapped_table(item_type)
-        old_data = [x._asdict() for item in data if (x := table.find_item(item))]
+        old_data = []
+        for item in data:
+            with suppress(SpineDBAPIError):
+                old_data.append(table.find_item(item)._asdict())
         if self.new_data == old_data:
             self.setObsolete(True)
         self.old_data = {x["id"]: x for x in old_data}

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -1352,8 +1352,9 @@ class SpineDBManager(QObject):
         with self._db_locks[db_map]:
             scenario_table = db_map.mapped_table("scenario")
             for scen in scenarios:
-                current_scen = scenario_table.find_item_by_id(scen["id"])
-                if current_scen is None:
+                try:
+                    current_scen = scenario_table.find_item_by_id(scen["id"])
+                except SpineDBAPIError:
                     error = f"no scenario matching {scen} to set alternatives for"
                     errors.append(error)
                     continue


### PR DESCRIPTION
The low-level item finding methods in `spinedb_api` now raise `SpineDBAPIError` instead of returning `None`.

No associated issue

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
