### PR TITLE
Use Mercator projection in Graph View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- Database Editor's Graph View no longer saves the item positions into *x* and *y* parameter values.
+  Instead, the positions are converted to latitude and longitude using the Mercator projection
+  and these are store as `lat` and `lon` coordinates in `entity_location` table.
+  The old *x* and *y* values are not used anymore.
+  There is no functionality to restore old positions;
+  users are requested to readjust the positions manually and save them again
+  after which the existing *x* and *y* values can be removed.
+
 ### Removed
 
 ### Fixed

--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -66,6 +66,8 @@ from PySide6.QtWidgets import (
     QStyle,
 )
 from spine_engine.utils.serialization import deserialize_path
+from spinedb_api import DatabaseMapping
+from spinedb_api.db_mapping_base import PublicItem
 from spinedb_api.helpers import group_consecutive
 from spinedb_api.spine_io.gdx_utils import find_gams_directory
 from .config import (
@@ -92,6 +94,8 @@ if _matplotlib_version[0] == 3 and _matplotlib_version[1] == 0:
     from pandas.plotting import register_matplotlib_converters
 
     register_matplotlib_converters()
+
+DBMapData = dict[DatabaseMapping, list[PublicItem]]
 
 
 @unique

--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -15,6 +15,7 @@ from contextlib import suppress
 import time
 from PySide6.QtGui import QUndoCommand, QUndoStack
 from spinedb_api import SpineDBAPIError
+from spinedb_api.exception import SpineDBAPIError
 
 
 class AgedUndoStack(QUndoStack):

--- a/tests/spine_db_editor/widgets/test_custom_qgraphicsviews.py
+++ b/tests/spine_db_editor/widgets/test_custom_qgraphicsviews.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """Unit tests for ``custom_qgraphicsviews`` module."""
+import math
 import unittest
 from unittest import mock
 from PySide6.QtWidgets import QWidget
@@ -45,6 +46,27 @@ class TestGraphOptionsOverlay(TestCaseWithQApplication):
         self.mock_editor.rebuild_graph.assert_not_called()
         self.graph._options_overlay._rebuild_button.click()
         self.mock_editor.rebuild_graph.assert_called_once_with(force=True)
+
+
+class TestEntityQGraphicsView(unittest.TestCase):
+    def test_latitude_longitude(self):
+        latitude, longitude = EntityQGraphicsView.latitude_longitude(0, 0)
+        self.assertEqual(latitude, 0.0)
+        self.assertEqual(longitude, 0.0)
+        latitude, longitude = EntityQGraphicsView.latitude_longitude(10, 0)
+        self.assertEqual(latitude, 0.0)
+        self.assertEqual(longitude, 1 / 6371 * 180 / math.pi)
+        latitude, longitude = EntityQGraphicsView.latitude_longitude(0, 10)
+        self.assertAlmostEqual(latitude, -1 / 6371 * 180 / math.pi, places=10)
+        self.assertEqual(longitude, 0.0)
+
+    def test_coordinate_conversion(self):
+        x = 2.3
+        y = -5.5
+        latitude, longitude = EntityQGraphicsView.latitude_longitude(x, y)
+        converted_x, converted_y = EntityQGraphicsView.x_y(latitude, longitude)
+        self.assertAlmostEqual(converted_x, x)
+        self.assertAlmostEqual(converted_y, y)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
DB Editor's Graph View now uses Mercator projection and stores 0-dimensional entity coordinates as latitude and longitude into the `entity_location` table in DB.

Resolves #2975

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
