### PR TITLE
Add descriptive notification texts to some DB editor actions

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """General helper functions and classes."""
+from __future__ import annotations
 import bisect
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
@@ -29,7 +30,7 @@ import shutil
 import sys
 import tempfile
 import time
-from typing import Any, Optional, Sequence, Union  # pylint: disable=unused-import
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Union  # pylint: disable=unused-import
 from xml.etree import ElementTree
 import matplotlib
 from PySide6.QtCore import (
@@ -98,6 +99,9 @@ from .config import (
 from .font import TOOLBOX_FONT
 from .logger_interface import LoggerInterface
 
+if TYPE_CHECKING:
+    from .ui_main import ToolboxUI
+
 if sys.platform == "win32":
     import ctypes
     import pywintypes
@@ -115,6 +119,7 @@ if _matplotlib_version[0] == 3 and _matplotlib_version[1] == 0:
 
 DBMapPublicItems = dict[DatabaseMapping, list[PublicItem]]
 DBMapDictItems = dict[DatabaseMapping, list[dict]]
+DBMapTypedDictItems = dict[DatabaseMapping, dict[str, list[dict]]]
 
 
 @unique
@@ -187,7 +192,7 @@ def create_dir(base_path: str, folder: str = "", verbosity: bool = False) -> Non
             logging.debug("Directory created: %s", directory)
 
 
-def rename_dir(old_dir: str, new_dir: str, toolbox: "ToolboxUI", box_title: str) -> bool:
+def rename_dir(old_dir: str, new_dir: str, toolbox: ToolboxUI, box_title: str) -> bool:
     """Renames directory.
 
     Args:

--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -11,44 +11,52 @@
 ######################################################################################################################
 
 """QUndoCommand subclasses for modifying the db."""
+from __future__ import annotations
+from collections.abc import Iterable
 from contextlib import suppress
 import time
+from typing import TYPE_CHECKING, Optional
 from PySide6.QtGui import QUndoCommand, QUndoStack
-from spinedb_api import SpineDBAPIError
+from spinedb_api import DatabaseMapping
 from spinedb_api.exception import SpineDBAPIError
+from spinedb_api.temp_id import TempId
+
+if TYPE_CHECKING:
+    from .spine_db_manager import SpineDBManager
 
 
 class AgedUndoStack(QUndoStack):
     @property
-    def redo_age(self):
+    def redo_age(self) -> int:
         if self.canRedo():
             return self.command(self.index()).age
         return -1
 
     @property
-    def undo_age(self):
+    def undo_age(self) -> int:
         if self.canUndo():
             return self.command(self.index() - 1).age
         return -1
 
 
 class AgedUndoCommand(QUndoCommand):
-    def __init__(self, parent=None, identifier=-1):
+    def __init__(self, parent: Optional[QUndoCommand] = None, identifier: int = -1):
         """
         Args:
-            parent (QUndoCommand, optional): The parent command, used for defining macros.
+            parent: The parent command, used for defining macros.
+            identifier: Command identifier, to identify whether succeeding commands can be merged.
         """
         super().__init__(parent=parent)
         self._age = -1
         self._id = identifier
-        self._buddies = []
+        self._buddies: list[AgedUndoCommand] = []
         self.merged = False
 
     def id(self):
         """override"""
         return self._id
 
-    def ours(self):
+    def ours(self) -> Iterable[AgedUndoCommand]:
         yield self
         yield from self._buddies
 
@@ -76,18 +84,19 @@ class AgedUndoCommand(QUndoCommand):
         self._age = time.time()
 
     @property
-    def age(self):
+    def age(self) -> int:
         return self._age
 
 
 class SpineDBCommand(AgedUndoCommand):
     """Base class for all commands that modify a Spine DB."""
 
-    def __init__(self, db_mngr, db_map, **kwargs):
+    def __init__(self, db_mngr: SpineDBManager, db_map: DatabaseMapping, **kwargs):
         """
         Args:
-            db_mngr (SpineDBManager): SpineDBManager instance
-            db_map (DatabaseMapping): DatabaseMapping instance
+            db_mngr: SpineDBManager instance
+            db_map: DatabaseMapping instance
+            **kwargs: Arguments passed to the parent class.
         """
         super().__init__(**kwargs)
         self.db_mngr = db_mngr
@@ -95,13 +104,22 @@ class SpineDBCommand(AgedUndoCommand):
 
 
 class AddItemsCommand(SpineDBCommand):
-    def __init__(self, db_mngr, db_map, item_type, data, check=True, **kwargs):
+    def __init__(
+        self,
+        db_mngr: SpineDBManager,
+        db_map: DatabaseMapping,
+        item_type: str,
+        data: list[dict],
+        check: bool = True,
+        **kwargs,
+    ):
         """
         Args:
-            db_mngr (SpineDBManager): SpineDBManager instance
-            db_map (DatabaseMapping): DatabaseMapping instance
-            data (list): list of dict-items to add
-            item_type (str): the item type
+            db_mngr: SpineDBManager instance
+            db_map: DatabaseMapping instance
+            data: list of dict-items to add
+            item_type: the item type
+            check: Whether to check data integrity.
         """
         super().__init__(db_mngr, db_map, **kwargs)
         if not data:
@@ -129,13 +147,23 @@ class AddItemsCommand(SpineDBCommand):
 
 
 class UpdateItemsCommand(SpineDBCommand):
-    def __init__(self, db_mngr, db_map, item_type, data, check=True, **kwargs):
+    def __init__(
+        self,
+        db_mngr: SpineDBManager,
+        db_map: DatabaseMapping,
+        item_type: str,
+        data: list[dict],
+        check: bool = True,
+        **kwargs,
+    ):
         """
         Args:
-            db_mngr (SpineDBManager): SpineDBManager instance
-            db_map (DatabaseMapping): DatabaseMapping instance
-            item_type (str): the item type
-            data (list): list of dict-items to update
+            db_mngr: SpineDBManager instance
+            db_map: DatabaseMapping instance
+            item_type: the item type
+            data: list of dict-items to update
+            check: Whether to check data integrity.
+            **kwargs: Arguments passed to the parent class.
         """
         super().__init__(db_mngr, db_map, **kwargs)
         if not data:
@@ -164,13 +192,17 @@ class UpdateItemsCommand(SpineDBCommand):
 
 
 class AddUpdateItemsCommand(SpineDBCommand):
-    def __init__(self, db_mngr, db_map, item_type, data, check=True, **kwargs):
+    def __init__(
+        self, db_mngr: SpineDBManager, db_map: DatabaseMapping, item_type: str, data: list[dict], text: str, **kwargs
+    ):
         """
         Args:
-            db_mngr (SpineDBManager): SpineDBManager instance
-            db_map (DatabaseMapping): DatabaseMapping instance
-            item_type (str): the item type
-            data (list): list of dict-items to add-update
+            db_mngr: SpineDBManager instance
+            db_map: DatabaseMapping instance
+            item_type: the item type
+            data: list of dict-items to add-update
+            text: command text
+            **kwargs: arguments passed to parent class
         """
         super().__init__(db_mngr, db_map, **kwargs)
         if not data:
@@ -189,7 +221,8 @@ class AddUpdateItemsCommand(SpineDBCommand):
         self.redo_update_data = None
         self.undo_remove_ids = None
         self.undo_update_data = None
-        self.setText(f"update {item_type} items in {self.db_mngr.name_registry.display_name(db_map.sa_url)}")
+        self.setText(text)
+        # self.setText(f"update {item_type} items in {self.db_mngr.name_registry.display_name(db_map.sa_url)}")
 
     def redo(self):
         super().redo()
@@ -217,13 +250,23 @@ class AddUpdateItemsCommand(SpineDBCommand):
 
 
 class RemoveItemsCommand(SpineDBCommand):
-    def __init__(self, db_mngr, db_map, item_type, ids, check=True, **kwargs):
+    def __init__(
+        self,
+        db_mngr: SpineDBManager,
+        db_map: DatabaseMapping,
+        item_type: str,
+        ids: set[TempId],
+        check: bool = True,
+        **kwargs,
+    ):
         """
         Args:
-            db_mngr (SpineDBManager): SpineDBManager instance
-            db_map (DatabaseMapping): DatabaseMapping instance
-            item_type (str): the item type
-            ids (set): set of ids to remove
+            db_mngr: SpineDBManager instance
+            db_map: DatabaseMapping instance
+            item_type: the item type
+            ids: set of ids to remove
+            check: Whether to check data integrity.
+            **kwargs: Arguments passed to the parent class.
         """
         super().__init__(db_mngr, db_map, **kwargs)
         if not ids:

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -375,13 +375,14 @@ class SpineDBEditorBase(QMainWindow):
         """Pastes data from clipboard."""
         call_on_focused_widget(self, "paste")
 
-    def import_data(self, data):
+    def import_data(self, data: dict[str, list[tuple]], command_text: str) -> None:
         """Imports data to all database mappings open in the editor.
 
         Args:
-            data (dict): data to import
+            data: data to import
+            command_text: Undo command text.
         """
-        self.db_mngr.import_data({db_map: data for db_map in self.db_maps})
+        self.db_mngr.import_data({db_map: data for db_map in self.db_maps}, command_text)
 
     @Slot(bool)
     def import_file(self, checked=False):
@@ -427,7 +428,7 @@ class SpineDBEditorBase(QMainWindow):
                 self.msg_error.emit(f"Data in {file_path} is not valid for importing.")
                 return
             sanitized_data[item_type] = sanitized_items
-        self.import_data(sanitized_data)
+        self.import_data(sanitized_data, "Import data from JSON.")
         filename = os.path.split(file_path)[1]
         self.msg.emit(f"File {filename} successfully imported.")
 
@@ -440,7 +441,7 @@ class SpineDBEditorBase(QMainWindow):
             self.msg.emit(f"Couldn't import file {filename}: {str(err)}")
             return
         data = export_data(db_map)
-        self.import_data(data)
+        self.import_data(data, "Import data from SQL database.")
         self.msg.emit(f"File {filename} successfully imported.")
 
     def import_from_excel(self, file_path):
@@ -453,7 +454,7 @@ class SpineDBEditorBase(QMainWindow):
         if errors:
             msg = f"The following errors where found parsing {filename}:" + format_string_list(errors)
             self.msg_error.emit(msg)
-        self.import_data(mapped_data)
+        self.import_data(mapped_data, "Import data from Excel.")
         self.msg.emit(f"File {filename} successfully imported.")
 
     @Slot(bool)

--- a/tests/spine_db_editor/mvcmodels/test_PivotTableModel.py
+++ b/tests/spine_db_editor/mvcmodels/test_PivotTableModel.py
@@ -33,7 +33,7 @@ class TestParameterValuePivotTableModel(TestBase):
                 ("class1", "object2", "parameter2", 7.0),
             ),
         }
-        self._db_mngr.import_data({self._db_map: data})
+        self._db_mngr.import_data({self._db_map: data}, "Import initial test data.")
         while self._db_editor.entity_tree_model._root_item.row_count() == 0:
             QApplication.processEvents()
 
@@ -126,7 +126,7 @@ class TestParameterValuePivotTableModel(TestBase):
         data = {
             "entity_classes": (("class1",),),
         }
-        self._db_mngr.import_data({self._db_map: data})
+        self._db_mngr.import_data({self._db_map: data}, "Import entity class.")
         while self._db_editor.entity_tree_model._root_item.row_count() == 0:
             QApplication.processEvents()
         model = self._start()
@@ -144,7 +144,7 @@ class TestParameterValuePivotTableModel(TestBase):
             "entity_classes": (("Object",),),
             "entities": (("Object", "spatula"),),
         }
-        self._db_mngr.import_data({self._db_map: initial_data})
+        self._db_mngr.import_data({self._db_map: initial_data}, "Import test data")
         while self._db_editor.entity_tree_model._root_item.row_count() == 0:
             QApplication.processEvents()
         model = self._start()
@@ -158,7 +158,7 @@ class TestParameterValuePivotTableModel(TestBase):
             "parameter_definitions": (("Object", "x"),),
             "entities": (("Object", "spatula"),),
         }
-        self._db_mngr.import_data({self._db_map: initial_data})
+        self._db_mngr.import_data({self._db_map: initial_data}, "Import test data.")
         while self._db_editor.entity_tree_model._root_item.row_count() == 0:
             QApplication.processEvents()
         model = self._start()
@@ -173,7 +173,7 @@ class TestParameterValuePivotTableModel(TestBase):
             "parameter_definitions": (("Object", "x"),),
             "parameter_values": (("Object", "spatula", "x", 2.3),),
         }
-        self._db_mngr.import_data({self._db_map: initial_data})
+        self._db_mngr.import_data({self._db_map: initial_data}, "Import test data.")
         while self._db_editor.entity_tree_model._root_item.row_count() == 0:
             QApplication.processEvents()
         model = self._start()
@@ -231,7 +231,7 @@ class TestParameterValuePivotTableModel(TestBase):
 
 class TestIndexExpansionPivotTableModel(TestBase):
     def _start(self, initial_data):
-        self._db_mngr.import_data({self._db_map: initial_data})
+        self._db_mngr.import_data({self._db_map: initial_data}, "Import initial test data.")
         object_class_index = self._db_editor.entity_tree_model.index(0, 0)
         fetch_model(self._db_editor.entity_tree_model)
         index = self._db_editor.entity_tree_model.index(0, 0, object_class_index)

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
@@ -291,7 +291,7 @@ class TestSpineDBEditorGraphFilter(DBEditorTestBase):
         cls.sanitized_data = sanitized_data
 
     def _import_data(self):
-        self.spine_db_editor.import_data(self.sanitized_data)
+        self.spine_db_editor.import_data(self.sanitized_data, "Import test data.")
         models = (
             self.spine_db_editor.parameter_value_model,
             self.spine_db_editor.parameter_definition_model,

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
@@ -72,7 +72,7 @@ class TestSpineDBEditorWithDBMapping(TestCaseWithQApplication):
             "parameter_definitions": [("fish", "color")],
             "parameter_values": [("fish", "nemo", "color", "orange")],
         }
-        self.db_mngr.import_data({self.db_map: data})
+        self.db_mngr.import_data({self.db_map: data}, "Import test data.")
         self.fetch_entity_tree_model()
         root_item = self.spine_db_editor.entity_tree_model.root_item
         fish_item = next(iter(item for item in root_item.children if item.display_data == "fish"))

--- a/tests/spine_db_editor/widgets/test_tabular_view_mixin.py
+++ b/tests/spine_db_editor/widgets/test_tabular_view_mixin.py
@@ -34,7 +34,7 @@ class TestPivotHeaderDraggingAndDropping(TestBase):
                 ("class1", "object2", "parameter2", 7.0),
             ),
         }
-        self._db_mngr.import_data({self._db_map: data})
+        self._db_mngr.import_data({self._db_map: data}, "Import entity class dta.")
 
     def _add_entity_class_data_with_indexes_values(self):
         data = {
@@ -56,7 +56,7 @@ class TestPivotHeaderDraggingAndDropping(TestBase):
                 ),
             ),
         }
-        self._db_mngr.import_data({self._db_map: data})
+        self._db_mngr.import_data({self._db_map: data}, "Import indexed value data.")
 
     def _start(self):
         get_item_exceptions = []

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -368,7 +368,7 @@ class TestImportExportData(TestCaseWithQApplication):
         self._db_mngr.export_to_excel(file_path, data, self.editor)
         mapped_data, errors = get_mapped_data_from_xlsx(file_path)
         self.assertEqual(errors, [])
-        self._db_mngr.import_data({self._db_map: mapped_data})
+        self._db_mngr.import_data({self._db_map: mapped_data}, command_text="Import Excel data")
         self._db_map.commit_session("imported items")
         with self._db_map:
             value = self._db_map.query(self._db_map.entity_parameter_value_sq).one()
@@ -401,7 +401,8 @@ class TestImportExportData(TestCaseWithQApplication):
             self._db_mngr.items_added, condition=lambda item_type, _: item_type == "list_value"
         ) as waiter:
             self._db_mngr.import_data(
-                {self._db_map: {"parameter_value_lists": [["list_1", "first value"], ["list_1", "second value"]]}}
+                {self._db_map: {"parameter_value_lists": [("list_1", "first value"), ("list_1", "second value")]}},
+                "import value lists",
             )
             waiter.wait()
         value_lists = self._db_map.get_items("parameter_value_list")


### PR DESCRIPTION
Instead of e.g. "update items in database successful", the notification now says "Duplicate entity successful".

Resolves #2727

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
