### PR TITLE
More fine-grained emitting of dataChanged

### DIFF
--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -144,8 +144,6 @@ class UpdateItemsCommand(SpineDBCommand):
         self.redo_data = data
         table = db_map.mapped_table(item_type)
         self.undo_data = [table[item["id"]]._asdict() for item in data]
-        if self.redo_data == self.undo_data:
-            self.setObsolete(True)
         self._check = check
         self.setText(f"update {item_type} items in {self.db_mngr.name_registry.display_name(db_map.sa_url)}")
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -623,7 +623,7 @@ class EditParameterValueMixin:
     """Provides the interface to edit values via ParameterValueEditor."""
 
     def handle_items_updated(self, db_map_data):
-        super().handle_items_updated(db_map_data)
+        changed_rows = []
         for db_map, items in db_map_data.items():
             if db_map not in self.db_maps:
                 continue
@@ -634,6 +634,15 @@ class EditParameterValueMixin:
                 )
                 if single_model is not None:
                     single_model.revalidate_item_types(class_items)
+                    changed_rows = [
+                        self._inv_row_map[(single_model, single_row)] for single_row in range(single_model.rowCount())
+                    ]
+        if changed_rows:
+            column_count = self.columnCount()
+            for first_row, count in rows_to_row_count_tuples(changed_rows):
+                top_left = self.index(first_row, 0)
+                bottom_right = self.index(first_row + count - 1, column_count - 1)
+                self.dataChanged.emit(top_left, bottom_right, [Qt.ItemDataRole.DisplayRole])
 
     def index_name(self, index):
         """Generates a name for data at given index.


### PR DESCRIPTION
No need to emit `dataChanged` for the entire `CompoundModel` on update, we know the single models that were affected.

Re #3094

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
