### PR TITLE
Fix EngineClient crash and a traceback

### DIFF
--- a/spinetoolbox/spine_engine_manager.py
+++ b/spinetoolbox/spine_engine_manager.py
@@ -319,7 +319,6 @@ class RemoteSpineEngineManager(SpineEngineManagerBase):
                 self.q.put(("server_status_msg", {"msg_type": "fail", "text": f"{event[0]: {event[1]}}"}))
                 break
             self.q.put(event)
-        self.engine_client.close()
 
     def answer_prompt(self, prompter_id, answer):
         """See base class."""
@@ -348,7 +347,8 @@ class RemoteSpineEngineManager(SpineEngineManagerBase):
 
     def kill_persistent(self, persistent_key):
         """See base class."""
-        return self.engine_client.send_kill_persistent(persistent_key)
+        if self.engine_client is not None:
+            return self.engine_client.send_kill_persistent(persistent_key)
 
     def get_persistent_completions(self, persistent_key, text):
         """See base class."""


### PR DESCRIPTION
- EngineClient.close() was called three times after each execution, now it's called only twice. This caused a crash when running Julia tools remotely many times in a row
- There was a traceback when closing toolbox after remote execution

No associated issue.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [x] Unit tests pass
