### PR TITLE
Add undo/redo actions to empty row tables in DB editor

### DIFF
--- a/spinetoolbox/fetch_parent.py
+++ b/spinetoolbox/fetch_parent.py
@@ -11,10 +11,14 @@
 ######################################################################################################################
 
 """The FetchParent and FlexibleFetchParent classes."""
+from __future__ import annotations
 from contextlib import suppress
+from typing import TYPE_CHECKING
 from PySide6.QtCore import QObject, Qt, QTimer, Signal, Slot
 from .helpers import busy_effect
-from .spine_db_manager import SpineDBManager
+
+if TYPE_CHECKING:
+    from .spine_db_manager import SpineDBManager
 
 
 class FetchParent(QObject):

--- a/spinetoolbox/mvcmodels/minimal_table_model.py
+++ b/spinetoolbox/mvcmodels/minimal_table_model.py
@@ -12,7 +12,6 @@
 
 """ Contains a minimal table model. """
 from collections.abc import Iterable, Sequence
-from copy import copy
 from typing import Any, Generic, Optional, TypeVar
 from PySide6.QtCore import QAbstractTableModel, QModelIndex, QObject, Qt
 

--- a/spinetoolbox/spine_db_commands.py
+++ b/spinetoolbox/spine_db_commands.py
@@ -53,7 +53,6 @@ class AgedUndoCommand(QUndoCommand):
         self.merged = False
 
     def id(self):
-        """override"""
         return self._id
 
     def ours(self) -> Iterable[AgedUndoCommand]:

--- a/spinetoolbox/spine_db_editor/commands.py
+++ b/spinetoolbox/spine_db_editor/commands.py
@@ -1,0 +1,131 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""DB Editor specific QUndoCommand subclasses."""
+from __future__ import annotations
+from collections.abc import Iterable
+import pickle
+from typing import TYPE_CHECKING
+from PySide6.QtCore import QModelIndex
+from PySide6.QtGui import QUndoCommand
+
+if TYPE_CHECKING:
+    from .mvcmodels.empty_models import EmptyModelBase
+
+
+class UpdateEmptyModel(QUndoCommand):
+    def __init__(self, model: EmptyModelBase, indexes: Iterable[QModelIndex], values: Iterable):
+        super().__init__(f"update unfinished {model.item_type}")
+        self._model = model
+        self._rows = []
+        self._columns = []
+        self._undo_values = []
+        for index in indexes:
+            self._rows.append(index.row())
+            self._columns.append(index.column())
+            self._undo_values.append(pickle.dumps(index.data()))
+        self._redo_values = [pickle.dumps(value) for value in values]
+
+    def redo(self):
+        self._apply(self._redo_values)
+
+    def undo(self):
+        if not self.isObsolete():
+            self._apply(self._undo_values)
+
+    def rows_dropped(self, dropped_rows: set[int]) -> None:
+        new_rows = []
+        new_columns = []
+        new_undo_values = []
+        new_redo_values = []
+        for row, column, redo_value, undo_value in zip(self._rows, self._columns, self._redo_values, self._undo_values):
+            if row not in dropped_rows:
+                new_rows.append(row)
+                new_columns.append(column)
+                new_redo_values.append(redo_value)
+                new_undo_values.append(undo_value)
+        if not new_rows:
+            self.setObsolete(True)
+        else:
+            self._rows = new_rows
+            self._columns = new_columns
+            self._redo_values = new_redo_values
+            self._undo_values = new_undo_values
+
+    def _apply(self, values: list[bytes]) -> None:
+        indexes = [self._model.index(row, column) for row, column in zip(self._rows, self._columns)]
+        values = [pickle.loads(x) for x in values]
+        if not self._model.do_batch_set_data(indexes, values):
+            self.setObsolete(True)
+
+
+class AppendEmptyRow(QUndoCommand):
+    def __init__(self, model: EmptyModelBase):
+        super().__init__("append empty row")
+        self._model = model
+
+    def redo(self):
+        self._model.append_empty_row()
+
+    def undo(self):
+        if not self.isObsolete():
+            self._model.remove_empty_row()
+
+    def rows_dropped(self, dropped_rows: set[int]) -> None:
+        if self._model.rowCount() < 2:
+            self.setObsolete(True)
+
+
+class InsertEmptyModelRow(QUndoCommand):
+    def __init__(self, model: EmptyModelBase, row: int):
+        super().__init__("remove row")
+        self._model = model
+        self._row = row
+
+    def redo(self):
+        self._model.do_insert_rows(self._row, 1)
+
+    def undo(self):
+        if self._row == self._model.rowCount() - 1:
+            self._model.remove_empty_row()
+        else:
+            self._model.do_remove_rows(self._row, 1)
+
+    def rows_dropped(self, dropped_rows: set[int]) -> None:
+        if self._row in dropped_rows:
+            self.setObsolete(True)
+        else:
+            self._row -= len([row for row in dropped_rows if row < self._row])
+
+
+class RemoveEmptyModelRow(QUndoCommand):
+    def __init__(self, model: EmptyModelBase, row: int):
+        super().__init__("remove row")
+        self._model = model
+        self._row = row
+        self._undo_data = [
+            pickle.dumps(self._model.index(row, column).data()) for column in range(self._model.columnCount())
+        ]
+
+    def redo(self):
+        self._model.do_remove_rows(self._row, 1)
+
+    def undo(self):
+        self._model.do_insert_rows(self._row, 1)
+        indexes = [self._model.index(self._row, column) for column in range(self._model.columnCount())]
+        values = [pickle.loads(value) for value in self._undo_data]
+        self._model.do_batch_set_data(indexes, values)
+
+    def rows_dropped(self, dropped_rows: set[int]) -> None:
+        if self._row in dropped_rows:
+            self.setObsolete(True)
+        else:
+            self._row -= len([row for row in dropped_rows if row < self._row])

--- a/spinetoolbox/spine_db_editor/mvcmodels/alternative_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/alternative_item.py
@@ -42,12 +42,6 @@ class AlternativeItem(GrayIfLastMixin, EditableMixin, LeafItem):
             return "<p>Drag this item on a <b>scenario</b> item in Scenario tree to add it to that scenario.</p>"
         return super().tool_tip(column)
 
-    def add_item_to_db(self, db_item):
-        self.db_mngr.add_alternatives({self.db_map: [db_item]})
-
-    def update_item_in_db(self, db_item):
-        self.db_mngr.update_alternatives({self.db_map: [db_item]})
-
     def flags(self, column):
         flags = super().flags(column)
         if self.id is None:

--- a/spinetoolbox/spine_db_editor/mvcmodels/alternative_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/alternative_model.py
@@ -73,4 +73,4 @@ class AlternativeModel(TreeModelBase):
                 continue
             alternative_db_items.append({"name": name, "description": description})
         if alternative_db_items:
-            self.db_mngr.add_alternatives({database_item.db_map: alternative_db_items})
+            self.db_mngr.add_items("alternative", {database_item.db_map: alternative_db_items})

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -11,9 +11,12 @@
 ######################################################################################################################
 
 """Empty models for dialogs as well as parameter definitions and values."""
+from collections import defaultdict
 from collections.abc import Iterable, Iterator
+from itertools import chain
 from typing import ClassVar, Optional
-from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtCore import QModelIndex, QObject, Qt, Signal, Slot
+from PySide6.QtGui import QUndoStack
 from spinedb_api import DatabaseMapping
 from spinedb_api.temp_id import TempId
 from ...fetch_parent import FlexibleFetchParent
@@ -21,14 +24,15 @@ from ...helpers import DB_ITEM_SEPARATOR, DBMapDictItems, rows_to_row_count_tupl
 from ...mvcmodels.empty_row_model import EmptyRowModel
 from ...mvcmodels.shared import DB_MAP_ROLE, PARSED_ROLE
 from ...spine_db_manager import SpineDBManager
-from .single_and_empty_model_mixins import MakeEntityOnTheFlyMixin, SplitValueAndTypeMixin
+from ..commands import AppendEmptyRow, InsertEmptyModelRow, RemoveEmptyModelRow, UpdateEmptyModel
+from .single_and_empty_model_mixins import SplitValueAndTypeMixin
 from .utils import (
     ENTITY_ALTERNATIVE_MODEL_HEADER,
     PARAMETER_DEFINITION_FIELD_MAP,
     PARAMETER_DEFINITION_MODEL_HEADER,
     PARAMETER_VALUE_FIELD_MAP,
     PARAMETER_VALUE_MODEL_HEADER,
-    cull_equal_rows_at_end,
+    make_entity_on_the_fly,
 )
 
 
@@ -42,6 +46,9 @@ class EmptyModelBase(EmptyRowModel):
     def __init__(self, header: list[str], db_mngr: SpineDBManager, parent: Optional[QObject]):
         super().__init__(parent, header)
         self.db_mngr = db_mngr
+        self._undo_stack: Optional[QUndoStack] = None
+        self._entity_class_column = header.index("entity_class_name")
+        self._database_column = header.index("database")
         self.entity_class_id: Optional[TempId] = None
         self._fetch_parent = FlexibleFetchParent(
             self.item_type,
@@ -49,40 +56,79 @@ class EmptyModelBase(EmptyRowModel):
             owner=self,
         )
 
+    def set_undo_stack(self, undo_stack: QUndoStack) -> None:
+        self._undo_stack = undo_stack
+        self.modelReset.connect(self._clear_undo_stack)
+
+    @Slot()
+    def _clear_undo_stack(self):
+        self._undo_stack.clear()
+
+    def fetchMore(self, parent):
+        self.append_empty_row()
+        self._fetched = True
+
     def add_items_to_db(self, db_map_data: DBMapDictItems) -> None:
         """Adds items to db.
 
         Args:
             db_map_data: mapping DatabaseMapping instance to list of items
         """
-        db_map_items, db_map_error_log = self._data_to_items(db_map_data)
+        db_map_items = self._data_to_items(db_map_data)
         if any(db_map_items.values()):
             self.db_mngr.add_items(self.item_type, db_map_items)
-        if db_map_error_log:
-            self.db_mngr.error_msg.emit(db_map_error_log)
 
-    def _data_to_items(self, db_map_data: DBMapDictItems) -> tuple[DBMapDictItems, dict[DatabaseMapping, list[str]]]:
+    def _data_to_items(self, db_map_data: DBMapDictItems) -> DBMapDictItems:
         db_map_items = {}
-        db_map_error_log = {}
         for db_map, items in db_map_data.items():
             for item in items:
-                item_to_add, errors = self._convert_to_db(item)
-                self._autocomplete_row(db_map, item_to_add)
+                item_to_add = self._convert_to_db(item)
                 if self._check_item(item_to_add):
                     db_map_items.setdefault(db_map, []).append(item_to_add)
-                if errors:
-                    db_map_error_log.setdefault(db_map, []).extend(errors)
-        return db_map_items, db_map_error_log
+        return db_map_items
 
     def _make_unique_id(self, item: dict) -> tuple:
         """Returns a unique id for the given model item (name-based). Used by handle_items_added to identify
         which rows have been added and thus need to be removed."""
         raise NotImplementedError()
 
+    def append_empty_row(self) -> None:
+        last = len(self._main_data)
+        self.beginInsertRows(QModelIndex(), last, last)
+        self._main_data.append([self.default_row.get(self.header[column]) for column in range(len(self.header))])
+        self.endInsertRows()
+
+    def remove_empty_row(self) -> None:
+        last = len(self._main_data) - 1
+        self.beginRemoveRows(QModelIndex(), last, last)
+        self._main_data = self._main_data[:-1]
+        self.endRemoveRows()
+
     def remove_rows(self, rows: Iterable[int]) -> None:
-        """Removes given rows by removing the corresponding items from the db map."""
-        for row in sorted(rows, reverse=True):
-            self.removeRow(row)
+        self._undo_stack.beginMacro("remove rows")
+        for row in rows:
+            self._undo_stack.push(RemoveEmptyModelRow(self, row))
+        self._undo_stack.endMacro()
+
+    def removeRows(self, row, count, parent=QModelIndex()):
+        self._undo_stack.beginMacro("remove rows")
+        for _ in range(count):
+            self._undo_stack.push(RemoveEmptyModelRow(self, row))
+        self._undo_stack.endMacro()
+        return self._undo_stack.command(self._undo_stack.count() - 1).isObsolete()
+
+    def do_remove_rows(self, row: int, count: int) -> None:
+        super().removeRows(row, count)
+
+    def insertRows(self, row, count, parent=QModelIndex()):
+        self._undo_stack.beginMacro("insert rows")
+        for _ in range(count):
+            self._undo_stack.push(InsertEmptyModelRow(self, row))
+        self._undo_stack.endMacro()
+        return self._undo_stack.command(self._undo_stack.count() - 1).isObsolete()
+
+    def do_insert_rows(self, row: int, count: int) -> None:
+        super().insertRows(row, count)
 
     def accepted_rows(self) -> Iterator[int]:
         yield from range(self.rowCount())
@@ -99,16 +145,70 @@ class EmptyModelBase(EmptyRowModel):
         for row in range(len(self._main_data)):
             item = self._make_item(row)
             database = item.get("database")
-            unique_id = (database, *self._make_unique_id(self._convert_to_db(item)[0]))
+            unique_id = (database, *self._make_unique_id(self._convert_to_db(item)))
             if unique_id in added_ids:
                 removed_rows.append(row)
         for row, count in sorted(rows_to_row_count_tuples(removed_rows), reverse=True):
-            self.removeRows(row, count)
-        if len(self._main_data) > 1:
-            cull_equal_rows_at_end(self._main_data, self.removeRow)
+            self.do_remove_rows(row, count)
+        clean_index = self._undo_stack.cleanIndex()
+        removed_row_set = set(removed_rows)
+        new_clean_index = -1
+        for command_index in range(self._undo_stack.count()):
+            command = self._undo_stack.command(command_index)
+            if command_index > clean_index:
+                command.setObsolete(True)
+            else:
+                if hasattr(command, "rows_dropped"):
+                    command.rows_dropped(removed_row_set)
+                    if not command.isObsolete():
+                        new_clean_index = command_index
+                else:
+                    children_obsolete = True
+                    for child_index in range(command.childCount()):
+                        child_command = command.child(child_index)
+                        if hasattr(child_command, "rows_dropped"):
+                            child_command.rows_dropped(removed_row_set)
+                            if not child_command.isObsolete():
+                                new_clean_index = command_index
+                                children_obsolete = False
+                    if children_obsolete:
+                        command.setObsolete(True)
+        self._undo_stack.setIndex(new_clean_index)
 
     def batch_set_data(self, indexes, data):
         """Sets data for indexes in batch. If successful, add items to db."""
+        modified_indexes = []
+        modified_data = []
+        data_by_row = defaultdict(dict)
+        for index, cell_data in zip(indexes, data):
+            if index.data() == cell_data:
+                continue
+            modified_indexes.append(index)
+            modified_data.append(cell_data)
+            data_by_row[index.row()][index.column()] = cell_data
+        db_map_cache = _TempDBMapCache(self.db_mngr)
+        for row, row_data in data_by_row.items():
+            main_data_row = self._main_data[row]
+            if (self._paste and self._entity_class_column in row_data) or main_data_row[self._entity_class_column]:
+                continue
+            combined_row = [row_data.get(column, main_data_row[column]) for column in range(len(main_data_row))]
+            db_name = combined_row[self._database_column]
+            db_map = db_map_cache.get(db_name)
+            if db_map is None:
+                continue
+            candidates = self._entity_class_name_candidates(db_map, combined_row)
+            if len(candidates) == 1:
+                modified_indexes.append(self.index(row, self._entity_class_column))
+                modified_data.extend(candidates)
+        if not modified_indexes:
+            return False
+        command = UpdateEmptyModel(self, modified_indexes, modified_data)
+        self._undo_stack.beginMacro(f"update unfinished {self.item_type}")
+        self._undo_stack.push(command)
+        self._undo_stack.endMacro()
+        return not command.isObsolete()
+
+    def do_batch_set_data(self, indexes: Iterable[QModelIndex], data: Iterable) -> bool:
         if not super().batch_set_data(indexes, data):
             return False
         rows = {ind.row() for ind in indexes}
@@ -116,26 +216,28 @@ class EmptyModelBase(EmptyRowModel):
         self.add_items_to_db(db_map_data)
         return True
 
-    def _autocomplete_row(self, db_map: DatabaseMapping, item: dict) -> None:
-        """Fills in entity_class_name whenever other selections make it obvious."""
-        if self._paste and item.get("entity_class_name"):
-            # If the data is pasted and the entity class column is already filled,
-            # trust that the user knows what they are doing. This makes pasting large
-            # amounts of data significantly faster.
-            del item["row"]
+    @Slot(QModelIndex, QModelIndex, list)
+    def _handle_data_changed(self, top_left, bottom_right, roles=None):
+        """Inserts a new last empty row in case the previous one has been filled
+        with any data other than the defaults."""
+        if roles and Qt.ItemDataRole.EditRole not in roles:
             return
-        candidates = self._entity_class_name_candidates(db_map, item)
-        row = item.pop("row", None)
-        if len(candidates) == 1:
-            entity_class_name = candidates[0]
-            item["entity_class_name"] = entity_class_name
-            self._main_data[row][self.header.index("entity_class_name")] = entity_class_name
+        last_row = self._main_data[-1]
+        for column, data in enumerate(last_row):
+            try:
+                field = self.header[column]
+            except IndexError:
+                field = None
+            default = self.default_row.get(field)
+            if (data or default) and data != default:
+                self._undo_stack.push(AppendEmptyRow(self))
+                break
 
-    def _entity_class_name_candidates(self, db_map: DatabaseMapping, item: dict) -> list[str]:
+    def _entity_class_name_candidates(self, db_map: DatabaseMapping, item: list) -> list[str]:
         raise NotImplementedError()
 
     def _make_item(self, row: int) -> dict:
-        return dict(zip(self.header, self._main_data[row]), row=row)
+        return dict(zip(self.header, self._main_data[row]))
 
     def _make_db_map_data(self, rows: Iterable[int]) -> DBMapDictItems:
         """
@@ -148,16 +250,12 @@ class EmptyModelBase(EmptyRowModel):
             mapping DatabaseMapping instance to list of items
         """
         db_map_data = {}
+        db_map_cache = _TempDBMapCache(self.db_mngr)
         for row in rows:
             item = self._make_item(row)
             database = item.pop("database")
-            try:
-                db_map = next(
-                    iter(
-                        x for x in self.db_mngr.db_maps if self.db_mngr.name_registry.display_name(x.sa_url) == database
-                    )
-                )
-            except StopIteration:
+            db_map = db_map_cache.get(database)
+            if db_map is None:
                 continue
             item = {k: v for k, v in item.items() if v is not None}
             db_map_data.setdefault(db_map, []).append(item)
@@ -174,12 +272,18 @@ class EmptyModelBase(EmptyRowModel):
 
     def _convert_to_db(self, item: dict) -> dict:
         """Returns a db item (id-based) from the given model item (name-based)."""
-        raise NotImplementedError()
+        return item.copy()
 
     @staticmethod
     def _check_item(item: dict) -> bool:
         """Checks if a db item is ready to be inserted."""
         raise NotImplementedError()
+
+    def set_default_row(self, **kwargs) -> None:
+        """Sets default row data."""
+        if self.default_row != kwargs:
+            super().set_default_row(**kwargs)
+            self._undo_stack.clear()
 
     def reset_db_maps(self, db_maps: Iterable[DatabaseMapping]):
         self._fetch_parent.set_obsolete(False)
@@ -188,9 +292,29 @@ class EmptyModelBase(EmptyRowModel):
             self.db_mngr.register_fetch_parent(db_map, self._fetch_parent)
 
 
+class _TempDBMapCache:
+    def __init__(self, db_mngr: SpineDBManager):
+        self._db_mngr = db_mngr
+        self._db_maps: dict[str, DatabaseMapping] = {}
+
+    def get(self, name: str) -> Optional[DatabaseMapping]:
+        try:
+            return self._db_maps[name]
+        except KeyError:
+            try:
+                db_map = next(
+                    iter(x for x in self._db_mngr.db_maps if self._db_mngr.name_registry.display_name(x.sa_url) == name)
+                )
+            except StopIteration:
+                return None
+        self._db_maps[name] = db_map
+        return db_map
+
+
 class ParameterMixin:
     value_field: ClassVar[str] = NotImplemented
     type_field: ClassVar[str] = NotImplemented
+    parameter_name_column: ClassVar[int] = NotImplemented
 
     def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         if self.header[index.column()] == self.value_field and role in {
@@ -203,16 +327,17 @@ class ParameterMixin:
             return self.db_mngr.get_value_from_data(data, role)
         return super().data(index, role)
 
-    @staticmethod
-    def _entity_class_name_candidates_by_parameter(db_map, item):
-        return [
-            x["entity_class_name"]
-            for x in db_map.get_items("parameter_definition", name=item.get("parameter_definition_name"))
-        ]
+    @classmethod
+    def _entity_class_name_candidates_by_parameter(cls, db_map: DatabaseMapping, row_data: list) -> list[str]:
+        name = row_data[cls.parameter_name_column]
+        if not name:
+            return []
+        return [x["entity_class_name"] for x in db_map.get_items("parameter_definition", name=name)]
 
 
 class EntityMixin:
     entities_added = Signal(object)
+    entity_byname_column: ClassVar[int] = NotImplemented
 
     def add_items_to_db(self, db_map_data):
         """Overridden to add entities on the fly first."""
@@ -220,9 +345,8 @@ class EntityMixin:
         db_map_error_log = {}
         for db_map, items in db_map_data.items():
             for item in items:
-                item_to_add, _ = self._convert_to_db(item)
-                self._autocomplete_row(db_map, item_to_add)
-                entity, errors = self._make_entity_on_the_fly(item, db_map)
+                item_to_add = self._convert_to_db(item)
+                entity, errors = make_entity_on_the_fly(item_to_add, db_map)
                 if entity:
                     entities = db_map_entities.setdefault(db_map, [])
                     if entity not in entities:
@@ -231,15 +355,13 @@ class EntityMixin:
                     db_map_error_log.setdefault(db_map, []).extend(errors)
         if db_map_error_log:
             self.db_mngr.error_msg.emit(db_map_error_log)
-        db_map_items, db_map_error_log = self._data_to_items(db_map_data)
+        db_map_items = self._data_to_items(db_map_data)
         if any(db_map_items.values()):
             db_map_entities_to_add = self._clean_to_be_added_entities(db_map_entities, db_map_items)
             if any(db_map_entities_to_add.values()):
                 self.db_mngr.add_items("entity", db_map_entities_to_add)
                 self.entities_added.emit(db_map_entities_to_add)
             self.db_mngr.add_items(self.item_type, db_map_items)
-        if db_map_error_log:
-            self.db_mngr.error_msg.emit(db_map_error_log)
 
     @staticmethod
     def _clean_to_be_added_entities(db_map_entities: DBMapDictItems, db_map_items: DBMapDictItems) -> DBMapDictItems:
@@ -261,9 +383,14 @@ class EntityMixin:
         item["entity_byname"] = tuple(byname.split(DB_ITEM_SEPARATOR)) if byname else ()
         return item
 
-    @staticmethod
-    def _entity_class_name_candidates_by_entity(db_map, item):
-        return [x["entity_class_name"] for x in db_map.get_items("entity", entity_byname=item.get("entity_byname"))]
+    @classmethod
+    def _entity_class_name_candidates_by_entity(cls, db_map: DatabaseMapping, row_data: list) -> list[str]:
+        byname = row_data[cls.entity_byname_column]
+        if not byname:
+            return []
+        return [
+            x["entity_class_name"] for x in db_map.find_entities(entity_byname=tuple(byname.split(DB_ITEM_SEPARATOR)))
+        ]
 
 
 class EmptyParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, EmptyModelBase):
@@ -273,6 +400,7 @@ class EmptyParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, Empt
     field_map = PARAMETER_DEFINITION_FIELD_MAP
     value_field = "default_value"
     type_field = "default_type"
+    parameter_name_column = PARAMETER_DEFINITION_MODEL_HEADER.index("parameter_name")
 
     def __init__(self, db_mngr: SpineDBManager, parent: Optional[QObject]):
         super().__init__(PARAMETER_DEFINITION_MODEL_HEADER, db_mngr, parent)
@@ -285,19 +413,19 @@ class EmptyParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, Empt
         """Checks if a db item is ready to be inserted."""
         return item.get("entity_class_name") and item.get("name")
 
-    def _entity_class_name_candidates(self, db_map, item):
-        return []
+    def _entity_class_name_candidates(self, db_map, row_data):
+        return self._entity_class_name_candidates_by_parameter(db_map, row_data)
 
 
-class EmptyParameterValueModel(
-    MakeEntityOnTheFlyMixin, SplitValueAndTypeMixin, ParameterMixin, EntityMixin, EmptyModelBase
-):
+class EmptyParameterValueModel(SplitValueAndTypeMixin, ParameterMixin, EntityMixin, EmptyModelBase):
     """A self-contained empty parameter_value model."""
 
     item_type = "parameter_value"
     field_map = PARAMETER_VALUE_FIELD_MAP
     value_field = "value"
     type_field = "type"
+    entity_byname_column = PARAMETER_VALUE_MODEL_HEADER.index("entity_byname")
+    parameter_name_column = PARAMETER_VALUE_MODEL_HEADER.index("parameter_name")
 
     def __init__(self, db_mngr: SpineDBManager, parent: Optional[QObject]):
         super().__init__(PARAMETER_VALUE_MODEL_HEADER, db_mngr, parent)
@@ -322,21 +450,19 @@ class EmptyParameterValueModel(
             item.get(x) for x in ("entity_class_name", "entity_byname", "parameter_definition_name", "alternative_name")
         )
 
-    def _entity_class_name_candidates(self, db_map, item):
-        candidates_by_parameter = self._entity_class_name_candidates_by_parameter(db_map, item)
-        candidates_by_entity = self._entity_class_name_candidates_by_entity(db_map, item)
+    def _entity_class_name_candidates(self, db_map, row_data):
+        candidates_by_parameter = self._entity_class_name_candidates_by_parameter(db_map, row_data)
+        candidates_by_entity = self._entity_class_name_candidates_by_entity(db_map, row_data)
         if not candidates_by_parameter:
             return candidates_by_entity
         if not candidates_by_entity:
             return candidates_by_parameter
-        return list(
-            set(self._entity_class_name_candidates_by_parameter(db_map, item))
-            & set(self._entity_class_name_candidates_by_entity(db_map, item))
-        )
+        return list(set(candidates_by_parameter) & set(candidates_by_entity))
 
 
-class EmptyEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, EmptyModelBase):
+class EmptyEntityAlternativeModel(EntityMixin, EmptyModelBase):
     item_type = "entity_alternative"
+    entity_byname_column = ENTITY_ALTERNATIVE_MODEL_HEADER.index("entity_byname")
 
     def __init__(self, db_mngr: SpineDBManager, parent: Optional[QObject]):
         super().__init__(ENTITY_ALTERNATIVE_MODEL_HEADER, db_mngr, parent)
@@ -349,8 +475,8 @@ class EmptyEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, EmptyMod
     def _make_unique_id(self, item):
         return tuple(item.get(x) for x in ("entity_class_name", "entity_byname", "alternative_name"))
 
-    def _entity_class_name_candidates(self, db_map, item):
-        return self._entity_class_name_candidates_by_entity(db_map, item)
+    def _entity_class_name_candidates(self, db_map, row_data):
+        return self._entity_class_name_candidates_by_entity(db_map, row_data)
 
 
 class EmptyAddEntityOrClassRowModel(EmptyRowModel):

--- a/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/item_metadata_table_model.py
@@ -136,23 +136,24 @@ class ItemMetadataTableModel(MetadataTableModelBase):
         """See base class."""
         item_id = self._item_ids[db_map]
         if self._item_type == ItemType.ENTITY:
-            self._db_mngr.add_ext_entity_metadata(
-                {db_map: [{"entity_id": item_id, "metadata_name": name, "metadata_value": value}]}
+            self._db_mngr.add_ext_item_metadata(
+                "entity_metadata", {db_map: [{"entity_id": item_id, "metadata_name": name, "metadata_value": value}]}
             )
         else:
-            self._db_mngr.add_ext_parameter_value_metadata(
-                {db_map: [{"parameter_value_id": item_id, "metadata_name": name, "metadata_value": value}]}
+            self._db_mngr.add_ext_item_metadata(
+                "parameter_value_metadata",
+                {db_map: [{"parameter_value_id": item_id, "metadata_name": name, "metadata_value": value}]},
             )
 
     def _update_data_in_db_mngr(self, id_, name, value, db_map):
         """See base class"""
         if self._item_type == ItemType.ENTITY:
-            self._db_mngr.update_ext_entity_metadata(
-                {db_map: [{"id": id_, "metadata_name": name, "metadata_value": value}]}
+            self._db_mngr.update_ext_item_metadata(
+                "entity_metadata", {db_map: [{"id": id_, "metadata_name": name, "metadata_value": value}]}
             )
         else:
-            self._db_mngr.update_ext_parameter_value_metadata(
-                {db_map: [{"id": id_, "metadata_name": name, "metadata_value": value}]}
+            self._db_mngr.update_ext_item_metadata(
+                "parameter_value_metadata", {db_map: [{"id": id_, "metadata_name": name, "metadata_value": value}]}
             )
 
     def flags(self, index):

--- a/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model.py
@@ -52,11 +52,11 @@ class MetadataTableModel(MetadataTableModelBase):
 
     def _add_data_to_db_mngr(self, name, value, db_map):
         """See base class."""
-        self._db_mngr.add_metadata({db_map: [{"name": name, "value": value}]})
+        self._db_mngr.add_items("metadata", {db_map: [{"name": name, "value": value}]})
 
     def _update_data_in_db_mngr(self, id_, name, value, db_map):
         """See base class"""
-        self._db_mngr.update_metadata({db_map: [{"id": id_, "name": name, "value": value}]})
+        self._db_mngr.update_items("metadata", {db_map: [{"id": id_, "name": name, "value": value}]})
 
     def _database_table_name(self):
         """See base class"""

--- a/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model_base.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model_base.py
@@ -253,9 +253,9 @@ class MetadataTableModelBase(QAbstractTableModel):
             else:
                 metadata_to_add.setdefault(db_map, []).append({"name": name, "value": value})
         if metadata_to_add:
-            self._db_mngr.add_metadata(metadata_to_add)
+            self._db_mngr.add_items("metadata", metadata_to_add)
         if metadata_to_update:
-            self._db_mngr.update_metadata(metadata_to_update)
+            self._db_mngr.update_items("metadata", metadata_to_update)
         if rows:
             top_left = self.index(min(rows), min(columns))
             bottom_right = self.index(max(rows), max(columns))

--- a/spinetoolbox/spine_db_editor/mvcmodels/parameter_value_list_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/parameter_value_list_item.py
@@ -81,12 +81,6 @@ class ListItem(
     def _make_item_to_add(self, value):
         return {"name": value}
 
-    def add_item_to_db(self, db_item):
-        self.db_mngr.add_parameter_value_lists({self.db_map: [db_item]})
-
-    def update_item_in_db(self, db_item):
-        self.db_mngr.update_parameter_value_lists({self.db_map: [db_item]})
-
 
 class ValueItem(GrayIfLastMixin, EditableMixin, LeafItem):
     item_type = "list_value"
@@ -110,9 +104,3 @@ class ValueItem(GrayIfLastMixin, EditableMixin, LeafItem):
     def _make_item_to_update(self, _column, value):
         db_value, db_type = value
         return {"id": self.id, "value": db_value, "type": db_type}
-
-    def add_item_to_db(self, db_item):
-        self.db_mngr.add_list_values({self.db_map: [db_item]})
-
-    def update_item_in_db(self, db_item):
-        self.db_mngr.update_list_values({self.db_map: [db_item]})

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -139,7 +139,7 @@ class TopLeftEntityHeaderItem(TopLeftHeaderItem):
         """See base class."""
         if not db_map_data:
             return False
-        self.db_mngr.update_entities(db_map_data)
+        self.db_mngr.update_items("entity", db_map_data)
         return True
 
     def add_data(self, names, db_map):
@@ -148,7 +148,7 @@ class TopLeftEntityHeaderItem(TopLeftHeaderItem):
             return False
         class_id = self._class_id[db_map]
         db_map_data = {db_map: [{"name": name, "class_id": class_id} for name in names]}
-        self.db_mngr.add_entities(db_map_data)
+        self.db_mngr.add_items("entity", db_map_data)
         return True
 
 
@@ -171,7 +171,7 @@ class TopLeftParameterHeaderItem(TopLeftHeaderItem):
         """See base class."""
         if not db_map_data:
             return False
-        self.db_mngr.update_parameter_definitions(db_map_data)
+        self.db_mngr.update_items("parameter_definition", db_map_data)
         return True
 
     def add_data(self, names, db_map):
@@ -180,7 +180,7 @@ class TopLeftParameterHeaderItem(TopLeftHeaderItem):
             return False
         class_id = self.model._parent.current_class_id[db_map]
         db_map_data = {db_map: [{"name": name, "entity_class_id": class_id} for name in names]}
-        self.db_mngr.add_parameter_definitions(db_map_data)
+        self.db_mngr.add_items("parameter_definition", db_map_data)
         return True
 
 
@@ -230,7 +230,7 @@ class TopLeftAlternativeHeaderItem(TopLeftHeaderItem):
         """See base class."""
         if not db_map_data:
             return False
-        self.db_mngr.update_alternatives(db_map_data)
+        self.db_mngr.update_items("alternative", db_map_data)
         return True
 
     def add_data(self, names, db_map):
@@ -238,7 +238,7 @@ class TopLeftAlternativeHeaderItem(TopLeftHeaderItem):
         if not names:
             return False
         db_map_data = {db_map: [{"name": name} for name in names]}
-        self.db_mngr.add_alternatives(db_map_data)
+        self.db_mngr.add_items("alternative", db_map_data)
         return True
 
 
@@ -261,7 +261,7 @@ class TopLeftScenarioHeaderItem(TopLeftHeaderItem):
         """See base class."""
         if not db_map_data:
             return False
-        self.db_mngr.update_scenarios(db_map_data)
+        self.db_mngr.update_items("scenario", db_map_data)
         return True
 
     def add_data(self, names, db_map):
@@ -269,7 +269,7 @@ class TopLeftScenarioHeaderItem(TopLeftHeaderItem):
         if not names:
             return False
         db_map_data = {db_map: [{"name": name} for name in names]}
-        self.db_mngr.add_scenarios(db_map_data)
+        self.db_mngr.add_items("scenario", db_map_data)
         return True
 
 
@@ -1344,10 +1344,10 @@ class ParameterValuePivotTableModel(PivotTableModelBase):
         return True
 
     def _add_parameter_values(self, db_map_data):
-        self.db_mngr.add_parameter_values(db_map_data)
+        self.db_mngr.add_items("parameter_value", db_map_data)
 
     def _update_parameter_values(self, db_map_data):
-        self.db_mngr.update_parameter_values(db_map_data)
+        self.db_mngr.update_items("parameter_value", db_map_data)
 
     def get_set_data_delayed(self, index):
         """Returns a function that ParameterValueEditor can call to set data for the given index at any later time,
@@ -1716,7 +1716,7 @@ class ElementPivotTableModel(PivotTableModelBase):
         if not to_add and not to_remove:
             return False
         if to_add:
-            self.db_mngr.add_entities(to_add)
+            self.db_mngr.add_items("entity", to_add)
         if to_remove:
             self.db_mngr.remove_items(to_remove)
         return True

--- a/spinetoolbox/spine_db_editor/mvcmodels/scenario_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/scenario_item.py
@@ -59,12 +59,6 @@ class ScenarioItem(GrayIfLastMixin, EditableMixin, EmptyChildMixin, FetchMoreMix
             return
         super()._do_set_up()
 
-    def add_item_to_db(self, db_item):
-        self.db_mngr.add_scenarios({self.db_map: [db_item]})
-
-    def update_item_in_db(self, db_item):
-        self.db_mngr.update_scenarios({self.db_map: [db_item]})
-
     def handle_updated_in_db(self):
         super().handle_updated_in_db()
         self.update_alternative_id_list()
@@ -138,12 +132,6 @@ class ScenarioAlternativeItem(GrayIfLastMixin, EditableMixin, LeafItem):
             return self.parent_item.alternative_id_list[self.child_number()]
         except IndexError:
             return None
-
-    def add_item_to_db(self, db_item):
-        raise NotImplementedError()
-
-    def update_item_in_db(self, db_item):
-        raise NotImplementedError()
 
     def flags(self, column):
         flags = super().flags(column) | Qt.ItemFlag.ItemNeverHasChildren

--- a/spinetoolbox/spine_db_editor/mvcmodels/scenario_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/scenario_model.py
@@ -188,8 +188,8 @@ class ScenarioModel(TreeModelBase):
                 scenarios_to_add.append({"name": scenario_data["name"], "description": scenario_data["description"]})
         if scenarios_to_add:
             if alternatives_to_add:
-                self.db_mngr.add_alternatives({db_item.db_map: alternatives_to_add})
-            self.db_mngr.add_scenarios({db_item.db_map: scenarios_to_add})
+                self.db_mngr.add_items("alternative", {db_item.db_map: alternatives_to_add})
+            self.db_mngr.add_items("scenario", {db_item.db_map: scenarios_to_add})
             alternatives = self.db_mngr.get_items(db_item.db_map, "alternative")
             alternative_id_by_name = {i["name"]: i["id"] for i in alternatives}
             scenarios = self.db_mngr.get_items(db_item.db_map, "scenario")
@@ -211,7 +211,9 @@ class ScenarioModel(TreeModelBase):
         db_map = scenario_item.db_map
         existing_names = {i["name"] for i in self.db_mngr.get_items(db_map, "scenario")}
         name = unique_name(scenario_item.item_data["name"], existing_names)
-        self.db_mngr.add_scenarios({db_map: [{"name": name, "description": scenario_item.item_data["description"]}]})
+        self.db_mngr.add_items(
+            "scenario", {db_map: [{"name": name, "description": scenario_item.item_data["description"]}]}
+        )
         alternative_id_list = self.db_mngr.get_scenario_alternative_id_list(db_map, scenario_item.id)
         for item in self.db_mngr.get_items(db_map, "scenario"):
             if item["name"] == name:

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_and_empty_model_mixins.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_and_empty_model_mixins.py
@@ -19,7 +19,7 @@ from spinedb_api.parameter_value import split_value_and_type
 class ConvertToDBMixin:
     """Base class for all mixins that convert model items (name-based) into database items (id-based)."""
 
-    def _convert_to_db(self, item: dict) -> tuple[dict, list[str]]:
+    def _convert_to_db(self, item: dict) -> dict:
         """Returns a db item (id-based) from the given model item (name-based).
 
         Args:
@@ -28,43 +28,14 @@ class ConvertToDBMixin:
         Returns:
             the db item and error log
         """
-        item = item.copy()
-        for field, real_field in self.field_map.items():
-            if field in item:
-                item[real_field] = item.pop(field)
-        return item, []
+        return {self.field_map.get(key, key): value for key, value in item.items()}
 
 
 class SplitValueAndTypeMixin(ConvertToDBMixin):
-    def _convert_to_db(self, item):
-        item, err = super()._convert_to_db(item)
+    def _convert_to_db(self, item: dict) -> dict:
+        item = super()._convert_to_db(item)
         if self.value_field in item:
             value, value_type = split_value_and_type(item[self.value_field])
             item[self.value_field] = value
             item[self.type_field] = value_type
-        return item, err
-
-
-class MakeEntityOnTheFlyMixin(ConvertToDBMixin):
-    """Makes relationships on the fly."""
-
-    @staticmethod
-    def _make_entity_on_the_fly(item: dict, db_map: DatabaseMapping) -> tuple[Optional[dict], list[str]]:
-        """Returns a database entity item (id-based) from the given model parameter_value item (name-based).
-
-        Args:
-            item: the model parameter_value item
-            db_map: the database where the resulting item belongs
-
-        Returns:
-            the db entity item and error log
-        """
-        entity_class_name = item.get("entity_class_name")
-        entity_class = db_map.get_item("entity_class", name=entity_class_name)
-        if not entity_class:
-            return None, [f"Unknown entity_class {entity_class_name}"] if entity_class_name else []
-        entity_byname = item.get("entity_byname")
-        if not entity_byname:
-            return None, []
-        item = {"entity_class_name": entity_class_name, "entity_byname": entity_byname}
-        return None if db_map.get_item("entity", **item) else item, []
+        return item

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -432,13 +432,13 @@ class EntityMixin:
             if errors:
                 error_log.extend(errors)
         if entities:
-            self.db_mngr.add_entities({self.db_map: entities})
+            self.db_mngr.add_items("entity", {self.db_map: entities})
         if error_log:
             self.db_mngr.error_msg.emit({self.db_map: error_log})
         super().update_items_in_db(items)
 
     def _do_update_items_in_db(self, db_map_data):
-        raise NotImplementedError()
+        self.db_mngr.update_items(self.item_type, db_map_data)
 
 
 class SingleParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, SingleModelBase):
@@ -455,7 +455,7 @@ class SingleParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, Sin
         return order_key(item.get("name", ""))
 
     def _do_update_items_in_db(self, db_map_data):
-        self.db_mngr.update_parameter_definitions(db_map_data)
+        self.db_mngr.update_items("parameter_definition", db_map_data)
 
 
 class SingleParameterValueModel(
@@ -480,9 +480,6 @@ class SingleParameterValueModel(
         alt_name = order_key(item.get("alternative_name", ""))
         return byname, parameter_name, alt_name
 
-    def _do_update_items_in_db(self, db_map_data):
-        self.db_mngr.update_parameter_values(db_map_data)
-
 
 class SingleEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, FilterEntityAlternativeMixin, SingleModelBase):
     """An entity_alternative model for a single entity_class."""
@@ -503,6 +500,3 @@ class SingleEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, FilterE
             "alternative_name": ("alternative_id", "alternative"),
             "database": ("database", None),
         }
-
-    def _do_update_items_in_db(self, db_map_data):
-        self.db_mngr.update_entity_alternatives(db_map_data)

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -17,8 +17,9 @@ from spinedb_api.temp_id import TempId
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR, order_key, plain_to_rich
 from ...mvcmodels.minimal_table_model import MinimalTableModel
 from ...mvcmodels.shared import DB_MAP_ROLE, PARAMETER_TYPE_VALIDATION_ROLE, PARSED_ROLE
-from ..mvcmodels.single_and_empty_model_mixins import MakeEntityOnTheFlyMixin, SplitValueAndTypeMixin
+from ..mvcmodels.single_and_empty_model_mixins import SplitValueAndTypeMixin
 from .colors import FIXED_FIELD_COLOR
+from .utils import make_entity_on_the_fly
 
 
 class HalfSortedTableModel(MinimalTableModel[TempId]):
@@ -88,17 +89,15 @@ class SingleModelBase(HalfSortedTableModel):
     def update_items_in_db(self, items):
         """Update items in db. Required by batch_set_data"""
         items_to_upd = []
-        error_log = []
         for item in items:
-            item_to_upd, errors = self._convert_to_db(item)
+            item_to_upd = self._convert_to_db(item)
             if tuple(item_to_upd.keys()) != ("id",):
                 items_to_upd.append(item_to_upd)
-            if errors:
-                error_log += errors
         if items_to_upd:
             self._do_update_items_in_db({self.db_map: items_to_upd})
-        if error_log:
-            self.db_mngr.error_msg.emit({self.db_map: error_log})
+
+    def _convert_to_db(self, item: dict) -> dict:
+        return item.copy()
 
     @property
     def _references(self):
@@ -426,7 +425,7 @@ class EntityMixin:
         entities = []
         error_log = []
         for item in items:
-            entity, errors = self._make_entity_on_the_fly(item, self.db_map)
+            entity, errors = make_entity_on_the_fly(item, self.db_map)
             if entity:
                 entities.append(entity)
             if errors:
@@ -459,7 +458,6 @@ class SingleParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, Sin
 
 
 class SingleParameterValueModel(
-    MakeEntityOnTheFlyMixin,
     SplitValueAndTypeMixin,
     ParameterMixin,
     EntityMixin,
@@ -481,7 +479,7 @@ class SingleParameterValueModel(
         return byname, parameter_name, alt_name
 
 
-class SingleEntityAlternativeModel(MakeEntityOnTheFlyMixin, EntityMixin, FilterEntityAlternativeMixin, SingleModelBase):
+class SingleEntityAlternativeModel(EntityMixin, FilterEntityAlternativeMixin, SingleModelBase):
     """An entity_alternative model for a single entity_class."""
 
     item_type = "entity_alternative"

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
@@ -278,12 +278,6 @@ class LeafItem(StandardTreeItem):
             return plain_to_tool_tip(self.item_data.get(header_data))
         return super().tool_tip(column)
 
-    def add_item_to_db(self, db_item):
-        raise NotImplementedError()
-
-    def update_item_in_db(self, db_item):
-        raise NotImplementedError()
-
     def header_data(self, column):
         return self.model.headerData(column, Qt.Orientation.Horizontal)
 
@@ -300,11 +294,11 @@ class LeafItem(StandardTreeItem):
             return False
         if self.id:
             db_item = self._make_item_to_update(column, value)
-            self.update_item_in_db(db_item)
+            self.db_mngr.update_items(self.item_type, {self.db_map: [db_item]})
             return True
         if column == 0:
             db_item = self._make_item_to_add(value)
-            self.add_item_to_db(db_item)
+            self.db_mngr.add_items(self.item_type, {self.db_map: [db_item]})
         return True
 
     def _make_item_to_add(self, value):

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -124,7 +124,7 @@ class AddReadyEntitiesDialog(DialogWithTableAndButtons):
         if not db_map_data:
             self.parent().msg_error.emit("Nothing to add")
             return
-        self.db_mngr.add_entities(db_map_data)
+        self.db_mngr.add_items("entity", db_map_data)
         super().accept()
 
     def get_db_map_data(self):
@@ -331,7 +331,7 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
         if not db_map_data:
             self.parent().msg_error.emit("Nothing to add")
             return
-        self.db_mngr.add_entity_classes(db_map_data)
+        self.db_mngr.add_items("entity_class", db_map_data)
         super().accept()
 
     def construct_composite_name(self, row):
@@ -617,15 +617,15 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
         if not db_map_data:
             self.parent().msg_error.emit("Nothing to add")
             return
-        self.db_mngr.add_entities(db_map_data)
+        self.db_mngr.add_items("entity", db_map_data)
         created_entities = {}
         for db_map, data in db_map_data.items():
             for item in data:
                 entity_name = item["name"]
-                created_entities[entity_name] = db_map.get_entity_item(class_id=item["class_id"], name=entity_name)
+                created_entities[entity_name] = db_map.entity(class_id=item["class_id"], name=entity_name)
         entity_alternatives = self.make_entity_alternatives(created_entities)
         if entity_alternatives:  # If alternatives have been defined
-            self.db_mngr.add_entity_alternatives(entity_alternatives)
+            self.db_mngr.add_items("entity_alternative", entity_alternatives)
         entity_groups = self.make_entity_groups(created_entities)
         if entity_groups:  # If entity groups have been defined
             self.db_mngr.import_data(entity_groups, command_text="Add entity group")
@@ -634,9 +634,10 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
     def make_entity_alternatives(self, entities):
         """Creates a mapping from db_map to entity alternatives that are to be created"""
         entity_alternatives = {}
-        name_column = self.model.horizontal_header_labels().index("entity name")
-        alternative_column = self.model.horizontal_header_labels().index("alternative")
-        db_column = self.model.horizontal_header_labels().index("databases")
+        header = self.model.horizontal_header_labels()
+        name_column = header.index("entity name")
+        alternative_column = header.index("alternative")
+        db_column = header.index("databases")
         for i in range(self.model.rowCount() - 1):
             row_data = self.model.row_data(i)
             alternative = row_data[alternative_column]

--- a/spinetoolbox/spine_db_editor/widgets/custom_qgraphicsviews.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qgraphicsviews.py
@@ -589,7 +589,7 @@ class EntityQGraphicsView(CustomQGraphicsView):
             for db_map, entity_id in item.db_map_ids:
                 db_map_update_data[db_map].append({"id": entity_id, "lat": latitude, "lon": longitude})
         if db_map_update_data:
-            self.db_mngr.update_entities(db_map_update_data)
+            self.db_mngr.update_items("entity", db_map_update_data)
         else:
             self._spine_db_editor.msg.emit("No 0-dimensional entities selected - no positions to saved.")
 
@@ -622,7 +622,7 @@ class EntityQGraphicsView(CustomQGraphicsView):
         for item in items:
             for db_map, entity_id in item.db_map_ids:
                 db_map_update_data[db_map].append({"id": entity_id, "lat": None, "lon": None, "alt": None})
-        self.db_mngr.update_entities(db_map_update_data)
+        self.db_mngr.update_items("entity", db_map_update_data)
         self._spine_db_editor.build_graph()
 
     @Slot(bool)

--- a/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
@@ -120,7 +120,7 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
         if not db_map_data:
             self.parent().msg_error.emit("Nothing to update")
             return
-        self.db_mngr.update_entity_classes(db_map_data)
+        self.db_mngr.update_items("entity_class", db_map_data)
         super().accept()
 
 
@@ -221,7 +221,7 @@ class EditEntitiesDialog(GetEntityClassesMixin, GetEntitiesMixin, EditOrRemoveIt
         if not db_map_data:
             self.parent().msg_error.emit("Nothing to update")
             return
-        self.db_mngr.update_entities(db_map_data)
+        self.db_mngr.update_items("entity", db_map_data)
         super().accept()
 
 

--- a/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/graph_view_mixin.py
@@ -474,7 +474,7 @@ class GraphViewMixin:
     def save_graph_data(self, name):
         db_map_graph_data = self._get_db_map_graph_data()
         db_map_data = {db_map: [{"name": name, "value": gd}] for db_map, gd in db_map_graph_data.items()}
-        self.db_mngr.add_metadata(db_map_data)
+        self.db_mngr.add_items("metadata", db_map_data)
         # TODO: also add entity_metadata so it sticks
 
     def overwrite_graph_data(self, db_map_graph_data):
@@ -482,7 +482,7 @@ class GraphViewMixin:
         db_map_data = {
             db_map: [{"id": db_map_graph_data[db_map]["id"], "value": gd}] for db_map, gd in db_map_graph_data_.items()
         }
-        self.db_mngr.update_metadata(db_map_data)
+        self.db_mngr.update_items("metadata", db_map_data)
 
     def get_db_map_graph_data_by_name(self):
         db_map_graph_data_by_name = {}
@@ -912,7 +912,7 @@ class GraphViewMixin:
     def _add_entities_from_dialog(self, dialog):
         db_map_data = dialog.get_db_map_data()
         self._entity_fetch_parent.set_busy(True)
-        self.db_mngr.add_entities(db_map_data)
+        self.db_mngr.add_items("entity", db_map_data)
         self._entity_fetch_parent.set_busy(False)
         added_db_map_data = {
             db_map: [db_map.get_item("entity", **item) for item in items] for db_map, items in db_map_data.items()

--- a/spinetoolbox/spine_db_editor/widgets/scenario_generator.py
+++ b/spinetoolbox/spine_db_editor/widgets/scenario_generator.py
@@ -118,7 +118,9 @@ class ScenarioGenerator(QWidget):
             with signal_waiter(
                 self._db_editor.db_mngr.items_added, condition=lambda item_type, _: item_type == "scenario"
             ) as waiter:
-                self._db_editor.db_mngr.add_scenarios({self._db_map: [{"name": name} for name in new_scenarios]})
+                self._db_editor.db_mngr.add_items(
+                    "scenario", {self._db_map: [{"name": name} for name in new_scenarios]}
+                )
                 waiter.wait()
         searchable_scenario_names = set(scenarios_to_modify)
         scenario_definitions_by_id = {}

--- a/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/spine_db_editor.py
@@ -13,8 +13,9 @@
 """Contains the SpineDBEditor class."""
 import json
 import os
+from typing import Optional
 from PySide6.QtCore import QCoreApplication, QModelIndex, Qt, QTimer, Signal, Slot
-from PySide6.QtGui import QColor, QGuiApplication, QKeySequence, QPalette, QShortcut
+from PySide6.QtGui import QAction, QColor, QGuiApplication, QKeySequence, QPalette, QShortcut
 from PySide6.QtWidgets import (
     QAbstractScrollArea,
     QCheckBox,
@@ -41,9 +42,9 @@ from ...helpers import (
     preferred_row_height,
     unique_name,
 )
+from ...spine_db_manager import SpineDBManager
 from ...spine_db_parcel import SpineDBParcel
 from ...widgets.commit_dialog import CommitDialog
-from ...widgets.custom_qgraphicsviews import CustomQGraphicsView
 from ...widgets.notification import ChangeNotifier, Notification
 from ...widgets.parameter_value_editor import ParameterValueEditor
 from ..helpers import table_name_from_item_type
@@ -67,11 +68,7 @@ class SpineDBEditorBase(QMainWindow):
     file_exported = Signal(str, float, bool)
     """filepath, progress between 0 and 1, True if sqlite file"""
 
-    def __init__(self, db_mngr):
-        """
-        Args:
-            db_mngr (SpineDBManager): The manager to use
-        """
+    def __init__(self, db_mngr: SpineDBManager):
         super().__init__()
         from ..ui.spine_db_editor_window import Ui_MainWindow  # pylint: disable=import-outside-toplevel
 
@@ -94,7 +91,7 @@ class SpineDBEditorBase(QMainWindow):
             self.toolbar.show_toolbox_action.triggered.connect(toolbox.restore_and_activate)
         else:
             self.toolbar.show_toolbox_action.deleteLater()
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setWindowTitle("")
         self.qsettings = self.db_mngr.qsettings
         self.err_msg = QErrorMessage(self)
@@ -104,10 +101,10 @@ class SpineDBEditorBase(QMainWindow):
         max_screen_height = max(s.availableSize().height() for s in QGuiApplication.screens())
         self.visible_rows = int(max_screen_height / preferred_row_height(self))
         self.settings_group = "spineDBEditor"
-        self.undo_action = None
-        self.redo_action = None
-        self.ui.actionUndo.setShortcuts(QKeySequence.Undo)
-        self.ui.actionRedo.setShortcuts(QKeySequence.Redo)
+        self.undo_action: Optional[QAction] = None
+        self.redo_action: Optional[QAction] = None
+        self.ui.actionUndo.setShortcuts(QKeySequence.StandardKey.Undo)
+        self.ui.actionRedo.setShortcuts(QKeySequence.StandardKey.Redo)
         self.setContextMenuPolicy(Qt.NoContextMenu)
         self._torn_down = False
         self._purge_items_dialog = None
@@ -183,6 +180,7 @@ class SpineDBEditorBase(QMainWindow):
             for db_map in self.db_maps
         ]
         self.db_mngr.register_listener(self, *self.db_maps)
+        self._connect_db_map_undo_stacks(self.db_maps)
         self.init_models()
         self.init_add_undo_redo_actions()
         self._reset_window_title()
@@ -309,31 +307,43 @@ class SpineDBEditorBase(QMainWindow):
         msg += "</ul>"
         self.msg.emit(msg)
 
-    @Slot(bool)
-    def update_undo_redo_actions(self, _):
+    def _connect_db_map_undo_stacks(self, db_maps: list[DatabaseMapping]) -> None:
+        for db_map in db_maps:
+            undo_stack = self.db_mngr.undo_stack[db_map]
+            undo_stack.indexChanged.connect(self.update_undo_redo_actions)
+            undo_stack.cleanChanged.connect(self.update_commit_enabled)
+
+    def _disconnect_db_map_undo_stacks(self) -> None:
+        for db_map in self.db_maps:
+            undo_stack = self.db_mngr.undo_stack[db_map]
+            undo_stack.indexChanged.disconnect(self.update_undo_redo_actions)
+            undo_stack.cleanChanged.disconnect(self.update_commit_enabled)
+
+    @Slot(int)
+    def update_undo_redo_actions(self, _=0):
         undo_db_map = max(self.db_maps, key=lambda db_map: self.db_mngr.undo_stack[db_map].undo_age)
         redo_db_map = max(self.db_maps, key=lambda db_map: self.db_mngr.undo_stack[db_map].redo_age)
         new_undo_action = self.db_mngr.undo_action[undo_db_map]
         new_redo_action = self.db_mngr.redo_action[redo_db_map]
         self._replace_undo_redo_actions(new_undo_action, new_redo_action)
 
-    def _replace_undo_redo_actions(self, new_undo_action, new_redo_action):
-        if new_undo_action != self.undo_action:
+    def _replace_undo_redo_actions(self, new_undo_action: QAction, new_redo_action: QAction) -> None:
+        if new_undo_action is not self.undo_action:
             if self.undo_action:
+                self.undo_action.enabledChanged.disconnect(self.ui.actionUndo.setEnabled)
                 self.ui.actionUndo.triggered.disconnect(self.undo_action.triggered)
             self.ui.actionUndo.triggered.connect(new_undo_action.triggered)
             self.undo_action = new_undo_action
-        if new_redo_action != self.redo_action:
+            self.undo_action.enabledChanged.connect(self.ui.actionUndo.setEnabled)
+            self.ui.actionUndo.setEnabled(self.undo_action.isEnabled())
+        if new_redo_action is not self.redo_action:
             if self.redo_action:
+                self.redo_action.enabledChanged.disconnect(self.ui.actionRedo.setEnabled)
                 self.ui.actionRedo.triggered.disconnect(self.redo_action.triggered)
             self.ui.actionRedo.triggered.connect(new_redo_action.triggered)
             self.redo_action = new_redo_action
-        self._refresh_undo_redo_actions()
-
-    @Slot()
-    def _refresh_undo_redo_actions(self):
-        self.ui.actionUndo.setEnabled(self.undo_action.isEnabled())
-        self.ui.actionRedo.setEnabled(self.redo_action.isEnabled())
+            self.redo_action.enabledChanged.connect(self.ui.actionRedo.setEnabled)
+            self.ui.actionRedo.setEnabled(self.redo_action.isEnabled())
 
     @Slot(bool)
     def update_commit_enabled(self, _clean=False):
@@ -775,12 +785,15 @@ class SpineDBEditorBase(QMainWindow):
                     return False
         self._purge_change_notifiers()
         self._torn_down = True
+        self._disconnect_db_map_undo_stacks()
         failed_db_maps = self.db_mngr.unregister_listener(
             self, *self.db_maps, dirty_db_maps=dirty_db_maps, commit_dirty=commit_dirty, commit_msg=commit_msg
         )
         if failed_db_maps:
-            msg = f"Failed to commit {list(self.db_mngr.name_registry.display_name_iter(failed_db_maps))}"
-            self.db_mngr.receive_error_msg({i: [msg] for i in failed_db_maps})
+            self.db_mngr.receive_error_msg(
+                {i: [f"Failed to commit {self.db_mngr.name_registry.display_name(i.db_url)}"] for i in failed_db_maps}
+            )
+            self._connect_db_map_undo_stacks(failed_db_maps)
             return False
         return True
 

--- a/spinetoolbox/spine_db_icon_manager.py
+++ b/spinetoolbox/spine_db_icon_manager.py
@@ -11,10 +11,12 @@
 ######################################################################################################################
 
 """Provides SpineDBIconManager."""
+from collections.abc import Iterable
 from PySide6.QtCore import QBuffer, QPointF, QRectF, Qt
 from PySide6.QtGui import QFont, QIcon, QPainter, QTextOption
 from PySide6.QtSvg import QSvgGenerator, QSvgRenderer
 from PySide6.QtWidgets import QGraphicsScene
+from spinedb_api.db_mapping_base import PublicItem
 from .font import TOOLBOX_FONT
 from .helpers import TransparentIconEngine, default_icon_id, interpret_icon_id
 
@@ -72,13 +74,13 @@ class SpineDBIconManager:
         self._group_renderers = {}  # A mapping from class name to associated group renderer
         self.icon_renderers = {}
 
-    def update_icon_caches(self, classes):
+    def update_icon_caches(self, classes: Iterable[PublicItem]):
         """Called after adding or updating entity classes.
         Stores display_icons and clears obsolete entries
         from the relationship class and entity group renderer caches.
 
         Args:
-            classes (list): List of entity classes that were updated.
+            classes: iterable of entity classes that were updated.
         """
         for class_ in classes:
             self.display_icons[class_["name"]] = class_["display_icon"]

--- a/spinetoolbox/spine_db_manager.py
+++ b/spinetoolbox/spine_db_manager.py
@@ -16,8 +16,12 @@ from contextlib import suppress
 import json
 import os
 from threading import RLock
-from typing import Optional, Union
-from PySide6.QtCore import QObject, Qt, Signal, Slot
+from typing import Any, Optional, Union
+import numpy as np
+import numpy.typing as nptyping
+from PySide6.QtCore import QObject, QSettings, Qt, Signal, Slot
+from PySide6.QtGui import QAction, QColor, QIcon, QUndoStack
+from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtWidgets import QApplication, QMessageBox
 from sqlalchemy.engine.url import URL
 from spinedb_api import (
@@ -45,6 +49,7 @@ from spinedb_api.db_mapping_base import PublicItem
 from spinedb_api.exception import NothingToCommit
 from spinedb_api.helpers import remove_credentials_from_url
 from spinedb_api.parameter_value import (
+    MapIndex,
     Value,
     deep_copy_value,
     dump_db_value,
@@ -55,7 +60,9 @@ from spinedb_api.parameter_value import (
 from spinedb_api.spine_io.exporters.excel import export_spine_database_to_xlsx
 from spinedb_api.temp_id import TempId
 from spinetoolbox.database_display_names import NameRegistry
-from .helpers import DBMapDictItems, DBMapTypedDictItems, busy_effect, plain_to_tool_tip
+from .fetch_parent import FetchParent
+from .helpers import DBMapDictItems, DBMapPublicItems, busy_effect, plain_to_tool_tip
+from .logger_interface import LoggerInterface
 from .mvcmodels.shared import INVALID_TYPE, PARAMETER_TYPE_VALIDATION_ROLE, PARSED_ROLE, TYPE_NOT_VALIDATED, VALID_TYPE
 from .parameter_type_validation import ParameterTypeValidator
 from .spine_db_commands import (
@@ -69,9 +76,11 @@ from .spine_db_icon_manager import SpineDBIconManager
 from .spine_db_worker import SpineDBWorker
 from .widgets.options_dialog import OptionsDialog
 
+ValidatedValueCache = dict[str, dict[int, dict[int, bool]]]
+
 
 @busy_effect
-def do_create_new_spine_database(url):
+def do_create_new_spine_database(url: str) -> None:
     """Creates a new spine database at the given url."""
     create_new_spine_database(url)
 
@@ -116,12 +125,12 @@ class SpineDBManager(QObject):
         object: database mapping
     """
 
-    def __init__(self, settings, parent, synchronous=False):
+    def __init__(self, settings: QSettings, parent: Optional[QObject], synchronous: bool = False):
         """
         Args:
-            settings (QSettings): Toolbox settings
-            parent (QObject, optional): parent object
-            synchronous (bool): If True, fetch database synchronously
+            settings: Toolbox settings
+            parent : parent object
+            synchronous: If True, fetch database synchronously
         """
         super().__init__(parent)
         self.qsettings = settings
@@ -129,21 +138,21 @@ class SpineDBManager(QObject):
         self.name_registry = NameRegistry(self)
         self._workers: dict[DatabaseMapping, SpineDBWorker] = {}
         self._lock_lock = RLock()
-        self._db_locks = {}
-        self.listeners = {}
-        self.undo_stack = {}
-        self.undo_action = {}
-        self.redo_action = {}
-        self._icon_mngr = {}
+        self._db_locks: dict[DatabaseMapping, RLock] = {}
+        self.listeners: dict[DatabaseMapping, set[object]] = {}
+        self.undo_stack: dict[DatabaseMapping, QUndoStack] = {}
+        self.undo_action: dict[DatabaseMapping, QAction] = {}
+        self.redo_action: dict[DatabaseMapping, QAction] = {}
+        self._icon_mngr: dict[DatabaseMapping, SpineDBIconManager] = {}
         self._connect_signals()
         self._cmd_id = 0
         self._synchronous = synchronous
-        self._validated_values = {"parameter_definition": {}, "parameter_value": {}}
+        self._validated_values: ValidatedValueCache = {"parameter_definition": {}, "parameter_value": {}}
         self._parameter_type_validator = ParameterTypeValidator(self)
         self._parameter_type_validator.validated.connect(self._parameter_value_validated)
-        self._no_prompt_urls = set()
+        self._no_prompt_urls: set[str] = set()
 
-    def _connect_signals(self):
+    def _connect_signals(self) -> None:
         self.error_msg.connect(self.receive_error_msg)
         qApp.aboutToQuit.connect(self.clean_up)  # pylint: disable=undefined-variable
 
@@ -184,111 +193,79 @@ class SpineDBManager(QObject):
                 except AttributeError:
                     pass
 
-    def _get_worker(self, db_map):
-        """Returns a worker.
-
-        Args:
-            db_map (DatabaseMapping): database mapping
-
-        Returns:
-            SpineDBWorker: worker for the db_map
-        """
-        return self._workers[db_map]
-
-    def get_lock(self, db_map):
+    def get_lock(self, db_map: DatabaseMapping) -> RLock:
         return self._db_locks[db_map]
 
-    def register_fetch_parent(self, db_map, parent):
+    def register_fetch_parent(self, db_map: DatabaseMapping, parent: FetchParent) -> None:
         """Registers a fetch parent.
 
         Args:
-            db_map (DatabaseMapping): target database mapping
-            parent (FetchParent): fetch parent
+            db_map: target database mapping
+            parent: fetch parent
         """
         if db_map.closed:
             return
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             return
         worker.register_fetch_parent(parent)
 
-    def can_fetch_more(self, db_map, parent):
-        """Whether we can fetch more items of given type from given db.
-
-        Args:
-            db_map (DatabaseMapping)
-            parent (FetchParent): The object that requests the fetching and that might want to react to further DB
-                modifications.
-
-        Returns:
-            bool
-        """
+    def can_fetch_more(self, db_map: DatabaseMapping, parent: FetchParent) -> bool:
+        """Whether we can fetch more items of given type from given db."""
         if db_map.closed:
             return False
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             return False
         return worker.can_fetch_more(parent)
 
-    def fetch_more(self, db_map, parent):
-        """Fetches more items of given type from given db.
-
-        Args:
-            db_map (DatabaseMapping)
-            parent (FetchParent): The object that requests the fetching.
-        """
+    def fetch_more(self, db_map: DatabaseMapping, parent: FetchParent) -> None:
+        """Fetches more items for fetch parent from given db."""
         if db_map.closed:
             return
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             return
         worker.fetch_more(parent)
 
-    def get_icon_mngr(self, db_map):
-        """Returns an icon manager for given db_map.
-
-        Args:
-            db_map (DatabaseMapping)
-
-        Returns:
-            SpineDBIconManager
-        """
+    def get_icon_mngr(self, db_map: DatabaseMapping) -> SpineDBIconManager:
+        """Returns an icon manager for given db_map."""
         if db_map not in self._icon_mngr:
             self._icon_mngr[db_map] = SpineDBIconManager()
         return self._icon_mngr[db_map]
 
-    def update_icons(self, db_map, item_type, items):
+    def update_icons(self, db_map: DatabaseMapping, item_type: str, items: Iterable[PublicItem]) -> None:
         """Runs when items are added or updated. Setups icons."""
         if item_type == "entity_class":
             self.get_icon_mngr(db_map).update_icon_caches(items)
 
     @property
-    def db_maps(self):
+    def db_maps(self) -> set[DatabaseMapping]:
         return set(self._db_maps.values())
 
     @staticmethod
-    def db_map_key(db_map):
+    def db_map_key(db_map: DatabaseMapping) -> str:
         """Creates an identifier for given db_map.
 
         Args:
-            db_map (DatabaseMapping): database mapping
+            db_map: database mapping
 
         Returns:
-            int: identification key
+            identification key
         """
         return str(hash(db_map))
 
-    def db_map_from_key(self, key):
+    def db_map_from_key(self, key: str) -> DatabaseMapping:
         """Returns database mapping that corresponds to given identification key.
 
         Args:
-            key (int): identification key
+            key: identification key
 
         Returns:
-            DatabaseMapping: database mapping
+            database mapping
 
         Raises:
             KeyError: raised if database map is not found
@@ -296,23 +273,23 @@ class SpineDBManager(QObject):
         return {self.db_map_key(db_map): db_map for db_map in self._db_maps.values()}[key]
 
     @property
-    def db_urls(self):
+    def db_urls(self) -> set[str]:
         return set(self._db_maps)
 
-    def db_map(self, url):
+    def db_map(self, url: str) -> DatabaseMapping:
         """
         Returns a database mapping for given URL.
 
         Args:
-            url (str): a database URL
+            url: a database URL
 
         Returns:
-            DatabaseMapping: a database map or None if not found
+            a database map or None if not found
         """
         url = str(url)
         return self._db_maps.get(url)
 
-    def create_new_spine_database(self, url, logger, overwrite=False):
+    def create_new_spine_database(self, url: str, logger: LoggerInterface, overwrite: bool = False):
         if not overwrite and not is_empty(url):
             msg = QMessageBox(qApp.activeWindow())  # pylint: disable=undefined-variable
             msg.setIcon(QMessageBox.Icon.Question)
@@ -359,23 +336,16 @@ class SpineDBManager(QObject):
         del self.undo_action[db_map]
         del self.redo_action[db_map]
 
-    def close_all_sessions(self):
+    def close_all_sessions(self) -> None:
         """Closes connections to all database mappings."""
         for url in list(self._db_maps):
             self.close_session(url)
 
-    def get_db_map(self, url, logger, create=False, force_upgrade_prompt=False):
+    def get_db_map(
+        self, url: str, logger: LoggerInterface, create: bool = False, force_upgrade_prompt: bool = False
+    ) -> Optional[DatabaseMapping]:
         """Returns a DatabaseMapping instance from url if possible, None otherwise.
         If needed, asks the user to upgrade to the latest db version.
-
-        Args:
-            url (str, URL)
-            logger (LoggerInterface)
-            create (bool)
-            force_upgrade_prompt (bool)
-
-        Returns:
-            DatabaseMapping, NoneType
         """
         url = str(url)
         db_map = self._db_maps.get(url)
@@ -406,11 +376,11 @@ class SpineDBManager(QObject):
             return None
 
     @busy_effect
-    def _do_get_db_map(self, url, **kwargs):
+    def _do_get_db_map(self, url: str, **kwargs) -> DatabaseMapping:
         """Returns a memorized DatabaseMapping instance from url.
 
         Args:
-            url (str, URL)
+            url: database URL
             **kwargs: arguments passed to worker's get_db_map()
 
         Returns:
@@ -434,31 +404,22 @@ class SpineDBManager(QObject):
         self.redo_action[db_map] = stack.createRedoAction(self)
         return db_map
 
-    def query(self, db_map, sq_name):
-        """For tests."""
-        return self._get_worker(db_map).query(sq_name)
-
-    def add_db_map_listener(self, db_map, listener):
+    def add_db_map_listener(self, db_map: DatabaseMapping, listener: object) -> None:
         """Adds listener for given db_map."""
         self.listeners.setdefault(db_map, set()).add(listener)
 
-    def remove_db_map_listener(self, db_map, listener):
+    def remove_db_map_listener(self, db_map: DatabaseMapping, listener: object) -> None:
         """Removes db_map from the maps listener listens to."""
         listeners = self.listeners.get(db_map, set())
         listeners.discard(listener)
         if not listeners:
             self.listeners.pop(db_map)
 
-    def db_map_listeners(self, db_map):
+    def db_map_listeners(self, db_map: DatabaseMapping) -> set[object]:
         return self.listeners.get(db_map, set())
 
-    def register_listener(self, listener, *db_maps):
-        """Register given listener for all given db_map's signals.
-
-        Args:
-            listener (object)
-            *db_maps
-        """
+    def register_listener(self, listener: object, *db_maps: DatabaseMapping) -> None:
+        """Register given listener for all given db_map's signals."""
         for db_map in db_maps:
             self.add_db_map_listener(db_map, listener)
             stack = self.undo_stack[db_map]
@@ -469,18 +430,26 @@ class SpineDBManager(QObject):
             except AttributeError:
                 pass
 
-    def unregister_listener(self, listener, *db_maps, dirty_db_maps=None, commit_dirty=False, commit_msg=""):
+    def unregister_listener(
+        self,
+        listener: object,
+        *db_maps: DatabaseMapping,
+        dirty_db_maps: Optional[Iterable[DatabaseMapping]] = None,
+        commit_dirty: bool = False,
+        commit_msg: str = "",
+    ) -> list[DatabaseMapping]:
         """Unregisters given listener from given db_map signals.
         If any of the db_maps becomes an orphan and is dirty, prompts user to commit or rollback.
 
         Args:
-            listener (object)
-            *db_maps
-            commit_dirty (bool): True to commit dirty database mapping, False to roll back
-            commit_msg (str): commit message
+            listener: listener to unregister
+            *db_maps: Database mappings from which to unregister
+            dirty_db_maps: Database mappings that have uncommitted changes
+            commit_dirty: True to commit dirty database mapping, False to roll back
+            commit_msg: commit message
 
         Returns:
-            failed_db_maps (list): All the db maps that failed to commit
+            All the db maps that failed to commit
         """
         failed_db_maps = []
         for db_map in db_maps:
@@ -515,18 +484,18 @@ class SpineDBManager(QObject):
                 self.close_session(db_map.db_url)
         return failed_db_maps
 
-    def is_dirty(self, db_map):
+    def is_dirty(self, db_map: DatabaseMapping) -> bool:
         """Returns True if mapping has pending changes.
 
         Args:
-            db_map (DatabaseMapping): database mapping
+            db_map: database mapping
 
         Returns:
-            bool: True if db_map has pending changes, False otherwise
+            True if db_map has pending changes, False otherwise
         """
         return not self.undo_stack[db_map].isClean()
 
-    def dirty(self, *db_maps):
+    def dirty(self, *db_maps: DatabaseMapping) -> list[DatabaseMapping]:
         """Filters clean mappings from given database maps.
 
         Args:
@@ -537,11 +506,11 @@ class SpineDBManager(QObject):
         """
         return [db_map for db_map in db_maps if self.is_dirty(db_map)]
 
-    def dirty_and_without_editors(self, listener, *db_maps):
+    def dirty_and_without_editors(self, listener: object, *db_maps: DatabaseMapping) -> list[DatabaseMapping]:
         """Checks which of the given database mappings are dirty and have no editors.
 
         Args:
-            listener (Any): a listener object
+            listener: a listener object
             *db_maps: mappings to check
 
         Return:
@@ -556,20 +525,20 @@ class SpineDBManager(QObject):
 
         return [db_map for db_map in self.dirty(*db_maps) if not has_editors(db_map)]
 
-    def clean_up(self):
+    def clean_up(self) -> None:
         while self._workers:
             _, worker = self._workers.popitem()
             worker.clean_up()
         self._parameter_type_validator.tear_down()
         self.deleteLater()
 
-    def refresh_session(self, *db_maps):
+    def refresh_session(self, *db_maps: DatabaseMapping) -> None:
         reset_db_maps = set()
         for db_map in db_maps:
             if not db_map or not db_map.has_external_commits():
                 continue
             try:
-                worker = self._get_worker(db_map)
+                worker = self._workers[db_map]
             except KeyError:
                 continue
             is_dirty = not self.undo_stack[db_map].isClean()
@@ -581,11 +550,11 @@ class SpineDBManager(QObject):
         if reset_db_maps:
             self.receive_session_refreshed(reset_db_maps)
 
-    def reset_session(self, *db_maps):
+    def reset_session(self, *db_maps: DatabaseMapping) -> set[DatabaseMapping]:
         reset_db_maps = set()
         for db_map in db_maps:
             try:
-                worker = self._get_worker(db_map)
+                worker = self._workers[db_map]
             except KeyError:
                 continue
             worker.reset_session()
@@ -594,14 +563,16 @@ class SpineDBManager(QObject):
             self.database_reset.emit(db_map)
         return reset_db_maps
 
-    def commit_session(self, commit_msg, *dirty_db_maps, cookie=None):
+    def commit_session(
+        self, commit_msg: str, *dirty_db_maps: DatabaseMapping, cookie: Optional[Any] = None
+    ) -> list[DatabaseMapping]:
         """
         Commits the current session.
 
         Args:
-            commit_msg (str): commit message for all database maps
+            commit_msg: commit message for all database maps
             *dirty_db_maps: dirty database maps to commit
-            cookie (object, optional): a free form identifier which will be forwarded to ``SpineDBWorker.commit_session``
+            cookie: a free form identifier which will be forwarded to ``SpineDBWorker.commit_session``
         """
         failed_db_maps = []
         for db_map in dirty_db_maps:
@@ -611,16 +582,16 @@ class SpineDBManager(QObject):
                 continue
         return failed_db_maps
 
-    def _do_commit_session(self, db_map, commit_msg, cookie=None):
+    def _do_commit_session(self, db_map: DatabaseMapping, commit_msg: str, cookie: Optional[Any] = None) -> bool:
         """Commits session for given db.
 
         Args:
-            db_map (DatabaseMapping): db map
-            commit_msg (str): commit message
-            cookie (Any): a cookie to include in receive_session_committed call
+            db_map: db map
+            commit_msg: commit message
+            cookie: a cookie to include in receive_session_committed call
 
         Returns:
-            bool
+            True if operation was successful, False otherwise.
         """
         try:
             try:
@@ -652,18 +623,18 @@ class SpineDBManager(QObject):
             self.error_msg.emit({db_map: [err.msg]})
             return False
 
-    def notify_session_committed(self, cookie, *db_maps):
+    def notify_session_committed(self, cookie: Optional[Any], *db_maps: DatabaseMapping) -> None:
         """Notifies manager and listeners when a commit has taken place by a third party.
 
         Args:
-            cookie (Any): commit cookie
+            cookie: commit cookie
             *db_maps: database maps that were committed
         """
         reset_db_maps = self.reset_session(*db_maps)
         if reset_db_maps:
             self.receive_session_committed(reset_db_maps, cookie)
 
-    def rollback_session(self, *dirty_db_maps):
+    def rollback_session(self, *dirty_db_maps: DatabaseMapping) -> None:
         """Rolls back the current session.
 
         Args:
@@ -672,12 +643,8 @@ class SpineDBManager(QObject):
         for db_map in dirty_db_maps:
             self._do_rollback_session(db_map)
 
-    def _do_rollback_session(self, db_map):
-        """Rolls back session for given db.
-
-        Args:
-            db_map (DatabaseMapping): db map
-        """
+    def _do_rollback_session(self, db_map: DatabaseMapping) -> None:
+        """Rolls back session for given db."""
         try:
             db_map.rollback_session()
         except SpineDBAPIError as err:
@@ -688,7 +655,9 @@ class SpineDBManager(QObject):
         self.undo_stack[db_map].clear()
         self.receive_session_rolled_back({db_map})
 
-    def entity_class_renderer(self, db_map, entity_class_id, for_group=False, color=None):
+    def entity_class_renderer(
+        self, db_map: DatabaseMapping, entity_class_id: TempId, for_group: bool = False, color: Optional[QColor] = None
+    ) -> Optional[QSvgRenderer]:
         """Returns an icon renderer for a given entity class.
 
         Args:
@@ -710,16 +679,18 @@ class SpineDBManager(QObject):
             return self.get_icon_mngr(db_map).color_class_renderer(entity_class, color_code)
         return self.get_icon_mngr(db_map).class_renderer(entity_class)
 
-    def entity_class_icon(self, db_map, entity_class_id, for_group=False):
+    def entity_class_icon(
+        self, db_map: DatabaseMapping, entity_class_id: TempId, for_group: bool = False
+    ) -> Optional[QIcon]:
         """Returns an appropriate icon for a given entity class.
 
         Args:
-            db_map (DatabaseMapping): database map
-            entity_class_id (int): entity class' id
-            for_group (bool): if True, return the group object icon instead
+            db_map: database map
+            entity_class_id: entity class' id
+            for_group: if True, return the group object icon instead
 
         Returns:
-            QIcon: requested icon or None if no entity class was found
+            requested icon or None if no entity class was found
         """
         renderer = self.entity_class_renderer(db_map, entity_class_id, for_group=for_group)
         return SpineDBIconManager.icon_from_renderer(renderer) if renderer is not None else None
@@ -735,54 +706,31 @@ class SpineDBManager(QObject):
         except KeyError:
             return None
 
-    def get_items(self, db_map, item_type, **kwargs):
-        """Returns a list of the items of the given type in the given db map.
-
-        Args:
-            db_map (DatabaseMapping)
-            item_type (str)
-            **kwargs: extra arguments passed to database mapping
-
-        Returns:
-            list
-        """
+    def get_items(self, db_map: DatabaseMapping, item_type: str, **search_criteria) -> list[PublicItem]:
+        """Returns a list of the items of the given type in the given db map."""
         with self.get_lock(db_map):
             table = db_map.mapped_table(item_type)
-            return db_map.find(table, **kwargs)
+            return db_map.find(table, **search_criteria)
 
-    def get_items_by_field(self, db_map, item_type, field, value):
+    def get_items_by_field(self, db_map: DatabaseMapping, item_type: str, field: str, value: Any) -> list[PublicItem]:
         """Returns a list of items of the given type in the given db map that have the given value
         for the given field.
-
-        Args:
-            db_map (DatabaseMapping)
-            item_type (str)
-            field (str)
-            value
-
-        Returns:
-            list
         """
-        return [x for x in db_map.get_items(item_type) if x.get(field) == value]
+        with self.get_lock(db_map):
+            mapped_table = db_map.mapped_table(item_type)
+            return [x for x in db_map.find(mapped_table) if x.get(field) == value]
 
-    def get_item_by_field(self, db_map, item_type, field, value):
+    def get_item_by_field(
+        self, db_map: DatabaseMapping, item_type: str, field: str, value: Any
+    ) -> Union[PublicItem, dict]:
         """Returns the first item of the given type in the given db map
         that has the given value for the given field
         Returns an empty dictionary if none found.
-
-        Args:
-            db_map (DatabaseMapping)
-            item_type (str)
-            field (str)
-            value
-
-        Returns:
-            dict
         """
         return next(iter(self.get_items_by_field(db_map, item_type, field, value)), {})
 
     @staticmethod
-    def display_data_from_parsed(parsed_data):
+    def display_data_from_parsed(parsed_data: Value) -> str:
         """Returns the value's database representation formatted for Qt.ItemDataRole.DisplayRole."""
         if isinstance(parsed_data, TimeSeries):
             display_data = "Time series"
@@ -799,7 +747,7 @@ class SpineDBManager(QObject):
         return display_data
 
     @staticmethod
-    def tool_tip_data_from_parsed(parsed_data):
+    def tool_tip_data_from_parsed(parsed_data: Value) -> Optional[str]:
         """Returns the value's database representation formatted for Qt.ItemDataRole.ToolTipRole."""
         if isinstance(parsed_data, TimeSeriesFixedResolution):
             resolution = [relativedelta_to_duration(r) for r in parsed_data.resolution]
@@ -813,15 +761,8 @@ class SpineDBManager(QObject):
             tool_tip_data = None
         return plain_to_tool_tip(tool_tip_data)
 
-    def _tool_tip_for_invalid_parameter_type(self, item):
-        """Returns tool tip for parameter (default) values that have an invalid type.
-
-        Args:
-            item (PublicItem):
-
-        Returns:
-            str: tool tip
-        """
+    def _tool_tip_for_invalid_parameter_type(self, item: PublicItem) -> str:
+        """Returns tool tip for parameter (default) values that have an invalid type."""
         if item.item_type == "parameter_value":
             definition = self.get_item(item.db_map, "parameter_definition", item["parameter_definition_id"])
         else:
@@ -831,7 +772,7 @@ class SpineDBManager(QObject):
             return plain_to_tool_tip(f"Expected value's type to be <b>{type_list[0]}</b>.")
         return plain_to_tool_tip(f"Expected value's type to be one of <b>{', '.join(type_list)}</b>.")
 
-    def _format_list_value(self, db_map, item_type, value, list_value_id):
+    def _format_list_value(self, db_map: DatabaseMapping, item_type: str, value: Value, list_value_id: TempId) -> str:
         list_value = self.get_item(db_map, "list_value", list_value_id)
         if not list_value:
             return value
@@ -846,7 +787,7 @@ class SpineDBManager(QObject):
 
     def get_value(
         self, db_map: DatabaseMapping, item: PublicItem, role: Union[int, Qt.ItemDataRole] = Qt.ItemDataRole.DisplayRole
-    ) -> Optional[Union[int, str, Value]]:
+    ) -> Optional[Union[int, Value]]:
         """Returns the value or default value of a parameter.
 
         Args:
@@ -886,71 +827,68 @@ class SpineDBManager(QObject):
             return join_value_and_type(item[value_field], item[type_field])
         return self._format_value(item["parsed_value"], role=role)
 
-    def get_value_from_data(self, data, role=Qt.ItemDataRole.DisplayRole):
-        """Returns the value or default value of a parameter directly from data.
-        Used by ``EmptyParameterModel.data()``.
-
-        Args:
-            data (str): joined value and type
-            role (int, optional)
-
-        Returns:
-            any
-        """
+    def get_value_from_data(
+        self, data: Optional[str], role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
+    ) -> Optional[Union[str, int]]:
+        """Returns the value or default value of a parameter directly from data."""
         if data is None:
             return None
         parsed_value = self._parse_value(*split_value_and_type(data))
         return self._format_value(parsed_value, role=role)
 
     @staticmethod
-    def _parse_value(db_value, type_=None):
+    def _parse_value(db_value: bytes, type_: Optional[str] = None) -> Value:
         try:
             return from_database(db_value, type_=type_)
         except ParameterValueFormatError as error:
-            return error
+            return str(error)
 
-    def _format_value(self, parsed_value, role=Qt.ItemDataRole.DisplayRole):
-        """Formats the given value for the given role.
-
-        Args:
-            parsed_value (object): A python object as returned by spinedb_api.from_database
-            role (int, optional)
-        """
+    def _format_value(
+        self, parsed_value: Value, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
+    ) -> Optional[Union[str, int]]:
+        """Formats the given value for the given role."""
         if role == Qt.ItemDataRole.DisplayRole:
             return self.display_data_from_parsed(parsed_value)
         if role == Qt.ItemDataRole.ToolTipRole:
             return self.tool_tip_data_from_parsed(parsed_value)
-        if role == Qt.TextAlignmentRole:
+        if role == Qt.ItemDataRole.TextAlignmentRole:
             if isinstance(parsed_value, str):
-                return int(Qt.AlignLeft | Qt.AlignVCenter)
-            return int(Qt.AlignRight | Qt.AlignVCenter)
+                return int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+            return int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         if role == PARSED_ROLE:
             return parsed_value
         return None
 
-    def get_value_indexes(self, db_map, item_type, id_):
+    def get_value_indexes(self, db_map: DatabaseMapping, item_type: str, id_: TempId) -> nptyping.NDArray:
         """Returns the value or default value indexes of a parameter.
 
         Args:
-            db_map (DatabaseMapping)
-            item_type (str): either "parameter_definition" or "parameter_value"
-            id_ (int): The parameter_value or definition id
+            db_map: Database mapping
+            item_type: either "parameter_definition" or "parameter_value"
+            id_: The parameter_value or definition id
         """
         item = self.get_item(db_map, item_type, id_)
         parsed_value = item["parsed_value"]
         if isinstance(parsed_value, IndexedValue):
             return parsed_value.indexes
-        return [""]
+        return np.array([""])
 
-    def get_value_index(self, db_map, item_type, id_, index, role=Qt.ItemDataRole.DisplayRole):
+    def get_value_index(
+        self,
+        db_map: DatabaseMapping,
+        item_type: str,
+        id_: TempId,
+        index: MapIndex,
+        role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
+    ) -> Optional[Value]:
         """Returns the value or default value of a parameter for a given index.
 
         Args:
-            db_map (DatabaseMapping)
-            item_type (str): either "parameter_definition" or "parameter_value"
-            id_ (int): The parameter_value or definition id
+            db_map: Database mapping.
+            item_type: either "parameter_definition" or "parameter_value"
+            id_: The parameter_value or definition id
             index: The index to retrieve
-            role (int, optional)
+            role: Data role.
         """
         item = self.get_item(db_map, item_type, id_)
         parsed_value = item["parsed_value"]
@@ -966,27 +904,31 @@ class SpineDBManager(QObject):
             return parsed_value
         return None
 
-    def get_value_list_item(self, db_map, id_, index, role=Qt.ItemDataRole.DisplayRole):
+    def get_value_list_item(
+        self, db_map: DatabaseMapping, id_: TempId, index: int, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
+    ) -> Optional[list[Optional[Union[int, Value]]]]:
         """Returns one value item of a parameter_value_list.
 
         Args:
-            db_map (DatabaseMapping)
-            id_ (int): The parameter_value_list id
-            index (int): The value item index
-            role (int, optional)
+            db_map: Database mapping
+            id_: The parameter_value_list id
+            index: The value item index
+            role: Data role
         """
         try:
             return self.get_parameter_value_list(db_map, id_, role=role)[index]
         except IndexError:
             return None
 
-    def get_parameter_value_list(self, db_map, id_, role=Qt.ItemDataRole.DisplayRole):
+    def get_parameter_value_list(
+        self, db_map: DatabaseMapping, id_: TempId, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole
+    ) -> list[Optional[Union[int, Value]]]:
         """Returns a parameter_value_list formatted for the given role.
 
         Args:
-            db_map (DatabaseMapping)
-            id_ (int): The parameter_value_list id
-            role (int, optional)
+            db_map: Database mapping
+            id_: The parameter_value_list id
+            role: Data role.
         """
         with self.get_lock(db_map):
             list_value_table = db_map.mapped_table("list_value")
@@ -995,7 +937,7 @@ class SpineDBManager(QObject):
                 for item in db_map.find(list_value_table, parameter_value_list_id=id_)
             ]
 
-    def get_scenario_alternative_id_list(self, db_map, scen_id):
+    def get_scenario_alternative_id_list(self, db_map: DatabaseMapping, scen_id: TempId) -> list[TempId]:
         if db_map in self._db_locks:
             with self._db_locks[db_map]:
                 scen = self.get_item(db_map, "scenario", scen_id)
@@ -1031,111 +973,7 @@ class SpineDBManager(QObject):
         if any(db_map_error_log.values()):
             self.error_msg.emit(db_map_error_log)
 
-    def add_alternatives(self, db_map_data):
-        """Adds alternatives to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("alternative", db_map_data)
-
-    def add_scenarios(self, db_map_data):
-        """Adds scenarios to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("scenario", db_map_data)
-
-    def add_entity_classes(self, db_map_data):
-        """Adds entity classes to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("entity_class", db_map_data)
-
-    def add_entities(self, db_map_data):
-        """Adds entities to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("entity", db_map_data)
-
-    def add_entity_groups(self, db_map_data):
-        """Adds entity groups to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("entity_group", db_map_data)
-
-    def add_entity_alternatives(self, db_map_data):
-        """Adds entity alternatives to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("entity_alternative", db_map_data)
-
-    def add_parameter_definitions(self, db_map_data):
-        """Adds parameter definitions to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("parameter_definition", db_map_data)
-
-    def add_parameter_values(self, db_map_data):
-        """Adds parameter values to db without checking integrity.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("parameter_value", db_map_data)
-
-    def add_parameter_value_lists(self, db_map_data):
-        """Adds parameter_value lists to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("parameter_value_list", db_map_data)
-
-    def add_list_values(self, db_map_data):
-        """Adds parameter_value list values to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("list_value", db_map_data)
-
-    def add_metadata(self, db_map_data):
-        """Adds metadata to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("metadata", db_map_data)
-
-    def add_entity_metadata(self, db_map_data):
-        """Adds entity metadata to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("entity_metadata", db_map_data)
-
-    def add_parameter_value_metadata(self, db_map_data):
-        """Adds parameter value metadata to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self.add_items("parameter_value_metadata", db_map_data)
-
-    def _add_ext_item_metadata(self, db_map_data, item_type):
+    def add_ext_item_metadata(self, item_type: str, db_map_data: DBMapDictItems) -> None:
         for db_map, items in db_map_data.items():
             identifier = self.get_command_identifier()
             metadata_items = db_map.get_metadata_to_add_with_item_metadata_items(*items)
@@ -1143,83 +981,11 @@ class SpineDBManager(QObject):
                 self.add_items("metadata", {db_map: metadata_items}, identifier=identifier)
             self.add_items(item_type, {db_map: items}, identifier=identifier)
 
-    def add_ext_entity_metadata(self, db_map_data):
-        """Adds entity metadata together with all necessary metadata to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self._add_ext_item_metadata(db_map_data, "entity_metadata")
-
-    def add_ext_parameter_value_metadata(self, db_map_data):
-        """Adds parameter value metadata together with all necessary metadata to db.
-
-        Args:
-            db_map_data (dict): lists of items to add keyed by DatabaseMapping
-        """
-        self._add_ext_item_metadata(db_map_data, "parameter_value_metadata")
-
-    def update_alternatives(self, db_map_data):
-        """Updates alternatives in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("alternative", db_map_data)
-
-    def update_scenarios(self, db_map_data):
-        """Updates scenarios in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("scenario", db_map_data)
-
-    def update_entity_classes(self, db_map_data):
-        """Updates entity classes in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("entity_class", db_map_data)
-
-    def update_entities(self, db_map_data):
-        """Updates entities in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("entity", db_map_data)
-
-    def update_entity_alternatives(self, db_map_data):
-        """Updates entity alternatives in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("entity_alternative", db_map_data)
-
-    def update_parameter_definitions(self, db_map_data):
-        """Updates parameter definitions in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("parameter_definition", db_map_data)
-
-    def update_parameter_values(self, db_map_data):
-        """Updates parameter values in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("parameter_value", db_map_data)
-
-    def update_expanded_parameter_values(self, db_map_data):
+    def update_expanded_parameter_values(self, db_map_data: DBMapDictItems) -> None:
         """Updates expanded parameter values in db.
 
         Args:
-            db_map_data (dict): lists of expanded items to update keyed by DatabaseMapping
+            db_map_data: lists of expanded items to update keyed by DatabaseMapping
         """
         for db_map, expanded_data in db_map_data.items():
             packed_data = {}
@@ -1242,47 +1008,7 @@ class SpineDBManager(QObject):
                 items.append(item)
             self.undo_stack[db_map].push(UpdateItemsCommand(self, db_map, "parameter_value", items))
 
-    def update_parameter_value_lists(self, db_map_data):
-        """Updates parameter_value lists in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("parameter_value_list", db_map_data)
-
-    def update_list_values(self, db_map_data):
-        """Updates parameter_value list values in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("list_value", db_map_data)
-
-    def update_metadata(self, db_map_data):
-        """Updates metadata in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("metadata", db_map_data)
-
-    def update_entity_metadata(self, db_map_data):
-        """Updates entity metadata in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("entity_metadata", db_map_data)
-
-    def update_parameter_value_metadata(self, db_map_data):
-        """Updates parameter value metadata in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self.update_items("parameter_value_metadata", db_map_data)
-
-    def _update_ext_item_metadata(self, db_map_data, item_type):
+    def update_ext_item_metadata(self, item_type: str, db_map_data: DBMapDictItems) -> None:
         for db_map, items in db_map_data.items():
             identifier = self.get_command_identifier()
             metadata_items = db_map.get_metadata_to_add_with_item_metadata_items(*items)
@@ -1290,27 +1016,11 @@ class SpineDBManager(QObject):
                 self.add_items("metadata", {db_map: metadata_items}, identifier=identifier)
             self.update_items(item_type, {db_map: items}, identifier=identifier)
 
-    def update_ext_entity_metadata(self, db_map_data):
-        """Updates entity metadata in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self._update_ext_item_metadata(db_map_data, "entity_metadata")
-
-    def update_ext_parameter_value_metadata(self, db_map_data):
-        """Updates parameter value metadata in db.
-
-        Args:
-            db_map_data (dict): lists of items to update keyed by DatabaseMapping
-        """
-        self._update_ext_item_metadata(db_map_data, "parameter_value_metadata")
-
-    def set_scenario_alternatives(self, db_map_data):
+    def set_scenario_alternatives(self, db_map_data: DBMapDictItems) -> None:
         """Sets scenario alternatives in db.
 
         Args:
-            db_map_data (dict): lists of items to set keyed by DatabaseMapping
+            db_map_data: lists of items to set keyed by DatabaseMapping
         """
         db_map_error_log = {}
         for db_map, data in db_map_data.items():
@@ -1325,11 +1035,13 @@ class SpineDBManager(QObject):
         if any(db_map_error_log.values()):
             self.error_msg.emit(db_map_error_log)
 
-    def get_data_to_set_scenario_alternatives(self, db_map, scenarios):
+    def get_data_to_set_scenario_alternatives(
+        self, db_map: DatabaseMapping, scenarios: Iterable[dict]
+    ) -> tuple[list[dict], set[TempId], list[str]]:
         """Returns data to add and remove, in order to set wide scenario alternatives.
 
         Args:
-            db_map (DatabaseMapping): the db_map
+            db_map: the db_map
             scenarios: One or more wide scenario :class:`dict` objects to set.
                 Each item must include the following keys:
 
@@ -1337,8 +1049,8 @@ class SpineDBManager(QObject):
                 - "alternative_id_list": list of alternative ids for that scenario
 
         Returns
-            list: scenario_alternative :class:`dict` objects to add.
-            set: integer scenario_alternative ids to remove
+            scenario_alternative :class:`dict` objects to add, integer scenario_alternative ids to remove,
+            and list of errors
         """
 
         def _is_equal(to_add, to_rm):
@@ -1382,11 +1094,11 @@ class SpineDBManager(QObject):
                 del scen_alt_ids_to_remove[id_]
         return scen_alts_to_add, set(scen_alt_ids_to_remove), errors
 
-    def purge_items(self, db_map_item_types, **kwargs):
+    def purge_items(self, db_map_item_types: dict[DatabaseMapping, list[str]], **kwargs) -> None:
         """Purges selected items from given database.
 
         Args:
-            db_map_item_types (dict): mapping from database map to list of purgable item types
+            db_map_item_types: mapping from database map to list of purgable item types
             **kwargs: keyword arguments passed to ``remove_items()``
         """
         db_map_typed_data = {
@@ -1395,7 +1107,9 @@ class SpineDBManager(QObject):
         }
         self.remove_items(db_map_typed_data, **kwargs)
 
-    def add_items(self, item_type, db_map_data, identifier=None, **kwargs):
+    def add_items(
+        self, item_type: str, db_map_data: DBMapDictItems, identifier: Optional[int] = None, **kwargs
+    ) -> None:
         """Pushes commands to add items to undo stack."""
         if identifier is None:
             identifier = self.get_command_identifier()
@@ -1404,7 +1118,9 @@ class SpineDBManager(QObject):
                 AddItemsCommand(self, db_map, item_type, data, identifier=identifier, **kwargs)
             )
 
-    def update_items(self, item_type, db_map_data, identifier=None, **kwargs):
+    def update_items(
+        self, item_type: str, db_map_data: DBMapDictItems, identifier: Optional[int] = None, **kwargs
+    ) -> None:
         """Pushes commands to update items to undo stack."""
         if identifier is None:
             identifier = self.get_command_identifier()
@@ -1428,7 +1144,12 @@ class SpineDBManager(QObject):
                 AddUpdateItemsCommand(self, db_map, item_type, data, command_text, identifier=identifier, **kwargs)
             )
 
-    def remove_items(self, db_map_typed_ids, identifier=None, **kwargs):
+    def remove_items(
+        self,
+        db_map_typed_ids: dict[DatabaseMapping, dict[str, set[TempId]]],
+        identifier: Optional[int] = None,
+        **kwargs,
+    ) -> None:
         """Pushes commands to remove items to undo stack."""
         if identifier is None:
             identifier = self.get_command_identifier()
@@ -1452,49 +1173,58 @@ class SpineDBManager(QObject):
         return id_
 
     @busy_effect
-    def do_add_items(self, db_map, item_type, data, check=True):
+    def do_add_items(
+        self, db_map: DatabaseMapping, item_type: str, data: list[dict], check: bool = True
+    ) -> list[PublicItem]:
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             # We're closing the kiosk.
             return []
         return worker.add_items(item_type, data, check)
 
     @busy_effect
-    def do_update_items(self, db_map, item_type, data, check=True):
+    def do_update_items(
+        self, db_map: DatabaseMapping, item_type: str, data: list[dict], check: bool = True
+    ) -> list[PublicItem]:
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             # We're closing the kiosk.
             return []
         return worker.update_items(item_type, data, check)
 
     @busy_effect
-    def do_add_update_items(self, db_map, item_type, data, check=True):
+    def do_add_update_items(
+        self, db_map: DatabaseMapping, item_type: str, data: list[dict], check: bool = True
+    ) -> tuple[list[PublicItem], list[PublicItem]]:
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             # We're closing the kiosk.
-            return []
+            return [], []
         return worker.add_update_items(item_type, data, check)
 
     @busy_effect
-    def do_remove_items(self, db_map, item_type, ids, check=True):
+    def do_remove_items(
+        self, db_map: DatabaseMapping, item_type: str, ids: set[TempId], check: bool = True
+    ) -> list[PublicItem]:
         """Removes items from database.
 
         Args:
             db_map: DatabaseMapping instance
-            item_type (str): database item type
-            ids (set): ids to remove
+            item_type: database item type
+            ids: ids to remove
+            check: If False, omit integrity checks.
         """
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             return []
         return worker.remove_items(item_type, ids, check)
 
     @busy_effect
-    def do_restore_items(self, db_map, item_type, ids):
+    def do_restore_items(self, db_map: DatabaseMapping, item_type: str, ids: set[TempId]) -> list[PublicItem]:
         """Restores items in database.
 
         Args:
@@ -1503,17 +1233,19 @@ class SpineDBManager(QObject):
             ids (set): ids to restore
         """
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             return []
         return worker.restore_items(item_type, ids)
 
     @staticmethod
-    def db_map_ids(db_map_data):
+    def db_map_ids(db_map_data: Union[DBMapDictItems, DBMapPublicItems]) -> dict[DatabaseMapping, set[TempId]]:
         return {db_map: {x["id"] for x in data if x} for db_map, data in db_map_data.items()}
 
     @staticmethod
-    def db_map_class_ids(db_map_data):
+    def db_map_class_ids(
+        db_map_data: Union[DBMapDictItems, DBMapPublicItems]
+    ) -> dict[tuple[DatabaseMapping, TempId], set[TempId]]:
         d = {}
         for db_map, items in db_map_data.items():
             for item in items:
@@ -1521,7 +1253,9 @@ class SpineDBManager(QObject):
                     d.setdefault((db_map, item["class_id"]), set()).add(item["id"])
         return d
 
-    def find_cascading_entity_classes(self, db_map_ids):
+    def find_cascading_entity_classes(
+        self, db_map_ids: dict[DatabaseMapping, Iterable[TempId]]
+    ) -> dict[DatabaseMapping, list[PublicItem]]:
         """Finds and returns cascading entity classes for the given dimension ids."""
         db_map_cascading_data = {}
         for db_map, dimension_ids in db_map_ids.items():
@@ -1534,7 +1268,9 @@ class SpineDBManager(QObject):
                         db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
-    def find_cascading_entities(self, db_map_ids):
+    def find_cascading_entities(
+        self, db_map_ids: dict[DatabaseMapping, Iterable[TempId]]
+    ) -> dict[DatabaseMapping, list[PublicItem]]:
         """Finds and returns cascading entities for the given element ids."""
         db_map_cascading_data = {}
         for db_map, element_ids in db_map_ids.items():
@@ -1547,7 +1283,9 @@ class SpineDBManager(QObject):
                         db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
-    def find_cascading_parameter_definitions(self, db_map_ids):
+    def find_cascading_parameter_definitions(
+        self, db_map_ids: dict[DatabaseMapping, Iterable[TempId]]
+    ) -> dict[DatabaseMapping, list[PublicItem]]:
         """Finds and returns cascading parameter definitions or values for the given entity_class ids."""
         db_map_cascading_data = {}
         for db_map, entity_class_ids in db_map_ids.items():
@@ -1560,7 +1298,9 @@ class SpineDBManager(QObject):
                         db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
-    def find_cascading_parameter_values_by_entity(self, db_map_ids):
+    def find_cascading_parameter_values_by_entity(
+        self, db_map_ids: dict[DatabaseMapping, Iterable[TempId]]
+    ) -> dict[DatabaseMapping, list[PublicItem]]:
         """Finds and returns cascading parameter values for the given entity ids."""
         db_map_cascading_data = {}
         for db_map, entity_ids in db_map_ids.items():
@@ -1573,7 +1313,9 @@ class SpineDBManager(QObject):
                         db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
-    def find_cascading_scenario_alternatives_by_scenario(self, db_map_ids):
+    def find_cascading_scenario_alternatives_by_scenario(
+        self, db_map_ids: dict[DatabaseMapping, Iterable[TempId]]
+    ) -> dict[DatabaseMapping, list[PublicItem]]:
         """Finds and returns cascading scenario alternatives for the given scenario ids."""
         db_map_cascading_data = {}
         for db_map, ids in db_map_ids.items():
@@ -1586,7 +1328,9 @@ class SpineDBManager(QObject):
                         db_map_cascading_data.setdefault(db_map, []).append(item.public_item)
         return db_map_cascading_data
 
-    def find_groups_by_entity(self, db_map_ids):
+    def find_groups_by_entity(
+        self, db_map_ids: dict[DatabaseMapping, Iterable[TempId]]
+    ) -> dict[DatabaseMapping, list[PublicItem]]:
         """Finds and returns groups for the given entity ids."""
         db_map_group_data = {}
         for db_map, entity_ids in db_map_ids.items():
@@ -1599,7 +1343,9 @@ class SpineDBManager(QObject):
                         db_map_group_data.setdefault(db_map, []).append(item.public_item)
         return db_map_group_data
 
-    def duplicate_scenario(self, scen_data, dup_name, db_map):
+    def duplicate_scenario(
+        self, scen_data: dict[DatabaseMapping, dict[str, Iterable[TempId]]], dup_name: str, db_map: DatabaseMapping
+    ) -> None:
         data = self._get_data_for_export(scen_data)
         data = {
             "scenarios": [(dup_name, active, description) for (_, active, description) in data.get("scenarios", [])],
@@ -1661,7 +1407,10 @@ class SpineDBManager(QObject):
             dup_import_data[db_map]["entity_alternatives"] = dup_entity_alternative_import_data
         self.import_data(dup_import_data, command_text="Duplicate entity")
 
-    def _get_data_for_export(self, db_map_item_ids):
+    @staticmethod
+    def _get_data_for_export(
+        db_map_item_ids: dict[DatabaseMapping, dict[str, Iterable[TempId]]]
+    ) -> dict[str, list[tuple]]:
         data = {}
         for db_map, item_ids in db_map_item_ids.items():
             with db_map:
@@ -1669,7 +1418,13 @@ class SpineDBManager(QObject):
                     data.setdefault(key, []).extend(items)
         return data
 
-    def export_data(self, caller, db_map_item_ids, file_path, file_filter):
+    def export_data(
+        self,
+        caller: object,
+        db_map_item_ids: dict[DatabaseMapping, dict[str, Iterable[TempId]]],
+        file_path: str,
+        file_filter: str,
+    ) -> None:
         data = self._get_data_for_export(db_map_item_ids)
         if file_filter.startswith("JSON"):
             self.export_to_json(file_path, data, caller)
@@ -1680,14 +1435,14 @@ class SpineDBManager(QObject):
         else:
             raise ValueError()
 
-    def _is_url_available(self, url, logger):
+    def _is_url_available(self, url: Union[URL, str], logger: LoggerInterface) -> bool:
         if str(url) in self.db_urls:
             message = f"The URL <b>{url}</b> is in use. Please close all applications using it and try again."
             logger.msg_error.emit(message)
             return False
         return True
 
-    def export_to_sqlite(self, file_path, data_for_export, caller):
+    def export_to_sqlite(self, file_path: str, data_for_export: dict[str, list[tuple]], caller: object) -> None:
         """Exports given data into SQLite file."""
         url = URL.create("sqlite", database=file_path)
         if not self._is_url_available(url, caller):
@@ -1703,7 +1458,7 @@ class SpineDBManager(QObject):
                 caller.file_exported.emit(file_path, 1.0, True)
 
     @staticmethod
-    def export_to_json(file_path, data_for_export, caller):
+    def export_to_json(file_path: str, data_for_export: dict[str, list[tuple]], caller: object) -> None:
         """Exports given data into JSON file."""
         json_data = json.dumps(data_for_export, indent=4)
         with open(file_path, "w", encoding="utf-8") as f:
@@ -1711,7 +1466,7 @@ class SpineDBManager(QObject):
         caller.file_exported.emit(file_path, 1.0, False)
 
     @staticmethod
-    def export_to_excel(file_path, data_for_export, caller):
+    def export_to_excel(file_path: str, data_for_export: dict[str, list[tuple]], caller: object) -> None:
         """Exports given data into Excel file."""
         # NOTE: We import data into an in-memory Spine db and then export that to excel.
         url = URL.create("sqlite", database="")
@@ -1740,9 +1495,9 @@ class SpineDBManager(QObject):
             else:
                 caller.file_exported.emit(file_path, 1.0, False)
 
-    def get_items_for_commit(self, db_map, commit_id):
+    def get_items_for_commit(self, db_map: DatabaseMapping, commit_id: TempId) -> dict[str, list[TempId]]:
         try:
-            worker = self._get_worker(db_map)
+            worker = self._workers[db_map]
         except KeyError:
             return {}
         return worker.commit_cache.get(commit_id.db_id, {})
@@ -1753,7 +1508,7 @@ class SpineDBManager(QObject):
             with suppress(KeyError):
                 self._validated_values[key.item_type][key.db_map_id][key.item_private_id] = is_valid
 
-    def _clear_validated_value_ids(self, item_type, db_map_data):
+    def _clear_validated_value_ids(self, item_type: str, db_map_data: DBMapPublicItems) -> None:
         db_map_validated_values = self._validated_values[item_type]
         for db_map, data in db_map_data.items():
             validated_values = db_map_validated_values[id(db_map)]

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -218,7 +218,7 @@ class SpineDBWorker(QObject):
         return items
 
     def _wake_up_parents(self, item_type, items):
-        for parent in list(self._get_parents(item_type)):
+        for parent in self._get_parents(item_type):
             for item in items:
                 if parent.accepts_item(item, self._db_map):
                     self._do_fetch_more(parent)

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -218,7 +218,7 @@ class SpineDBWorker(QObject):
         return items
 
     def _wake_up_parents(self, item_type, items):
-        for parent in self._get_parents(item_type):
+        for parent in list(self._get_parents(item_type)):
             for item in items:
                 if parent.accepts_item(item, self._db_map):
                     self._do_fetch_more(parent)

--- a/spinetoolbox/spine_db_worker.py
+++ b/spinetoolbox/spine_db_worker.py
@@ -13,6 +13,7 @@
 """The SpineDBWorker class."""
 from PySide6.QtCore import QObject, QTimer, Signal, Slot
 from spinedb_api import Asterisk, DatabaseMapping
+from spinedb_api.temp_id import TempId
 from .helpers import busy_effect
 from .qthread_pool_executor import QtBasedThreadPoolExecutor, SynchronousExecutor
 
@@ -31,7 +32,7 @@ class SpineDBWorker(QObject):
         self._db_map = None
         self._executor = (SynchronousExecutor if synchronous else QtBasedThreadPoolExecutor)()
         self._parents_by_type = {}
-        self.commit_cache = {}
+        self.commit_cache: dict[int, dict[str, list[TempId]]] = {}
         self._parents_fetching = {}
         self._offsets = {}
         self._fetched_item_types = set()

--- a/tests/project_item/test_logging_connection.py
+++ b/tests/project_item/test_logging_connection.py
@@ -111,7 +111,7 @@ class TestLoggingConnectionWithDatabaseManager(TestCaseWithQApplication):
 
     def test_has_filters_when_database_has_an_unknown_scenario(self):
         with signal_waiter(self._toolbox.db_mngr.items_added) as waiter:
-            self._toolbox.db_mngr.add_scenarios({self._db_map: [{"name": "Base", "id": 1}]})
+            self._toolbox.db_mngr.add_items("scenario", {self._db_map: [{"name": "Base", "id": 1}]})
             waiter.wait()
         connection = LoggingConnection("Store 1", "right", "Store 2", "left", toolbox=self._toolbox)
         connection.link = MagicMock()
@@ -123,7 +123,7 @@ class TestLoggingConnectionWithDatabaseManager(TestCaseWithQApplication):
 
     def test_set_online(self):
         with signal_waiter(self._toolbox.db_mngr.items_added) as waiter:
-            self._toolbox.db_mngr.add_scenarios({self._db_map: [{"name": "Base", "id": 1}]})
+            self._toolbox.db_mngr.add_items("scenario", {self._db_map: [{"name": "Base", "id": 1}]})
             waiter.wait()
         filter_settings = FilterSettings({"database@Store 1": {"scenario_filter": {"Base": False}}})
         connection = LoggingConnection(

--- a/tests/spine_db_editor/mvcmodels/test_alternative_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_alternative_model.py
@@ -58,7 +58,7 @@ class TestAlternativeModel(TestCaseWithQApplication):
         model = AlternativeModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         _fetch_all_recursively(model)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         data = model_data_to_dict(model)
         expected = [
             [
@@ -78,9 +78,9 @@ class TestAlternativeModel(TestCaseWithQApplication):
         model = AlternativeModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         _fetch_all_recursively(model)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternative_id = self._db_map.alternative(name="alternative_1")["id"]
-        self._db_mngr.update_alternatives({self._db_map: [{"id": alternative_id, "name": "renamed"}]})
+        self._db_mngr.update_items("alternative", {self._db_map: [{"id": alternative_id, "name": "renamed"}]})
         data = model_data_to_dict(model)
         expected = [
             [
@@ -100,7 +100,7 @@ class TestAlternativeModel(TestCaseWithQApplication):
         model = AlternativeModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         _fetch_all_recursively(model)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternative_id = self._db_map.alternative(name="alternative_1")["id"]
         self._db_mngr.remove_items({self._db_map: {"alternative": {alternative_id}}})
         data = model_data_to_dict(model)
@@ -154,8 +154,8 @@ class TestAlternativeModelWithTwoDatabases(TestCaseWithQApplication):
         self._temp_dir.cleanup()
 
     def test_paste_alternative_mime_data(self):
-        self._db_mngr.add_alternatives(
-            {self._db_map1: [{"name": "my_alternative", "description": "My test alternative"}]}
+        self._db_mngr.add_items(
+            "alternative", {self._db_map1: [{"name": "my_alternative", "description": "My test alternative"}]}
         )
         model = AlternativeModel(self._db_editor, self._db_mngr, self._db_map1, self._db_map2)
         model.build_tree()

--- a/tests/spine_db_editor/mvcmodels/test_compound_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_compound_models.py
@@ -42,8 +42,8 @@ class TestCompoundParameterDefinitionModel(TestBase):
         model = CompoundParameterDefinitionModel(self._db_editor, self._db_mngr, self._db_map)
         model.init_model()
         fetch_model(model)
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc", "id": 1}]})
-        self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "entity_class_id": 1, "id": 1}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "oc", "id": 1}]})
+        self._db_mngr.add_items("parameter_definition", {self._db_map: [{"name": "p", "entity_class_id": 1, "id": 1}]})
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.columnCount(), 7)
         row = [model.index(0, column).data() for column in range(model.columnCount())]
@@ -54,9 +54,9 @@ class TestCompoundParameterDefinitionModel(TestBase):
         model = CompoundParameterDefinitionModel(self._db_editor, self._db_mngr, self._db_map)
         model.init_model()
         fetch_model(model)
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc", "id": 1}]})
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "rc", "dimension_id_list": [1], "id": 2}]})
-        self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "entity_class_id": 2, "id": 1}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "oc", "id": 1}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "rc", "dimension_id_list": [1], "id": 2}]})
+        self._db_mngr.add_items("parameter_definition", {self._db_map: [{"name": "p", "entity_class_id": 2, "id": 1}]})
         self._db_map.fetch_all()
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.columnCount(), 7)
@@ -113,11 +113,12 @@ class TestCompoundParameterValueModel(TestBase):
         model = CompoundParameterValueModel(self._db_editor, self._db_mngr, self._db_map)
         model.init_model()
         fetch_model(model)
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc", "id": 1}]})
-        self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "entity_class_id": 1, "id": 1}]})
-        self._db_mngr.add_entities({self._db_map: [{"name": "o", "class_id": 1, "id": 1}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "oc", "id": 1}]})
+        self._db_mngr.add_items("parameter_definition", {self._db_map: [{"name": "p", "entity_class_id": 1, "id": 1}]})
+        self._db_mngr.add_items("entity", {self._db_map: [{"name": "o", "class_id": 1, "id": 1}]})
         value, value_type = to_database(23.0)
-        self._db_mngr.add_parameter_values(
+        self._db_mngr.add_items(
+            "parameter_value",
             {
                 self._db_map: [
                     {
@@ -130,7 +131,7 @@ class TestCompoundParameterValueModel(TestBase):
                         "id": 1,
                     }
                 ]
-            }
+            },
         )
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.columnCount(), 6)
@@ -142,13 +143,16 @@ class TestCompoundParameterValueModel(TestBase):
         model = CompoundParameterValueModel(self._db_editor, self._db_mngr, self._db_map)
         model.init_model()
         fetch_model(model)
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc", "id": 1}]})
-        self._db_mngr.add_entities({self._db_map: [{"name": "o", "class_id": 1, "id": 1}]})
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "rc", "dimension_id_list": [1], "id": 2}]})
-        self._db_mngr.add_parameter_definitions({self._db_map: [{"name": "p", "entity_class_id": 2, "id": 1}]})
-        self._db_mngr.add_entities({self._db_map: [{"name": "r", "class_id": 2, "element_id_list": [1], "id": 2}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "oc", "id": 1}]})
+        self._db_mngr.add_items("entity", {self._db_map: [{"name": "o", "class_id": 1, "id": 1}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "rc", "dimension_id_list": [1], "id": 2}]})
+        self._db_mngr.add_items("parameter_definition", {self._db_map: [{"name": "p", "entity_class_id": 2, "id": 1}]})
+        self._db_mngr.add_items(
+            "entity", {self._db_map: [{"name": "r", "class_id": 2, "element_id_list": [1], "id": 2}]}
+        )
         value, value_type = to_database(23.0)
-        self._db_mngr.add_parameter_values(
+        self._db_mngr.add_items(
+            "parameter_value",
             {
                 self._db_map: [
                     {
@@ -161,7 +165,7 @@ class TestCompoundParameterValueModel(TestBase):
                         "id": 1,
                     }
                 ]
-            }
+            },
         )
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.columnCount(), 6)

--- a/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
+++ b/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
@@ -13,8 +13,8 @@
 """Unit tests for the EmptyParameterModel subclasses."""
 from unittest import mock
 from PySide6.QtCore import QObject
+from PySide6.QtGui import QUndoStack
 from spinedb_api import (
-    DatabaseMapping,
     import_object_classes,
     import_object_parameters,
     import_objects,
@@ -47,16 +47,19 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         import_relationship_parameters(self._db_map, (("dog__fish", "relative_speed"),))
         import_relationships(self._db_map, (("dog__fish", ("pluto", "nemo")),))
         self._db_map.commit_session("Add test data")
+        self._undo_stack = QUndoStack()
 
     def tearDown(self):
         self._db_mngr.close_all_sessions()
         self._db_mngr.clean_up()
         self._db_mngr.deleteLater()
+        self._undo_stack.deleteLater()
 
     def test_add_object_parameter_values_to_db(self):
         """Test that object parameter values are added to the db when editing the table."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             value, value_type = to_database("bloodhound")
             self.assertTrue(
@@ -76,6 +79,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that object parameter values aren't added to the db if data is incomplete."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
                 model.batch_set_data(_empty_indexes(model), ["fish", "nemo", "water", "Base", "salty", "mock_db"])
@@ -87,6 +91,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that object classes are inferred from the object and parameter if possible."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             indexes = _empty_indexes(model)
             value, value_type = to_database("bloodhound")
@@ -107,6 +112,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that relationship parameter values are added to the db when editing the table."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             value, value_type = to_database(-1)
             self.assertTrue(
@@ -133,6 +139,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that relationship parameter values aren't added to the db if data is incomplete."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
                 model.batch_set_data(
@@ -146,6 +153,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that object parameter definitions are added to the db when editing the table."""
         with q_object(QObject()) as parent:
             model = EmptyParameterDefinitionModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
                 model.batch_set_data(_empty_indexes(model), ["dog", "color", (), None, None, None, "mock_db"])
@@ -159,6 +167,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that object parameter definitions are added to the db when editing the table."""
         with q_object(QObject()) as parent:
             model = EmptyParameterDefinitionModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
                 model.batch_set_data(
@@ -174,6 +183,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that object parameter definitions aren't added to the db if data is incomplete."""
         with q_object(QObject()) as parent:
             model = EmptyParameterDefinitionModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(model.batch_set_data(_empty_indexes(model), ["cat", "color", None, None, None, "mock_db"]))
             definitions = [x for x in self._db_map.get_items("parameter_definition") if not x["dimension_id_list"]]
@@ -184,6 +194,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that relationship parameter definitions are added to the db when editing the table."""
         with q_object(QObject()) as parent:
             model = EmptyParameterDefinitionModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
                 model.batch_set_data(
@@ -199,6 +210,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that relationship parameter definitions aren't added to the db if data is incomplete."""
         with q_object(QObject()) as parent:
             model = EmptyParameterDefinitionModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
                 model.batch_set_data(
@@ -213,6 +225,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Test that adding parameter a value for a nonexistent entity creates the entity."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             value, value_type = to_database("dog-human")
             with signal_waiter(model.entities_added) as waiter:
@@ -242,6 +255,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Tests that the model is not too keen on making entities on the fly."""
         with q_object(QObject()) as parent:
             model = EmptyParameterValueModel(self._db_mngr, parent)
+            model.set_undo_stack(self._undo_stack)
             db_map_entities = {self._db_map: [{"entity_class_name": "dog", "entity_byname": ("plato",)}]}
             value = join_value_and_type(*to_database("dog-human"))
             db_map_items = {

--- a/tests/spine_db_editor/mvcmodels/test_empty_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_empty_models.py
@@ -1,0 +1,228 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from itertools import product
+import unittest
+from unittest import mock
+from PySide6.QtGui import QUndoStack
+from PySide6.QtWidgets import QApplication
+from spinetoolbox.spine_db_editor.mvcmodels.empty_models import EmptyModelBase
+from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, fetch_model
+
+
+class TestEmptyModelBase(TestCaseWithQApplication):
+    def setUp(self):
+        """Overridden method. Runs before each test."""
+        app_settings = mock.MagicMock()
+        logger = mock.MagicMock()
+        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
+        self._db_mngr.name_registry.register(self._db_map.sa_url, "mock_db")
+        self._undo_stack = QUndoStack()
+
+    def tearDown(self):
+        self._db_mngr.close_all_sessions()
+        self._db_mngr.clean_up()
+        self._db_mngr.deleteLater()
+        self._undo_stack.deleteLater()
+
+    def test_undo_change_in_single_cell(self):
+        model = EmptyModelBase(["entity_class_name", "header 2", "database"], self._db_mngr, parent=self._db_mngr)
+        model.set_undo_stack(self._undo_stack)
+        fetch_model(model)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.columnCount(), 3)
+        self.assertTrue(model.batch_set_data([model.index(0, 0)], ["X"]))
+        expected = [["X", None, None]]
+        for row, column in product(range(1), range(3)):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+        self.assertTrue(self._undo_stack.canUndo())
+        self._undo_stack.undo()
+        expected = [[None, None, None]]
+        for row, column in product(range(1), range(3)):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_undo_handles_entity_class_name_candidates(self):
+        with self._db_map:
+            self._db_map.add_entity_class(name="Widget")
+        model = EmptyModelBase(
+            ["entity_class_name", "name", "description", "database"], self._db_mngr, parent=self._db_mngr
+        )
+        model.item_type = "entity"
+        model.set_undo_stack(self._undo_stack)
+        fetch_model(model)
+        model.set_default_row(database="mock_db")
+        model.set_rows_to_default(model.rowCount() - 1)
+        self.assertEqual(model.columnCount(), 4)
+        self.assertEqual(model.rowCount(), 1)
+        with (
+            mock.patch.object(model, "_convert_to_db") as convert_to_db,
+            mock.patch.object(model, "_entity_class_name_candidates") as entity_class_name_candidates,
+            mock.patch.object(model, "_check_item") as check_item,
+        ):
+            convert_to_db.side_effect = lambda item: item
+            entity_class_name_candidates.return_value = ["Widget"]
+            check_item.side_effect = lambda item: "entity_class_name" in item and "name" in item
+            self.assertTrue(model.batch_set_data([model.index(0, 1)], ["gadget"]))
+            expected = [["Widget", "gadget", None, "mock_db"], [None, None, None, "mock_db"]]
+            self.assertEqual(model.rowCount(), len(expected))
+            for row, column in product(range(len(expected)), range(len(expected[0]))):
+                with self.subTest(row=row, column=column):
+                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+            self.assertTrue(self._undo_stack.canUndo())
+            self._undo_stack.undo()
+            expected = [[None, None, None, "mock_db"]]
+            self.assertEqual(model.rowCount(), len(expected))
+            for row, column in product(range(len(expected)), range(len(expected[0]))):
+                with self.subTest(row=row, column=column):
+                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_undo_remove_rows(self):
+        model = EmptyModelBase(
+            ["entity_class_name", "header 1", "header 2", "database"], self._db_mngr, parent=self._db_mngr
+        )
+        model.set_undo_stack(self._undo_stack)
+        fetch_model(model)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.columnCount(), 4)
+        model.insertRow(0)
+        self.assertTrue(model.batch_set_data([model.index(0, 1)], ["X"]))
+        expected = [[None, "X", None, None], [None, None, None, None]]
+        self.assertEqual(model.rowCount(), len(expected))
+        for row, column in product(range(model.rowCount()), range(len(expected[0]))):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+        model.removeRows(0, 1)
+        expected = [[None, None, None, None]]
+        self.assertEqual(model.rowCount(), len(expected))
+        for row, column in product(range(model.rowCount()), range(len(expected[0]))):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+        self.assertTrue(self._undo_stack.canUndo())
+        self._undo_stack.undo()
+        expected = [[None, "X", None, None], [None, None, None, None]]
+        self.assertEqual(model.rowCount(), len(expected))
+        for row, column in product(range(model.rowCount()), range(len(expected[0]))):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_undo_command_removed_when_row_goes_to_database(self):
+        self._db_map.add_entity_class(name="Widget")
+        model = EmptyModelBase(
+            ["entity_class_name", "name", "description", "database"], self._db_mngr, parent=self._db_mngr
+        )
+        model.item_type = "entity"
+        model.set_undo_stack(self._undo_stack)
+        model._fetch_parent.fetch_item_type = model.item_type
+        model.reset_db_maps([self._db_map])
+        fetch_model(model)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.columnCount(), 4)
+        with (
+            mock.patch.object(model, "_convert_to_db") as convert_to_db,
+            mock.patch.object(model, "_entity_class_name_candidates") as entity_class_name_candidates,
+            mock.patch.object(model, "_check_item") as check_item,
+            mock.patch.object(model, "_make_unique_id") as make_unique_id,
+        ):
+            convert_to_db.side_effect = lambda item: item
+            entity_class_name_candidates.return_value = ["Widget"]
+            check_item.side_effect = lambda item: "entity_class_name" in item and "name" in item
+            make_unique_id.side_effect = lambda item: (item["entity_class_name"], item["name"])
+            self.assertTrue(
+                model.batch_set_data(
+                    [model.index(0, 0), model.index(0, 1), model.index(0, 2), model.index(0, 3)],
+                    ["Widget", "gadget", "A new friend for other widgets.", "mock_db"],
+                )
+            )
+            while model.rowCount() != 1:
+                QApplication.processEvents()
+        new_entity = self._db_map.entity(entity_class_name="Widget", name="gadget")
+        self.assertEqual(new_entity["description"], "A new friend for other widgets.")
+        expected = [[None, None, None, None]]
+        self.assertEqual(model.rowCount(), len(expected))
+        for row, column in product(range(model.rowCount()), range(len(expected[0]))):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+        self.assertFalse(self._undo_stack.canUndo())
+        self.assertFalse(self._undo_stack.canRedo())
+
+    def test_undo_multiple_row_insertions(self):
+        self._db_map.add_entity_class(name="Widget")
+        model = EmptyModelBase(
+            ["entity_class_name", "name", "description", "database"], self._db_mngr, parent=self._db_mngr
+        )
+        model.item_type = "entity"
+        model.set_undo_stack(self._undo_stack)
+        model._fetch_parent.fetch_item_type = model.item_type
+        model.reset_db_maps([self._db_map])
+        fetch_model(model)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.columnCount(), 4)
+        model.insertRows(model.rowCount(), 1)
+        self.assertEqual(model.rowCount(), 2)
+        model.insertRows(model.rowCount(), 1)
+        self.assertEqual(model.rowCount(), 3)
+        self._undo_stack.undo()
+        self.assertEqual(model.rowCount(), 2)
+        self._undo_stack.undo()
+        self.assertEqual(model.rowCount(), 1)
+        expected = [[None, None, None, None]]
+        self.assertEqual(model.rowCount(), len(expected))
+        for row, column in product(range(model.rowCount()), range(len(expected[0]))):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+    def test_batch_setting_same_values_is_considered_a_no_operation(self):
+        self._db_map.add_entity_class(name="Widget")
+        model = EmptyModelBase(
+            ["entity_class_name", "name", "description", "database"], self._db_mngr, parent=self._db_mngr
+        )
+        model.item_type = "entity"
+        model.set_undo_stack(self._undo_stack)
+        model._fetch_parent.fetch_item_type = model.item_type
+        model.set_default_row(database="mock_db")
+        model.reset_db_maps([self._db_map])
+        fetch_model(model)
+        with (
+            mock.patch.object(model, "_convert_to_db") as convert_to_db,
+            mock.patch.object(model, "_entity_class_name_candidates") as entity_class_name_candidates,
+            mock.patch.object(model, "_check_item") as check_item,
+            mock.patch.object(model, "_make_unique_id") as make_unique_id,
+        ):
+            convert_to_db.side_effect = lambda item: item
+            entity_class_name_candidates.return_value = ["Widget"]
+            check_item.side_effect = lambda item: "entity_class_name" in item and "name" in item
+            make_unique_id.side_effect = lambda item: (item["entity_class_name"], item["name"])
+            self.assertTrue(model.batch_set_data([model.index(0, 1)], ["gadget"]))
+        self.assertEqual(self._undo_stack.count(), 1)
+        expected = [["Widget", "gadget", None, "mock_db"], [None, None, None, "mock_db"]]
+        self.assertEqual(model.rowCount(), len(expected))
+        for row, column in product(range(model.rowCount()), range(len(expected[0]))):
+            with self.subTest(row=row, column=column):
+                self.assertEqual(model.index(row, column).data(), expected[row][column])
+        with (
+            mock.patch.object(model, "_convert_to_db") as convert_to_db,
+            mock.patch.object(model, "_entity_class_name_candidates") as entity_class_name_candidates,
+            mock.patch.object(model, "_check_item") as check_item,
+            mock.patch.object(model, "_make_unique_id") as make_unique_id,
+        ):
+            convert_to_db.side_effect = lambda item: item
+            entity_class_name_candidates.return_value = ["Widget"]
+            check_item.side_effect = lambda item: "entity_class_name" in item and "name" in item
+            make_unique_id.side_effect = lambda item: (item["entity_class_name"], item["name"])
+            self.assertFalse(model.batch_set_data([model.index(0, 1)], ["gadget"]))
+        self.assertEqual(self._undo_stack.count(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/spine_db_editor/mvcmodels/test_frozen_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_frozen_table_model.py
@@ -76,7 +76,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
         self.assertEqual(self._model.index(1, 1).data(), self.db_codename)
 
     def test_remove_values_before_selected_row(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.set_headers(["alternative", "database"])
@@ -92,7 +92,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
         self.assertEqual(self._model.get_frozen_value(), ((self._db_map, frozen_alternative_id), self._db_map))
 
     def test_remove_selected_row_when_selected_row_gets_updated_during_removal(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.set_headers(["alternative", "database"])
@@ -113,7 +113,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
         self.assertEqual(self._model.get_frozen_value(), ((self._db_map, base_alternative_id), self._db_map))
 
     def test_remove_values_after_selected_row(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.set_headers(["alternative", "database"])
@@ -154,7 +154,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
         self.assertEqual(self._model.index(0, 2).data(), "index 2")
 
     def test_insert_column_data_extends_existing_data_in_model(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         self._model.insert_column_data("database", {self._db_map}, 0)
         self.assertEqual(self._model.columnCount(), 1)
         self.assertEqual(self._model.rowCount(), 2)
@@ -171,7 +171,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
                     self.assertEqual(self._model.index(row, column).data(), expected[row - 1][column])
 
     def test_insert_column_data_extends_inserted_data(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.insert_column_data("alternative", {(self._db_map, id_) for id_ in ids}, 0)
@@ -197,7 +197,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
 
     def test_remove_column_shortens_existing_data(self):
         self._model.insert_column_data("database", {self._db_map}, 0)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.insert_column_data("alternative", {(self._db_map, id_) for id_ in ids}, 0)
@@ -211,7 +211,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
 
     def test_move_columns(self):
         self._model.insert_column_data("database", {self._db_map}, 0)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}
         self._model.insert_column_data("alternative", {(self._db_map, id_) for id_ in ids}, 1)
@@ -230,15 +230,16 @@ class TestFrozenTableModel(TestCaseWithQApplication):
 
     def test_table_stays_sorted(self):
         self._model.insert_column_data("database", {self._db_map}, 0)
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Gadget"}]})
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Gadget"}]})
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "Gadget", "name": "fork"},
                     {"entity_class_name": "Gadget", "name": "spoon"},
                 ]
-            }
+            },
         )
         alternatives = self._db_map.get_items("alternative")
         ids = {item["id"] for item in alternatives}

--- a/tests/spine_db_editor/mvcmodels/test_item_metadata_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_item_metadata_table_model.py
@@ -182,7 +182,7 @@ class TestItemMetadataTableModelWithExistingData(TestCaseWithQApplication):
                 {"metadata_name": "author", "metadata_value": "Anonymous", "parameter_value_id": 2, "commit_id": None}
             ]
         }
-        self._db_mngr.add_parameter_value_metadata(db_map_item_metadata)
+        self._db_mngr.add_items("parameter_value_metadata", db_map_item_metadata)
         self.assertEqual(self._model.rowCount(), 3)
         self.assertEqual(self._model.index(0, Column.NAME).data(), "source")
         self.assertEqual(self._model.index(0, Column.VALUE).data(), "Fountain of relationship values")
@@ -206,7 +206,7 @@ class TestItemMetadataTableModelWithExistingData(TestCaseWithQApplication):
                 }
             ]
         }
-        self._db_mngr.add_entity_metadata(db_map_item_metadata)
+        self._db_mngr.add_items("entity_metadata", db_map_item_metadata)
         self.assertEqual(self._model.rowCount(), 3)
         self.assertEqual(self._model.index(0, Column.NAME).data(), "source")
         self.assertEqual(self._model.index(0, Column.VALUE).data(), "Fountain of relationships")

--- a/tests/spine_db_editor/mvcmodels/test_metadata_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_metadata_table_model.py
@@ -52,7 +52,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_add_metadata_from_database_to_empty_model(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous", "id": 1}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self.assertEqual(self._model.rowCount(), 2)
         self.assertEqual(self._model.index(0, Column.NAME).data(), "author")
         self.assertEqual(self._model.index(0, Column.VALUE).data(), "Anonymous")
@@ -61,7 +61,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_updating_metadata_in_database_updates_existing_row(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous"}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         index = self._model.index(0, Column.VALUE)
         self.assertTrue(self._model.setData(index, "Prof. T. Est"))
         self.assertEqual(self._model.rowCount(), 2)
@@ -73,7 +73,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
     def test_remove_metadata_removes_the_row(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous", "id": 1}]}
         db_map_typed_ids = {self._db_map: {"metadata": {1}}}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self.assertEqual(self._model.rowCount(), 2)
         self._db_mngr.remove_items(db_map_typed_ids)
         self.assertEqual(self._model.rowCount(), 1)
@@ -89,7 +89,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_adding_data_to_another_database(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous", "id": 1}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         logger = mock.MagicMock()
         with TemporaryDirectory() as temp_dir:
             database_path = Path(temp_dir, "db.sqlite")
@@ -120,11 +120,11 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_add_and_update_via_adding_entity_metadata(self):
         db_map_data = {self._db_map: [{"name": "object class", "id": 1}]}
-        self._db_mngr.add_entity_classes(db_map_data)
+        self._db_mngr.add_items("entity_class", db_map_data)
         db_map_data = {self._db_map: [{"class_id": 1, "name": "object"}]}
-        self._db_mngr.add_entities(db_map_data)
+        self._db_mngr.add_items("entity", db_map_data)
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous"}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self.assertEqual(self._model.rowCount(), 2)
         self.assertEqual(self._model.index(0, Column.NAME).data(), "author")
         self.assertEqual(self._model.index(0, Column.VALUE).data(), "Anonymous")
@@ -136,7 +136,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
                 {"entity_name": "object", "metadata_name": "source", "metadata_value": "The Internet"},
             ]
         }
-        self._db_mngr.add_ext_entity_metadata(db_map_data)
+        self._db_mngr.add_ext_item_metadata("entity_metadata", db_map_data)
         self.assertEqual(self._model.rowCount(), 3)
         self.assertEqual(self._model.index(0, Column.NAME).data(), "author")
         self.assertEqual(self._model.index(0, Column.VALUE).data(), "Anonymous")
@@ -155,13 +155,14 @@ class TestMetadataTableModel(TestCaseWithQApplication):
         self._assert_empty_last_row()
 
     def test_insert_rows_to_beginning_and_middle_and_end(self):
-        self._db_mngr.add_metadata(
+        self._db_mngr.add_items(
+            "metadata",
             {
                 self._db_map: [
                     {"name": "name_1", "value": "value_1", "id": 1},
                     {"name": "name_2", "value": "value_2", "id": 2},
                 ]
-            }
+            },
         )
         self._model.insertRows(0, 1)
         self._model.insertRows(2, 1)
@@ -182,7 +183,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_insert_rows_after_adder_row_extends_normal_rows_instead(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous", "id": 1}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self.assertEqual(self._model.rowCount(), 2)
         self._model.insertRows(2, 1)
         self.assertEqual(self._model.rowCount(), 3)
@@ -200,7 +201,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_remove_rows_also_from_database(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous", "id": 1}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self.assertTrue(self._model.removeRows(0, 1))
         self.assertEqual(self._model.rowCount(), 1)
         self._assert_empty_last_row()
@@ -220,7 +221,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_update_metadata_using_batch_set_data(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous", "id": 1}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         indexes = [self._model.index(0, Column.NAME), self._model.index(0, Column.VALUE)]
         data = ["title", "My precious."]
         self._model.batch_set_data(indexes, data)
@@ -245,7 +246,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
 
     def test_roll_back(self):
         db_map_data = {self._db_map: [{"name": "author", "value": "Anonymous"}]}
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self._db_mngr.commit_session("Add test data.", self._db_map)
         index = self._model.index(1, Column.NAME)
         self.assertTrue(self._model.setData(index, "title"))
@@ -260,7 +261,7 @@ class TestMetadataTableModel(TestCaseWithQApplication):
         self.assertEqual(self._model.index(1, Column.DB_MAP).data(), "database")
         self._assert_empty_last_row()
         self._db_mngr.rollback_session(self._db_map)
-        self._db_mngr.add_metadata(db_map_data)
+        self._db_mngr.add_items("metadata", db_map_data)
         self.assertEqual(self._model.rowCount(), 2)
         self.assertEqual(self._model.index(0, Column.NAME).data(), "author")
         self.assertEqual(self._model.index(0, Column.VALUE).data(), "Anonymous")

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -70,7 +70,7 @@ class TestScenarioModel(_TestBase):
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
+        self._db_mngr.add_items("scenario", {self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
         data = model_data_to_dict(model)
         expected = [
             [
@@ -89,10 +89,11 @@ class TestScenarioModel(_TestBase):
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
+        self._db_mngr.add_items("scenario", {self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
         scenario_id = self._db_map.scenario(name="scenario_1")["id"]
-        self._db_mngr.update_scenarios(
-            {self._db_map: [{"name": "scenario_2.0", "description": "More than just a test.", "id": scenario_id}]}
+        self._db_mngr.update_items(
+            "scenario",
+            {self._db_map: [{"name": "scenario_2.0", "description": "More than just a test.", "id": scenario_id}]},
         )
         data = model_data_to_dict(model)
         expected = [
@@ -112,7 +113,7 @@ class TestScenarioModel(_TestBase):
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
+        self._db_mngr.add_items("scenario", {self._db_map: [{"name": "scenario_1", "description": "Just a test."}]})
         scenario_id = self._db_map.scenario(name="scenario_1")["id"]
         self._db_mngr.remove_items({self._db_map: {"scenario": {scenario_id}}})
         data = model_data_to_dict(model)
@@ -197,7 +198,7 @@ class TestScenarioModel(_TestBase):
         self.assertEqual(model_data, expected)
 
     def test_dropMimeData_reorders_alternatives(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
@@ -286,7 +287,7 @@ class TestScenarioModel(_TestBase):
         self.assertEqual(model_data, expected)
 
     def test_paste_alternative_mime_data(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
@@ -317,7 +318,7 @@ class TestScenarioModel(_TestBase):
         self.assertEqual(model_data, expected)
 
     def test_paste_alternative_mime_data_ranks_alternatives(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map)
         model.build_tree()
         self._fetch_recursively(model)
@@ -383,8 +384,10 @@ class TestScenarioModel(_TestBase):
         self.assertEqual(model_data, expected)
 
     def test_duplicate_scenario(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alternative_1"}]})
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "my_scenario", "description": "My test scenario"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items(
+            "scenario", {self._db_map: [{"name": "my_scenario", "description": "My test scenario"}]}
+        )
         scenario_id = self._db_map.scenario(name="my_scenario")["id"]
         base_alternative_id = self._db_map.alternative(name="Base")["id"]
         alternative_1_id = self._db_map.alternative(name="alternative_1")["id"]
@@ -461,7 +464,7 @@ class TestScenarioModelWithTwoDatabases(_TestBase):
         self._temp_dir.cleanup()
 
     def test_paste_alternative_mime_data_doesnt_paste_across_databases(self):
-        self._db_mngr.add_alternatives({self._db_map1: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map1: [{"name": "alternative_1"}]})
         model = ScenarioModel(self._db_editor, self._db_mngr, self._db_map1, self._db_map2)
         model.build_tree()
         self._fetch_recursively(model)
@@ -493,8 +496,8 @@ class TestScenarioModelWithTwoDatabases(_TestBase):
         self.assertEqual(model_data, expected)
 
     def test_paste_scenario_mime_data(self):
-        self._db_mngr.add_scenarios({self._db_map1: [{"name": "my_scenario"}]})
-        self._db_mngr.add_alternatives({self._db_map1: [{"name": "alternative_1"}]})
+        self._db_mngr.add_items("scenario", {self._db_map1: [{"name": "my_scenario"}]})
+        self._db_mngr.add_items("alternative", {self._db_map1: [{"name": "alternative_1"}]})
         scenario_id = self._db_map1.scenario(name="my_scenario")["id"]
         self._db_mngr.set_scenario_alternatives(
             {self._db_map1: [{"id": scenario_id, "alternative_name_list": ["alternative_1", "Base"]}]}

--- a/tests/spine_db_editor/mvcmodels/test_single_parameter_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_single_parameter_models.py
@@ -87,17 +87,18 @@ class TestSingleObjectParameterValueModel(TestCaseWithQApplication):
         self._db_mngr.deleteLater()
 
     def test_data_db_map_role(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "my_class"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "my_class"}]})
         entity_class = self._db_map.get_entity_class_item(name="my_class")
-        self._db_mngr.add_parameter_definitions(
-            {self._db_map: [{"entity_class_id": entity_class["id"], "name": "my_parameter"}]}
+        self._db_mngr.add_items(
+            "parameter_definition", {self._db_map: [{"entity_class_id": entity_class["id"], "name": "my_parameter"}]}
         )
         definition = self._db_map.get_parameter_definition_item(entity_class_id=entity_class["id"], name="my_parameter")
-        self._db_mngr.add_entities({self._db_map: [{"class_id": entity_class["id"], "name": "my_object"}]})
+        self._db_mngr.add_items("entity", {self._db_map: [{"class_id": entity_class["id"], "name": "my_object"}]})
         entity = self._db_map.get_entity_item(class_id=entity_class["id"], name="my_object")
         alternative = self._db_map.get_alternative_item(name="Base")
         value, type_ = to_database(2.3)
-        self._db_mngr.add_parameter_values(
+        self._db_mngr.add_items(
+            "parameter_value",
             {
                 self._db_map: [
                     {
@@ -109,7 +110,7 @@ class TestSingleObjectParameterValueModel(TestCaseWithQApplication):
                         "alternative_id": alternative["id"],
                     }
                 ]
-            }
+            },
         )
         parameter_value = self._db_map.get_parameter_value_item(
             entity_class_id=entity_class["id"],

--- a/tests/spine_db_editor/test_graphics_items.py
+++ b/tests/spine_db_editor/test_graphics_items.py
@@ -36,10 +36,11 @@ class TestEntityItem(TestCaseWithQApplication):
             self._db_mngr.name_registry.register(self._db_map.sa_url, "database")
             self._spine_db_editor = SpineDBEditor(self._db_mngr, {"sqlite://": "database"})
             self._spine_db_editor.pivot_table_model = mock.MagicMock()
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "oc"}]})
-        self._db_mngr.add_entities({self._db_map: [{"name": "o", "entity_class_name": "oc"}]})
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "rc", "dimension_name_list": ["oc"]}]})
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "oc"}]})
+        self._db_mngr.add_items("entity", {self._db_map: [{"name": "o", "entity_class_name": "oc"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "rc", "dimension_name_list": ["oc"]}]})
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {
@@ -48,7 +49,7 @@ class TestEntityItem(TestCaseWithQApplication):
                         "element_name_list": ["o"],
                     }
                 ]
-            }
+            },
         )
         entity_id = self._db_map.entity(entity_class_name="rc", name="r")["id"]
         with mock.patch.object(EntityItem, "refresh_icon"):

--- a/tests/spine_db_editor/widgets/test_SpineDBEditor.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditor.py
@@ -280,7 +280,7 @@ class TestClosingDBEditors(TestCaseWithQApplication):
     def test_first_editor_to_close_does_not_ask_for_confirmation_on_dirty_database(self):
         editor_1 = self._make_db_editor()
         editor_2 = self._make_db_editor()
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "my_object_class"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "my_object_class"}]})
         self.assertTrue(self._db_mngr.dirty(self._db_map))
         with (
             mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.save_window_state"),
@@ -297,7 +297,7 @@ class TestClosingDBEditors(TestCaseWithQApplication):
 
     def test_editor_asks_for_confirmation_even_when_non_editor_listeners_are_connected(self):
         editor = self._make_db_editor()
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "my_object_class"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "my_object_class"}]})
         self.assertTrue(self._db_mngr.dirty(self._db_map))
         non_editor_listener = object()
         self._db_mngr.register_listener(non_editor_listener, self._db_map)

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorUpdate.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorUpdate.py
@@ -23,7 +23,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
         self.put_mock_object_classes_in_db_mngr()
         self.fetch_entity_tree_model()
         fish_update = {"id": self.fish_class["id"], "name": "octopus"}
-        self.db_mngr.update_entity_classes({self.mock_db_map: [fish_update]})
+        self.db_mngr.update_items("entity_class", {self.mock_db_map: [fish_update]})
         root_item = self.spine_db_editor.entity_tree_model.root_item
         fish_item = root_item.child(1)
         self.assertEqual(fish_item.item_type, "entity_class")
@@ -36,7 +36,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
         self.put_mock_objects_in_db_mngr()
         self.fetch_entity_tree_model()
         nemo_update = {"id": self.nemo_object["id"], "name": "dory"}
-        self.db_mngr.update_entities({self.mock_db_map: [nemo_update]})
+        self.db_mngr.update_items("entity", {self.mock_db_map: [nemo_update]})
         root_item = self.spine_db_editor.entity_tree_model.root_item
         fish_item = root_item.child(1)
         nemo_item = fish_item.child(0)
@@ -51,7 +51,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
         self.put_mock_relationship_classes_in_db_mngr()
         self.fetch_entity_tree_model()
         fish_dog_update = {"id": self.fish_dog_class["id"], "name": "octopus__dog"}
-        self.db_mngr.update_entity_classes({self.mock_db_map: [fish_dog_update]})
+        self.db_mngr.update_items("entity_class", {self.mock_db_map: [fish_dog_update]})
         root_item = self.spine_db_editor.entity_tree_model.root_item
         fish_dog_item = root_item.child(3)
         self.assertEqual(fish_dog_item.item_type, "entity_class")
@@ -67,7 +67,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
         self.put_mock_object_parameter_definitions_in_db_mngr()
         self.fetch_entity_tree_model()
         water_update = {"id": self.water_parameter["id"], "name": "fire"}
-        self.db_mngr.update_parameter_definitions({self.mock_db_map: [water_update]})
+        self.db_mngr.update_items("parameter_definition", {self.mock_db_map: [water_update]})
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):
@@ -88,7 +88,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
         self.put_mock_relationship_parameter_definitions_in_db_mngr()
         self.fetch_entity_tree_model()
         relative_speed_update = {"id": self.relative_speed_parameter["id"], "name": "each_others_opinion"}
-        self.db_mngr.update_parameter_definitions({self.mock_db_map: [relative_speed_update]})
+        self.db_mngr.update_items("parameter_definition", {self.mock_db_map: [relative_speed_update]})
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):
@@ -110,7 +110,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
         self.fetch_entity_tree_model()
         value, type_ = to_database("pepper")
         nemo_water_update = {"id": self.nemo_water["id"], "value": value, "type": type_}
-        self.db_mngr.update_parameter_values({self.mock_db_map: [nemo_water_update]})
+        self.db_mngr.update_items("parameter_value", {self.mock_db_map: [nemo_water_update]})
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):
@@ -137,7 +137,7 @@ class TestSpineDBEditorUpdate(DBEditorTestBase):
             "value": value,
             "type": type_,
         }
-        self.db_mngr.update_parameter_values({self.mock_db_map: [nemo_pluto_relative_speed_update]})
+        self.db_mngr.update_items("parameter_value", {self.mock_db_map: [nemo_pluto_relative_speed_update]})
         h = model.header.index
         parameters = []
         for row in range(model.rowCount()):

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
@@ -31,6 +31,7 @@ class TestSpineDBEditorWithDBMapping(TestCaseWithQApplication):
             mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.show"),
         ):
             mock_settings = mock.MagicMock()
+            mock_settings.value = mock.MagicMock()
             mock_settings.value.side_effect = lambda *args, **kwards: 0
             self.db_mngr = TestSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
@@ -30,7 +30,7 @@ class TestSpineDBEditorWithDBMapping(TestCaseWithQApplication):
             mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"),
             mock.patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.show"),
         ):
-            mock_settings = mock.Mock()
+            mock_settings = mock.MagicMock()
             mock_settings.value.side_effect = lambda *args, **kwards: 0
             self.db_mngr = TestSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()

--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -201,17 +201,19 @@ class TestAddItemsDialog(TestCaseWithQApplication):
 
     def test_add_entities_dialog_autofill(self):
         """Test that the autofill also works for the add entities dialog."""
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "first_class"}, {"name": "second_class"}]})
-        self._db_mngr.add_entity_classes(
-            {self._db_map: [{"name": "entity_class", "dimension_name_list": ["first_class", "second_class"]}]}
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "first_class"}, {"name": "second_class"}]})
+        self._db_mngr.add_items(
+            "entity_class",
+            {self._db_map: [{"name": "entity_class", "dimension_name_list": ["first_class", "second_class"]}]},
         )
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "first_class", "name": "entity_1"},
                     {"entity_class_name": "second_class", "name": "entity_2"},
                 ]
-            }
+            },
         )
         for item in self._db_editor.entity_tree_model.visit_all():
             while item.can_fetch_more():
@@ -260,21 +262,23 @@ class TestAddItemsDialog(TestCaseWithQApplication):
 
 class TestManageElementsDialog(TestBase):
     def test_add_relationship_among_existing_ones(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Object_1"}, {"name": "Object_2"}]})
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Object_1"}, {"name": "Object_2"}]})
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "Object_1", "name": "object_11"},
                     {"entity_class_name": "Object_1", "name": "object_12"},
                     {"entity_class_name": "Object_2", "name": "object_21"},
                 ]
-            }
+            },
         )
-        self._db_mngr.add_entity_classes(
-            {self._db_map: [{"name": "rc", "dimension_name_list": ["Object_1", "Object_2"]}]}
+        self._db_mngr.add_items(
+            "entity_class", {self._db_map: [{"name": "rc", "dimension_name_list": ["Object_1", "Object_2"]}]}
         )
-        self._db_mngr.add_entities(
-            {self._db_map: [{"name": "r", "entity_class_name": "rc", "element_name_list": ["object_11", "object_21"]}]}
+        self._db_mngr.add_items(
+            "entity",
+            {self._db_map: [{"name": "r", "entity_class_name": "rc", "element_name_list": ["object_11", "object_21"]}]},
         )
         root_index = self._db_editor.entity_tree_model.index(0, 0)
         class_index = self._db_editor.entity_tree_model.index(2, 0, root_index)
@@ -297,26 +301,28 @@ class TestManageElementsDialog(TestBase):
         self.assertEqual(dialog.new_items_model.index(0, 2).data(), "object_12__object_21")
 
     def test_accept_relationship_removal(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Object_1"}, {"name": "Object_2"}]})
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Object_1"}, {"name": "Object_2"}]})
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "Object_1", "name": "object_11"},
                     {"entity_class_name": "Object_1", "name": "object_12"},
                     {"entity_class_name": "Object_2", "name": "object_21"},
                 ]
-            }
+            },
         )
-        self._db_mngr.add_entity_classes(
-            {self._db_map: [{"name": "rc", "dimension_name_list": ["Object_1", "Object_2"]}]}
+        self._db_mngr.add_items(
+            "entity_class", {self._db_map: [{"name": "rc", "dimension_name_list": ["Object_1", "Object_2"]}]}
         )
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"name": "r11", "entity_class_name": "rc", "element_name_list": ["object_11", "object_21"]},
                     {"name": "r21", "entity_class_name": "rc", "element_name_list": ["object_12", "object_21"]},
                 ]
-            }
+            },
         )
         root_index = self._db_editor.entity_tree_model.index(0, 0)
         class_index = self._db_editor.entity_tree_model.index(2, 0, root_index)
@@ -363,7 +369,7 @@ class TestManageElementsDialog(TestBase):
 
 class TestAddEntitiesDialog(TestBase):
     def test_default_alternative_skips_add_alternatives_row(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Object_1", "active_by_default": False}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Object_1", "active_by_default": False}]})
         alternative_model = self._db_editor.ui.alternative_tree_view.model()
         alternative_tree_root = alternative_model.index(0, 0)
         add_alternative_index = alternative_model.index(1, 0, alternative_tree_root)
@@ -391,7 +397,7 @@ class TestAddEntitiesDialog(TestBase):
         self.assertEqual(model.index(0, 3).data(), self.db_codename)
 
     def test_default_alternative_is_empty_if_class_is_active_by_default(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "Object_1"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Object_1"}]})
         alternative_model = self._db_editor.ui.alternative_tree_view.model()
         alternative_tree_root = alternative_model.index(0, 0)
         add_alternative_index = alternative_model.index(1, 0, alternative_tree_root)

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -355,7 +355,7 @@ class TestParameterValueTableWithExistingData(TestBase):
         self.assertEqual(model.rowCount(), self._CHUNK_SIZE)
         self._db_mngr.purge_items({self._db_map: ["parameter_value"]})
         self.assertEqual(model.rowCount(), 0)
-        self._db_editor.undo_action.trigger()
+        self._db_mngr.undo_stack[self._db_map].undo()
         while model.rowCount() != self._whole_model_rowcount():
             # Fetch the entire model, because we want to validate all the data.
             model.fetchMore(QModelIndex())

--- a/tests/spine_db_editor/widgets/test_custom_qtreeview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtreeview.py
@@ -199,24 +199,18 @@ class TestEntityTreeViewWithInitiallyEmptyDatabase(TestBase):
             self.assertEqual(data[0].name, "an_entity")
 
     def test_add_entity_with_alternative(self):
-        """Tests that adding a new entity with the alternative -column filled
+        """Tests that adding a new entity with the alternative column filled
         will actually add the alternative"""
         view = self._db_editor.ui.treeView_entity
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "Alt1"}]})
         add_zero_dimension_entity_class(view, "an_entity_class")
-        with mock.patch.object(self._db_mngr, "add_entity_alternatives") as mock_add_entity_alternatives:
-            add_entity(view, "an_entity", alternative="Alt1")
-            mock_add_entity_alternatives.assert_called_once_with(
-                {
-                    self._db_map: [
-                        {
-                            "active": True,
-                            "alternative_name": "Alt1",
-                            "entity_byname": ("an_entity",),
-                            "entity_class_name": "an_entity_class",
-                        }
-                    ]
-                }
-            )
+        entity_class_id = self._db_map.entity_class(name="an_entity_class")["id"]
+        add_entity(view, "an_entity", alternative="Alt1")
+        entity = self._db_map.entity(class_id=entity_class_id, name="an_entity")
+        entity_alternative = self._db_map.entity_alternative(
+            alternative_name="Alt1", entity_class_id=entity_class_id, entity_id=entity["id"]
+        )
+        self.assertTrue(entity_alternative["active"])
         model = view.model()
         root_index = model.index(0, 0)
         class_index = model.index(0, 0, root_index)

--- a/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
+++ b/tests/spine_db_editor/widgets/test_mass_select_items_dialogs.py
@@ -69,10 +69,10 @@ class TestMassRemoveItemsDialog(TestCaseWithQApplication):
         self.assertTrue(dialog._database_check_boxes_widget._check_boxes[self._db_map].isChecked())
 
     def test_purge_objects(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "my_class"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "my_class"}]})
         classes = self._db_map.get_items("entity_class")
         class_id = classes[0]["id"]
-        self._db_mngr.add_entities({self._db_map: [{"class_id": class_id, "name": "my_object"}]})
+        self._db_mngr.add_items("entity", {self._db_map: [{"class_id": class_id, "name": "my_object"}]})
         entities = [item._asdict() for item in self._db_map.get_items("entity")]
         self.assertEqual(len(entities), 1)
         entity_id = entities[0]["id"]

--- a/tests/spine_db_editor/widgets/test_scenario_generator.py
+++ b/tests/spine_db_editor/widgets/test_scenario_generator.py
@@ -19,7 +19,7 @@ from tests.spine_db_editor.helpers import TestBase
 
 class TestScenarioGenerator(TestBase):
     def test_alternative_list_contains_alternatives(self):
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "alt1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "alt1"}]})
         alternatives = self._db_map.get_items("alternative")
         scenario_generator = ScenarioGenerator(self._db_editor, self._db_map, alternatives, self._db_editor)
         list_widget = scenario_generator._ui.alternative_list
@@ -30,7 +30,7 @@ class TestScenarioGenerator(TestBase):
 
     def test_zero_padding_in_generated_scenario_names(self):
         db_map_items = [{"name": f"alt{n}"} for n in range(13)]
-        self._db_mngr.add_alternatives({self._db_map: db_map_items})
+        self._db_mngr.add_items("alternative", {self._db_map: db_map_items})
         alternatives = self._db_map.get_items("alternative")
         scenario_generator = ScenarioGenerator(self._db_editor, self._db_map, alternatives, self._db_editor)
         scenario_generator._ui.scenario_prefix_edit.setText("S_")

--- a/tests/test_SpineDBManager.py
+++ b/tests/test_SpineDBManager.py
@@ -596,7 +596,8 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         self._db_mngr.clean_up()
 
     def test_find_cascading_entity_classes(self):
-        self._db_mngr.add_entity_classes(
+        self._db_mngr.add_items(
+            "entity_class",
             {
                 self._db_map: [
                     {"name": "O1"},
@@ -611,7 +612,7 @@ class TestFindCascadingItems(TestCaseWithQApplication):
                     {"dimension_name_list": ["O2", "O3"]},
                     {"dimension_name_list": ["O1", "O2", "O3"]},
                 ]
-            }
+            },
         )
         o1_id = self._db_map.entity_class(name="O1")["id"]
         data = {
@@ -633,7 +634,8 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         self.assertCountEqual(data[self._db_map], ["O1__", "O1__O3", "O1__O2__O3"])
 
     def test_find_cascading_entities(self):
-        self._db_mngr.add_entity_classes(
+        self._db_mngr.add_items(
+            "entity_class",
             {
                 self._db_map: [
                     {"name": "O1"},
@@ -648,9 +650,10 @@ class TestFindCascadingItems(TestCaseWithQApplication):
                     {"dimension_name_list": ["O2", "O3"]},
                     {"dimension_name_list": ["O1", "O2", "O3"]},
                 ]
-            }
+            },
         )
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "O1", "name": "o11"},
@@ -662,7 +665,7 @@ class TestFindCascadingItems(TestCaseWithQApplication):
                     {"entity_class_name": "O1__O2", "element_name_list": ("o12", "o21")},
                     {"entity_class_name": "O2__O3", "element_name_list": ("o21", "o31")},
                 ]
-            }
+            },
         )
         o13_id = self._db_map.entity(entity_class_name="O1", name="o13")["id"]
         self.assertEqual(self._db_mngr.find_cascading_entities({self._db_map: [o13_id]}), {})
@@ -678,9 +681,10 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         self.assertEqual(self._db_mngr.find_cascading_entities({self._db_map: [o11_id]}), {})
 
     def test_find_cascading_parameter_definitions(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}, {"name": "O2"}, {"name": "O3"}]})
-        self._db_mngr.add_parameter_definitions(
-            {self._db_map: [{"entity_class_name": "O1", "name": "p11"}, {"entity_class_name": "O2", "name": "p21"}]}
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "O1"}, {"name": "O2"}, {"name": "O3"}]})
+        self._db_mngr.add_items(
+            "parameter_definition",
+            {self._db_map: [{"entity_class_name": "O1", "name": "p11"}, {"entity_class_name": "O2", "name": "p21"}]},
         )
         o3_id = self._db_map.entity_class(name="O3")["id"]
         self.assertEqual(self._db_mngr.find_cascading_parameter_definitions({self._db_map: [o3_id]}), {})
@@ -698,17 +702,19 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         self.assertEqual(self._db_mngr.find_cascading_parameter_definitions({self._db_map: [o1_id]}), {})
 
     def test_find_cascading_parameter_values_by_entity(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}, {"name": "O2"}, {"name": "O3"}]})
-        self._db_mngr.add_parameter_definitions(
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "O1"}, {"name": "O2"}, {"name": "O3"}]})
+        self._db_mngr.add_items(
+            "parameter_definition",
             {
                 self._db_map: [
                     {"entity_class_name": "O1", "name": "p11"},
                     {"entity_class_name": "O2", "name": "p21"},
                     {"entity_class_name": "O3", "name": "p31"},
                 ]
-            }
+            },
         )
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "O1", "name": "o11"},
@@ -716,9 +722,10 @@ class TestFindCascadingItems(TestCaseWithQApplication):
                     {"entity_class_name": "O2", "name": "o21"},
                     {"entity_class_name": "O3", "name": "o31"},
                 ]
-            }
+            },
         )
-        self._db_mngr.add_parameter_values(
+        self._db_mngr.add_items(
+            "parameter_value",
             {
                 self._db_map: [
                     {
@@ -743,7 +750,7 @@ class TestFindCascadingItems(TestCaseWithQApplication):
                         "parsed_value": "yes",
                     },
                 ]
-            }
+            },
         )
         o31_id = self._db_map.entity(entity_class_name="O3", name="o31")["id"]
         self.assertEqual(self._db_mngr.find_cascading_parameter_values_by_entity({self._db_map: [o31_id]}), {})
@@ -771,9 +778,9 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         self.assertEqual(self._db_mngr.find_cascading_parameter_values_by_entity({self._db_map: [o11_id]}), {})
 
     def test_find_cascading_scenario_alternatives_by_scenario(self):
-        self._db_mngr.add_scenarios({self._db_map: [{"name": "S1"}, {"name": "S2"}]})
+        self._db_mngr.add_items("scenario", {self._db_map: [{"name": "S1"}, {"name": "S2"}]})
         s1_id = self._db_map.scenario(name="S1")["id"]
-        self._db_mngr.add_alternatives({self._db_map: [{"name": "a1"}]})
+        self._db_mngr.add_items("alternative", {self._db_map: [{"name": "a1"}]})
         a1_id = self._db_map.alternative(name="a1")["id"]
         self._db_mngr.set_scenario_alternatives({self._db_map: [{"id": s1_id, "alternative_id_list": [a1_id]}]})
         s2_id = self._db_map.scenario(name="S2")["id"]
@@ -786,22 +793,23 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         }
         self.assertEqual(data, {self._db_map: [("S1", "a1")]})
         sa_id = self._db_map.scenario_alternative(scenario_name="S1", alternative_name="a1", rank=0)["id"]
-        self._db_mngr.remove_items({self._db_map: {"scenario_alternative": [sa_id]}})
+        self._db_mngr.remove_items({self._db_map: {"scenario_alternative": {sa_id}}})
         self.assertEqual(self._db_mngr.find_cascading_scenario_alternatives_by_scenario({self._db_map: [s1_id]}), {})
 
     def test_find_groups_by_entity(self):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}]})
-        self._db_mngr.add_entities(
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "O1"}]})
+        self._db_mngr.add_items(
+            "entity",
             {
                 self._db_map: [
                     {"entity_class_name": "O1", "name": "o1"},
                     {"entity_class_name": "O1", "name": "o2"},
                     {"entity_class_name": "O1", "name": "o3"},
                 ]
-            }
+            },
         )
-        self._db_mngr.add_entity_groups(
-            {self._db_map: [{"entity_class_name": "O1", "group_name": "o1", "member_name": "o2"}]}
+        self._db_mngr.add_items(
+            "entity_group", {self._db_map: [{"entity_class_name": "O1", "group_name": "o1", "member_name": "o2"}]}
         )
         o3_id = self._db_map.entity(entity_class_name="O1", name="o3")["id"]
         self.assertEqual(self._db_mngr.find_groups_by_entity({self._db_map: [o3_id]}), {})
@@ -812,7 +820,7 @@ class TestFindCascadingItems(TestCaseWithQApplication):
         }
         self.assertEqual(data, {self._db_map: [("o1", "o2")]})
         group_id = self._db_map.entity_group(group_name="o1", member_name="o2", entity_class_name="O1")["id"]
-        self._db_mngr.remove_items({self._db_map: {"entity_group": [group_id]}})
+        self._db_mngr.remove_items({self._db_map: {"entity_group": {group_id}}})
         self.assertEqual(self._db_mngr.find_groups_by_entity({self._db_map: [o1_id]}), {})
 
 
@@ -834,7 +842,7 @@ class TestCommitSession(TestCaseWithQApplication):
     def test_nothing_to_commit_is_not_error(self):
         error_listener = MagicMock()
         self._db_mngr.register_listener(error_listener, self._db_map)
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "O1"}]})
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "O1"}]})
         class_id = self._db_map.entity_class(name="O1")["id"]
         self._db_mngr.remove_items({self._db_map: {"entity_class": [class_id]}})
         self.assertEqual(self._db_mngr.commit_session("Nothing to commit.", self._db_map), [])

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -48,13 +48,14 @@ from tests.spine_db_editor.helpers import TestBase
 
 class TestPlotPivotTableSelection(TestBase):
     def _add_object_parameter_values(self, values):
-        self._db_mngr.add_entity_classes({self._db_map: [{"name": "class", "id": 1}]})
-        self._db_mngr.add_parameter_definitions(
-            {self._db_map: [{"entity_class_id": 1, "name": name, "id": i + 1} for i, name in enumerate(values)]}
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "class", "id": 1}]})
+        self._db_mngr.add_items(
+            "parameter_definition",
+            {self._db_map: [{"entity_class_id": 1, "name": name, "id": i + 1} for i, name in enumerate(values)]},
         )
         object_count = max(len(x) for x in values.values())
-        self._db_mngr.add_entities(
-            {self._db_map: [{"class_id": 1, "name": f"o{i + 1}", "id": i + 1} for i in range(object_count)]}
+        self._db_mngr.add_items(
+            "entity", {self._db_map: [{"class_id": 1, "name": f"o{i + 1}", "id": i + 1} for i in range(object_count)]}
         )
         db_values = {name: list(map(to_database, value_list)) for name, value_list in values.items()}
         value_items = [
@@ -69,7 +70,7 @@ class TestPlotPivotTableSelection(TestBase):
             for param_i, values_and_types in enumerate(db_values.values())
             for i, (db_value, type_) in enumerate(values_and_types)
         ]
-        self._db_mngr.add_parameter_values({self._db_map: value_items})
+        self._db_mngr.add_items("parameter_value", {self._db_map: value_items})
 
     def _select_object_class_in_tree_view(self):
         object_tree_model = self._db_editor.ui.treeView_entity.model()


### PR DESCRIPTION
This PR adds undo/redo actions to the empty row tables in Entity alternative, Parameter definition and Parameter value docks in Database editor.

Resolves #2407

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
