### PR TITLE
Fix changing capitalization in project item's name

### DIFF
--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -16,6 +16,7 @@ from itertools import chain
 import json
 import os
 from pathlib import Path
+from typing import Optional
 import networkx as nx
 from PySide6.QtCore import QCoreApplication, Signal, Slot
 from PySide6.QtGui import QColor
@@ -132,11 +133,11 @@ class SpineToolboxProject(MetaObject):
         self._settings = settings
         self._engine_workers = []
         self._execution_in_progress = False
-        self.project_dir = None  # Full path to project directory
-        self.config_dir = None  # Full path to .spinetoolbox directory
-        self.items_dir = None  # Full path to items directory
-        self.specs_dir = None  # Full path to specs directory
-        self.config_file = None  # Full path to .spinetoolbox/project.json file
+        self.project_dir: Optional[str] = None  # Full path to project directory
+        self.config_dir: Optional[str] = None  # Full path to .spinetoolbox directory
+        self.items_dir: Optional[str] = None  # Full path to items directory
+        self.specs_dir: Optional[str] = None  # Full path to specs directory
+        self.config_file: Optional[str] = None  # Full path to .spinetoolbox/project.json file
         p_dir = os.path.abspath(p_dir)
         if not self._create_project_structure(p_dir):
             self._logger.msg_error.emit(f"Creating project directory structure in <b>{p_dir}</b> failed")
@@ -629,16 +630,16 @@ class SpineToolboxProject(MetaObject):
         self.item_added.emit(name)
         item.set_up()
 
-    def rename_item(self, previous_name, new_name, rename_data_dir_message):
+    def rename_item(self, previous_name: str, new_name: str, rename_data_dir_message: str) -> bool:
         """Renames a project item
 
         Args:
-            previous_name (str): item's current name
-            new_name (str): item's new name
-            rename_data_dir_message (str): message to show when renaming item's data directory
+            previous_name: item's current name
+            new_name: item's new name
+            rename_data_dir_message: message to show when renaming item's data directory
 
         Returns:
-            bool: True if item was renamed successfully, False otherwise
+            True if item was renamed successfully, False otherwise
         """
         if not new_name.strip() or new_name == previous_name:
             return False
@@ -651,14 +652,15 @@ class SpineToolboxProject(MetaObject):
             msg = f"Project item <b>{new_name}</b> already exists"
             self._logger.error_box.emit("Invalid name", msg)
             return False
-        if name_status == ItemNameStatus.SHORT_NAME_EXISTS:
+        if name_status == ItemNameStatus.SHORT_NAME_EXISTS and shorten(previous_name) != shorten(new_name):
             msg = f"Project item using directory <b>{shorten(new_name)}</b> already exists"
             self._logger.error_box.emit("Invalid name", msg)
             return False
-        item = self._project_items.pop(previous_name, None)
-        if item is None:
+        try:
+            item = self._project_items.pop(previous_name)
+        except KeyError:
             # Happens when renaming an item, removing, and then closing the project.
-            # We try to undo the renaming because it's critical, but the item doesn't exist anymore so it's fine.
+            # We try to undo the renaming because it's critical, but the item doesn't exist anymore, so it's fine.
             return True
         resources_to_predecessors = item.resources_for_direct_predecessors()
         resources_to_successors = item.resources_for_direct_successors()
@@ -684,14 +686,14 @@ class SpineToolboxProject(MetaObject):
         self._logger.msg_success.emit(f"Project item <b>{previous_name}</b> renamed to <b>{new_name}</b>.")
         return True
 
-    def validate_project_item_name(self, name):
+    def validate_project_item_name(self, name: str) -> ItemNameStatus:
         """Validates item name.
 
         Args:
-            name (str): proposed project item's name
+            name: proposed project item's name
 
         Returns:
-            ItemNameStatus: validation result
+            validation result
         """
         if any(x in INVALID_CHARS for x in name):
             return ItemNameStatus.INVALID

--- a/spinetoolbox/project_item/project_item.py
+++ b/spinetoolbox/project_item/project_item.py
@@ -50,7 +50,7 @@ class ProjectItem(LogMixin, MetaObject):
         self._active = False
         self._actions = []
         # Make project directory for this Item
-        self.data_dir = os.path.join(self._project.items_dir, self.short_name)
+        self.data_dir: str = str(os.path.join(self._project.items_dir, self.short_name))
         self._specification = None
 
     def create_data_dir(self):
@@ -373,7 +373,7 @@ class ProjectItem(LogMixin, MetaObject):
         """
         return self._actions
 
-    def rename(self, new_name, rename_data_dir_message):
+    def rename(self, new_name: str, rename_data_dir_message: str) -> bool:
         """
         Renames this item.
 
@@ -381,17 +381,18 @@ class ProjectItem(LogMixin, MetaObject):
         method in subclass. See e.g. rename() method in DataStore class.
 
         Args:
-            new_name (str): New name
-            rename_data_dir_message (str): Message to show when renaming item's data directory
+            new_name: New name
+            rename_data_dir_message: Message to show when renaming item's data directory
 
         Returns:
             bool: True if item was renamed successfully, False otherwise
         """
-        new_data_dir = os.path.join(self._toolbox.project().items_dir, shorten(new_name))
-        if not rename_dir(self.data_dir, new_data_dir, self._toolbox, rename_data_dir_message):
-            return False
+        if shorten(new_name) != self.short_name:
+            new_data_dir = str(os.path.join(self._project.items_dir, shorten(new_name)))
+            if not rename_dir(self.data_dir, new_data_dir, self._toolbox, rename_data_dir_message):
+                return False
+            self.data_dir = new_data_dir
         self.set_name(new_name)
-        self.data_dir = new_data_dir
         self.get_icon().update_name_item(new_name)
         if self._active:
             self.update_name_label()


### PR DESCRIPTION
This fixes an oversight that forbade changing capitalization of the name of a project item, e.g. from "Data" to "data".

Fixes #889

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
