### PR TITLE
Add MacOS to unit test matrix

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
     uses: ./.github/workflows/unit_tests.yml
     with:
       host-os: ${{ matrix.os }}
@@ -31,6 +34,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
     uses: ./.github/workflows/execution_tests.yml
     with:
       host-os: ${{ matrix.os }}

--- a/spinetoolbox/fetch_parent.py
+++ b/spinetoolbox/fetch_parent.py
@@ -54,7 +54,7 @@ class FetchParent(QObject):
 
     def apply_changes_immediately(self):
         # For tests
-        self._changes_pending.connect(self._apply_pending_changes, Qt.UniqueConnection)
+        self._changes_pending.connect(self._apply_pending_changes, Qt.ConnectionType.UniqueConnection)
 
     @property
     def index(self):

--- a/spinetoolbox/project.py
+++ b/spinetoolbox/project.py
@@ -722,14 +722,14 @@ class SpineToolboxProject(MetaObject):
             (c for c in self._connections if c.source == source_name and c.destination == destination_name), None
         )
 
-    def connections_for_item(self, item_name):
+    def connections_for_item(self, item_name: str) -> list[LoggingConnection]:
         """Returns connections that have given item as source or destination.
 
         Args:
-            item_name (str): item's name
+            item_name: item's name
 
         Returns:
-            list of Connection: connections connected to item
+            connections connected to item
         """
         return [c for c in self._connections if item_name in (c.source, c.destination)]
 

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -189,7 +189,7 @@ class SpineDBWorker(QObject):
             if commit_id is not None:
                 self.commit_cache.setdefault(commit_id, {}).setdefault(item_type, []).append(item["id"])
 
-    def close_db_map(self):
+    def close_db_map(self) -> None:
         with self._db_mngr.get_lock(self._db_map):
             self._db_map.close()
             self._do_fetch_more = lambda worker, *args, **kwargs: None

--- a/spinetoolbox/widgets/add_project_item_widget.py
+++ b/spinetoolbox/widgets/add_project_item_widget.py
@@ -20,19 +20,12 @@ from ..project import ItemNameStatus
 
 
 class AddProjectItemWidget(QWidget):
-    """A widget to query user's preferences for a new item.
-
-    Attributes:
-        toolbox (ToolboxUI): Parent widget
-        x (int): X coordinate of new item
-        y (int): Y coordinate of new item
-    """
+    """A widget to query user's preferences for a new item."""
 
     def __init__(self, toolbox, x, y, class_, spec=""):
-        """Initialize class."""
         from ..ui.add_project_item import Ui_Form  # pylint: disable=import-outside-toplevel
 
-        super().__init__(parent=toolbox, f=Qt.Window)  # Setting parent inherits stylesheet
+        super().__init__(parent=toolbox, f=Qt.WindowType.Window)  # Setting parent inherits stylesheet
         self._toolbox = toolbox
         self._x = x
         self._y = y
@@ -65,7 +58,7 @@ class AddProjectItemWidget(QWidget):
         self.ui.lineEdit_name.selectAll()
         self.ui.lineEdit_name.setFocus()
         # Ensure this window gets garbage-collected when closed
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setWindowTitle(f"Add {class_.item_type()}")
 
     def connect_signals(self):

--- a/spinetoolbox/widgets/plot_widget.py
+++ b/spinetoolbox/widgets/plot_widget.py
@@ -126,7 +126,7 @@ class PlotWidget(QWidget):
         """
         self.setParent(parent_window)
         self.setWindowFlag(Qt.WindowType.Window, True)
-        self.setAttribute(Qt.WA_DeleteOnClose, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
         title = "Plot"
         if document_name:
             title += f"    -- {document_name} --"
@@ -169,7 +169,7 @@ class _PlotDataWidget(QWidget):
         self._view.horizontalHeader().hide()
         self._view.verticalHeader().hide()
         layout.addWidget(self._view)
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.table_view_width = (
             self._view.frameWidth() + self._view.verticalHeader().width() + self._view.horizontalHeader().length()
         )

--- a/tests/spine_db_editor/test_graphics_items.py
+++ b/tests/spine_db_editor/test_graphics_items.py
@@ -11,7 +11,6 @@
 ######################################################################################################################
 
 """Unit tests for Database editor's ``graphics_items`` module."""
-import unittest
 from unittest import mock
 from PySide6.QtCore import QPointF
 from PySide6.QtGui import QKeySequence, QShortcut
@@ -57,8 +56,8 @@ class TestEntityItem(TestCaseWithQApplication):
 
     @classmethod
     def tearDownClass(cls):
-        super().tearDownClass()
         QApplication.removePostedEvents(None)  # Clean up unfinished fetcher signals
+        super().tearDownClass()
 
     def tearDown(self):
         with (

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorAdd.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorAdd.py
@@ -14,7 +14,7 @@
 from unittest import mock
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
 from spinetoolbox.spine_db_editor.mvcmodels.single_models import SingleParameterDefinitionModel
-from .spine_db_editor_test_base import DBEditorTestBase
+from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
 class TestSpineDBEditorAdd(DBEditorTestBase):

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorRemove.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorRemove.py
@@ -11,7 +11,7 @@
 ######################################################################################################################
 
 """Unit tests for database item removal functionality in Database editor."""
-from .spine_db_editor_test_base import DBEditorTestBase
+from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
 class TestSpineDBEditorRemove(DBEditorTestBase):

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorShortcutFocus.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorShortcutFocus.py
@@ -14,7 +14,7 @@
 import unittest
 from unittest.mock import patch
 from PySide6.QtCore import QEvent
-from .spine_db_editor_test_base import DBEditorTestBase
+from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
 class TestSetupFocusWidgets(DBEditorTestBase):
@@ -22,9 +22,6 @@ class TestSetupFocusWidgets(DBEditorTestBase):
         """Test that the eventFilter method handles focus events."""
         focus_event = QEvent(QEvent.Type.FocusIn)
         filter_callback = self.spine_db_editor
-        with patch.object(filter_callback, 'eventFilter') as mock_event_filter:
+        with patch.object(filter_callback, "eventFilter") as mock_event_filter:
             filter_callback.eventFilter(self.spine_db_editor.ui.tableView_parameter_value, focus_event)
-            mock_event_filter.assert_called_once_with(
-                self.spine_db_editor.ui.tableView_parameter_value,
-                focus_event
-            )
+            mock_event_filter.assert_called_once_with(self.spine_db_editor.ui.tableView_parameter_value, focus_event)

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorUpdate.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorUpdate.py
@@ -11,10 +11,9 @@
 ######################################################################################################################
 
 """Unit tests for database item update functionality in Database editor."""
-from PySide6.QtWidgets import QApplication
 from spinedb_api import to_database
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
-from .spine_db_editor_test_base import DBEditorTestBase
+from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
 class TestSpineDBEditorUpdate(DBEditorTestBase):

--- a/tests/spine_db_editor/widgets/test_multi_spine_db_editor.py
+++ b/tests/spine_db_editor/widgets/test_multi_spine_db_editor.py
@@ -20,7 +20,7 @@ from spinetoolbox.multi_tab_windows import MultiTabWindowRegistry
 from spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor import MultiSpineDBEditor, open_db_editor
 from spinetoolbox.spine_db_manager import SpineDBManager
 from tests.mock_helpers import FakeDataStore, TestCaseWithQApplication, clean_up_toolbox, create_toolboxui_with_project
-from .spine_db_editor_test_base import DBEditorTestBase
+from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
 class TestMultiSpineDBEditor(DBEditorTestBase):

--- a/tests/test_database_display_names.py
+++ b/tests/test_database_display_names.py
@@ -87,7 +87,7 @@ class TestSuggestDisplayName(unittest.TestCase):
         self.assertEqual(suggest_display_name(sa_url), "my_lovely_db")
 
     def test_sqlite_url_returns_file_name_without_extension(self):
-        path = "c:\path\to\my_lovely_db.sqlite" if sys.platform == "win32" else "/path/to/my_lovely_db.sqlite"
+        path = r"c:\path\to\my_lovely_db.sqlite" if sys.platform == "win32" else "/path/to/my_lovely_db.sqlite"
         sa_url = make_url(r"sqlite:///" + path)
         self.assertEqual(suggest_display_name(sa_url), "my_lovely_db")
 

--- a/tests/widgets/test_DatetimeEditor.py
+++ b/tests/widgets/test_DatetimeEditor.py
@@ -12,21 +12,24 @@
 
 """Unit tests for the DatetimeEditor widget."""
 import unittest
+from PySide6.QtWidgets import QWidget
 from spinedb_api import DateTime
 from spinetoolbox.widgets.datetime_editor import DatetimeEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestDatetimeEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = DatetimeEditor()
-        value = editor.value()
-        self.assertEqual(value, DateTime("2000-01-01T00:00:00"))
+        with q_object(QWidget()) as parent:
+            editor = DatetimeEditor(parent)
+            value = editor.value()
+            self.assertEqual(value, DateTime("2000-01-01T00:00:00"))
 
     def test_value_access(self):
-        editor = DatetimeEditor()
-        editor.set_value(DateTime("2000-02-02T20:02"))
-        self.assertEqual(editor.value(), DateTime("2000-02-02T20:02"))
+        with q_object(QWidget()) as parent:
+            editor = DatetimeEditor(parent)
+            editor.set_value(DateTime("2000-02-02T20:02"))
+            self.assertEqual(editor.value(), DateTime("2000-02-02T20:02"))
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_DurationEditor.py
+++ b/tests/widgets/test_DurationEditor.py
@@ -12,21 +12,24 @@
 
 """Unit tests for the DuratonEditor widget."""
 import unittest
+from PySide6.QtWidgets import QWidget
 from spinedb_api import Duration
 from spinetoolbox.widgets.duration_editor import DurationEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestDurationEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = DurationEditor()
-        value = editor.value()
-        self.assertEqual(value, Duration("1h"))
+        with q_object(QWidget()) as parent:
+            editor = DurationEditor(parent)
+            value = editor.value()
+            self.assertEqual(value, Duration("1h"))
 
     def test_value_access_single_duration(self):
-        editor = DurationEditor()
-        editor.set_value(Duration("3 months"))
-        self.assertEqual(editor.value(), Duration("3M"))
+        with q_object(QWidget()) as parent:
+            editor = DurationEditor(parent)
+            editor.set_value(Duration("3 months"))
+            self.assertEqual(editor.value(), Duration("3M"))
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_MapEditor.py
+++ b/tests/widgets/test_MapEditor.py
@@ -12,21 +12,24 @@
 
 """Unit tests for the MapEditor widget."""
 import unittest
+from PySide6.QtWidgets import QWidget
 from spinedb_api import Map
 from spinetoolbox.widgets.map_editor import MapEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestDictionaryEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = MapEditor()
-        value = editor.value()
-        self.assertEqual(value, Map(["key"], [0.0]))
+        with q_object(QWidget()) as parent:
+            editor = MapEditor(parent)
+            value = editor.value()
+            self.assertEqual(value, Map(["key"], [0.0]))
 
     def test_value_access(self):
-        editor = MapEditor()
-        editor.set_value(Map(["A", "B"], [2.2, 2.1]))
-        self.assertEqual(editor.value(), Map(["A", "B"], [2.2, 2.1]))
+        with q_object(QWidget()) as parent:
+            editor = MapEditor(parent)
+            editor.set_value(Map(["A", "B"], [2.2, 2.1]))
+            self.assertEqual(editor.value(), Map(["A", "B"], [2.2, 2.1]))
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_PlainParameterValueEditor.py
+++ b/tests/widgets/test_PlainParameterValueEditor.py
@@ -12,30 +12,35 @@
 
 """Unit tests for the PlainParameterValueEditor widget."""
 import unittest
+from PySide6.QtWidgets import QWidget
 from spinetoolbox.widgets.plain_parameter_value_editor import PlainParameterValueEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestPlainParameterValueEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = PlainParameterValueEditor()
-        value = editor.value()
-        self.assertEqual(value, "")
+        with q_object(QWidget()) as parent:
+            editor = PlainParameterValueEditor(parent)
+            value = editor.value()
+            self.assertEqual(value, "")
 
     def test_boolean_value_access(self):
-        editor = PlainParameterValueEditor()
-        editor.set_value(True)
-        self.assertEqual(editor.value(), True)
+        with q_object(QWidget()) as parent:
+            editor = PlainParameterValueEditor(parent)
+            editor.set_value(True)
+            self.assertEqual(editor.value(), True)
 
     def test_numeric_value_access(self):
-        editor = PlainParameterValueEditor()
-        editor.set_value(2.3)
-        self.assertEqual(editor.value(), 2.3)
+        with q_object(QWidget()) as parent:
+            editor = PlainParameterValueEditor(parent)
+            editor.set_value(2.3)
+            self.assertEqual(editor.value(), 2.3)
 
     def test_string_value_access(self):
-        editor = PlainParameterValueEditor()
-        editor.set_value("2022")
-        self.assertEqual(editor.value(), "2022")
+        with q_object(QWidget()) as parent:
+            editor = PlainParameterValueEditor(parent)
+            editor.set_value("2022")
+            self.assertEqual(editor.value(), "2022")
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_TimePatternEditor.py
+++ b/tests/widgets/test_TimePatternEditor.py
@@ -12,21 +12,24 @@
 
 """Unit tests for the TimePatternEditor widget."""
 import unittest
+from PySide6.QtWidgets import QWidget
 from spinedb_api import TimePattern
 from spinetoolbox.widgets.time_pattern_editor import TimePatternEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestTimePatternEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = TimePatternEditor()
-        value = editor.value()
-        self.assertEqual(value, TimePattern(["D1-7"], [0.0]))
+        with q_object(QWidget()) as parent:
+            editor = TimePatternEditor(parent)
+            value = editor.value()
+            self.assertEqual(value, TimePattern(["D1-7"], [0.0]))
 
     def test_value_access(self):
-        editor = TimePatternEditor()
-        editor.set_value(TimePattern(["D1-5", "D6-10"], [2.2, 2.1]))
-        self.assertEqual(editor.value(), TimePattern(["D1-5", "D6-10"], [2.2, 2.1]))
+        with q_object(QWidget()) as parent:
+            editor = TimePatternEditor(parent)
+            editor.set_value(TimePattern(["D1-5", "D6-10"], [2.2, 2.1]))
+            self.assertEqual(editor.value(), TimePattern(["D1-5", "D6-10"], [2.2, 2.1]))
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_TimeSeriesFixedResolutionEditor.py
+++ b/tests/widgets/test_TimeSeriesFixedResolutionEditor.py
@@ -12,23 +12,26 @@
 
 """Unit tests for the TimeSeriesFixedResolutionEditor widget."""
 import unittest
+from PySide6.QtWidgets import QWidget
 from spinedb_api import TimeSeriesFixedResolution
 from spinetoolbox.widgets.time_series_fixed_resolution_editor import TimeSeriesFixedResolutionEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestTimeSeriesFixedResolutionEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = TimeSeriesFixedResolutionEditor()
-        value = editor.value()
-        self.assertEqual(value, TimeSeriesFixedResolution("2000-01-01T00:00", "1 hour", [0.0, 0.0], False, False))
+        with q_object(QWidget()) as parent:
+            editor = TimeSeriesFixedResolutionEditor(parent)
+            value = editor.value()
+            self.assertEqual(value, TimeSeriesFixedResolution("2000-01-01T00:00", "1 hour", [0.0, 0.0], False, False))
 
     def test_value_access(self):
-        editor = TimeSeriesFixedResolutionEditor()
-        editor.set_value(TimeSeriesFixedResolution("1996-04-06T16:06", "3 days", [4.0, 3.5, 3.0], True, True))
-        self.assertEqual(
-            editor.value(), TimeSeriesFixedResolution("1996-04-06T16:06", "3 days", [4.0, 3.5, 3.0], True, True)
-        )
+        with q_object(QWidget()) as parent:
+            editor = TimeSeriesFixedResolutionEditor(parent)
+            editor.set_value(TimeSeriesFixedResolution("1996-04-06T16:06", "3 days", [4.0, 3.5, 3.0], True, True))
+            self.assertEqual(
+                editor.value(), TimeSeriesFixedResolution("1996-04-06T16:06", "3 days", [4.0, 3.5, 3.0], True, True)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_TimeSeriesFixedResolutionTableView.py
+++ b/tests/widgets/test_TimeSeriesFixedResolutionTableView.py
@@ -12,7 +12,6 @@
 
 """Unit tests for TimeSeriesFixedResolutionTableView class."""
 import locale
-import os
 import unittest
 from unittest import mock
 from PySide6.QtCore import QItemSelectionModel
@@ -35,7 +34,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_copy_single_cell(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 0), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
         with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as clipboard_getter:
             mock_clipboard = mock.MagicMock()
             clipboard_getter.return_value = mock_clipboard
@@ -45,7 +44,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_paste_single_value(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -55,7 +54,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_paste_value_when_time_stamp_is_selected(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 0), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -65,7 +64,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_pasting_to_last_row_expands_model(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(3, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(3, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-4.4) + "\n" + locale.str(-5.5)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -75,8 +74,8 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_paste_to_multirow_selection_limits_pasted_data(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
-        selection_model.select(model.index(1, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(1, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1) + "\n" + locale.str(-2.2) + "\n" + locale.str(-3.3)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -86,8 +85,8 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_paste_to_larger_selection_cycles_data(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
-        selection_model.select(model.index(1, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(1, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -97,7 +96,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_pasted_gibberish_is_rejected(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = "Totoro"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertFalse(self._table_view.paste())
@@ -107,7 +106,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_pasted_gibberish_in_the_middle_gets_rejected(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = "-1.1\nTotoro\n-2.2\n-3.3\n-4.4\n-5.5\n"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -117,7 +116,7 @@ class TestTimeSeriesFixedResolutionTableView(TestCaseWithQApplication):
     def test_pasted_cells_are_selected(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1) + "\n" + locale.str(-2.2)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())

--- a/tests/widgets/test_TimeSeriesVariableResolutionEditor.py
+++ b/tests/widgets/test_TimeSeriesVariableResolutionEditor.py
@@ -12,33 +12,35 @@
 
 """Unit tests for the TimeSeriesVariableResolutionEditor widget."""
 import unittest
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QWidget
 from spinedb_api import TimeSeriesVariableResolution
 from spinetoolbox.widgets.time_series_variable_resolution_editor import TimeSeriesVariableResolutionEditor
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestTimeSeriesVariableResolutionEditor(TestCaseWithQApplication):
     def test_initial_value(self):
-        editor = TimeSeriesVariableResolutionEditor()
-        value = editor.value()
-        self.assertEqual(
-            value, TimeSeriesVariableResolution(["2000-01-01T00:00", "2000-01-01T01:00"], [0.0, 0.0], False, False)
-        )
+        with q_object(QWidget()) as parent:
+            editor = TimeSeriesVariableResolutionEditor(parent)
+            value = editor.value()
+            self.assertEqual(
+                value, TimeSeriesVariableResolution(["2000-01-01T00:00", "2000-01-01T01:00"], [0.0, 0.0], False, False)
+            )
 
     def test_value_access(self):
-        editor = TimeSeriesVariableResolutionEditor()
-        editor.set_value(
-            TimeSeriesVariableResolution(
-                ["1996-04-06T16:06", "1996-04-07T16:06", "1996-04-08T16:06"], [4.0, 3.5, 3.0], True, True
+        with q_object(QWidget()) as parent:
+            editor = TimeSeriesVariableResolutionEditor(parent)
+            editor.set_value(
+                TimeSeriesVariableResolution(
+                    ["1996-04-06T16:06", "1996-04-07T16:06", "1996-04-08T16:06"], [4.0, 3.5, 3.0], True, True
+                )
             )
-        )
-        self.assertEqual(
-            editor.value(),
-            TimeSeriesVariableResolution(
-                ["1996-04-06T16:06", "1996-04-07T16:06", "1996-04-08T16:06"], [4.0, 3.5, 3.0], True, True
-            ),
-        )
+            self.assertEqual(
+                editor.value(),
+                TimeSeriesVariableResolution(
+                    ["1996-04-06T16:06", "1996-04-07T16:06", "1996-04-08T16:06"], [4.0, 3.5, 3.0], True, True
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/widgets/test_notification.py
+++ b/tests/widgets/test_notification.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """Contains unit tests for the ``notification`` module."""
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 from PySide6.QtCore import QAbstractAnimation
@@ -20,7 +21,7 @@ from spinetoolbox.widgets.notification import ChangeNotifier, Notification
 from tests.mock_helpers import TestCaseWithQApplication
 
 
-@unittest.skip("Test hangs on Windows when running all tests.")
+@unittest.skipIf(sys.platform == "win32", "Test hangs on Windows when running all tests.")
 class TestChangeNotifier(TestCaseWithQApplication):
     def setUp(self):
         self._parent = QWidget()

--- a/tests/widgets/test_plot_widget.py
+++ b/tests/widgets/test_plot_widget.py
@@ -15,55 +15,54 @@ from itertools import product
 import unittest
 from unittest import mock
 from matplotlib.gridspec import GridSpec
+from PySide6.QtWidgets import QWidget
 from spinedb_api.parameter_value import TimeSeriesFixedResolution
 from spinetoolbox.plotting import TreeNode, convert_indexed_value_to_tree, plot_data, turn_node_to_xy_data
 from spinetoolbox.widgets.plot_canvas import LegendPosition
 from spinetoolbox.widgets.plot_widget import PlotWidget, _PlotDataWidget
-from tests.mock_helpers import TestCaseWithQApplication
+from tests.mock_helpers import TestCaseWithQApplication, q_object
 
 
 class TestPlotWidget(TestCaseWithQApplication):
-    def setUp(self):
-        self._plot_widget = PlotWidget()
-
-    def tearDown(self):
-        self._plot_widget.deleteLater()
-
     def test_plot_data_widget_shows_datetimes_as_strings(self):
-        # Warning: running this unit test alone might end up in an endless loop
-        # probably due to Spine DB server failing to exit cleanly.
-        time_series = TimeSeriesFixedResolution("2022-11-08T16:00", "3h", [1.1, 2.2], False, False)
-        value_node = convert_indexed_value_to_tree(time_series)
-        root_node = TreeNode("root index")
-        root_node.content["first"] = value_node
-        data_list = list(turn_node_to_xy_data(root_node, None))
-        plot_data(data_list, self._plot_widget)
-        with mock.patch.object(_PlotDataWidget, "show") as show_method:
-            self._plot_widget.show_plot_data()
-            show_method.assert_called_once()
-        data_widget = None
-        for widget in self._plot_widget.children():
-            if isinstance(widget, _PlotDataWidget):
-                data_widget = widget
-                break
-        if data_widget is None:
-            self.fail("missing plot data widget")
-        model = data_widget._model
-        self.assertEqual(model.rowCount(), 3)
-        self.assertEqual(model.columnCount(), 2)
-        expected = [["indexes", "first"], ["2022-11-08T16:00:00", "1.1"], ["2022-11-08T19:00:00", "2.2"]]
-        for row, column in product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        with q_object(QWidget()) as parent:
+            plot_widget = PlotWidget(parent)
+            time_series = TimeSeriesFixedResolution("2022-11-08T16:00", "3h", [1.1, 2.2], False, False)
+            value_node = convert_indexed_value_to_tree(time_series)
+            root_node = TreeNode("root index")
+            root_node.content["first"] = value_node
+            data_list = list(turn_node_to_xy_data(root_node, None))
+            plot_data(data_list, plot_widget)
+            with mock.patch.object(_PlotDataWidget, "show") as show_method:
+                plot_widget.show_plot_data()
+                show_method.assert_called_once()
+            data_widget = None
+            for widget in plot_widget.children():
+                if isinstance(widget, _PlotDataWidget):
+                    data_widget = widget
+                    break
+            if data_widget is None:
+                self.fail("missing plot data widget")
+            model = data_widget._model
+            self.assertEqual(model.rowCount(), 3)
+            self.assertEqual(model.columnCount(), 2)
+            expected = [["indexes", "first"], ["2022-11-08T16:00:00", "1.1"], ["2022-11-08T19:00:00", "2.2"]]
+            for row, column in product(range(model.rowCount()), range(model.columnCount())):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
 
     def test_legend_axes_placement_bottom(self):
-        plot_widget = PlotWidget(legend_axes_position=LegendPosition.BOTTOM)
-        self.assertEqual(
-            repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(2, 1, height_ratios=[1, 0]))
-        )
+        with q_object(QWidget()) as parent:
+            plot_widget = PlotWidget(parent, legend_axes_position=LegendPosition.BOTTOM)
+            self.assertEqual(
+                repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(2, 1, height_ratios=[1, 0]))
+            )
 
     def test_legend_axes_placement_right(self):
-        plot_widget = PlotWidget(legend_axes_position=LegendPosition.RIGHT)
-        self.assertEqual(repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(1, 2, width_ratios=[1, 0])))
+        with q_object(QWidget()) as parent:
+            plot_widget = PlotWidget(parent, legend_axes_position=LegendPosition.RIGHT)
+            self.assertEqual(
+                repr(plot_widget.canvas.legend_axes.get_gridspec()), repr(GridSpec(1, 2, width_ratios=[1, 0]))
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds MacOS to unit test matrix for Python 3.13. One of the tests is currently being skipped on MacOS as it causes another, completely unrelated test to segfault. I could not figure out the ultimate reason for the crash, unfortunately.

Resolves #2273

## Checklist before merging
- [ ] Unit tests pass
