### PR TITLE
Enable Pytest

### DIFF
--- a/.github/workflows/execution_tests.yml
+++ b/.github/workflows/execution_tests.yml
@@ -56,4 +56,4 @@ jobs:
           ${{ inputs.post-installation-command }}
       - name: Run tests
         run:
-          python -m unittest discover --pattern execution_test.py --verbose
+          pytest execution_tests/ --cov --verbose

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -66,7 +66,7 @@ jobs:
         if [ "$RUNNER_OS" != "Windows" ]; then
           export QT_QPA_PLATFORM=offscreen
         fi
-        ${{ inputs.coverage && 'coverage run' || 'python' }} -m unittest discover --verbose
+        ${{ inputs.coverage && 'pytest tests/ --cov --verbose' || 'pytest tests/ --verbose' }}
       shell: bash
     - name: Upload coverage report to Codecov
       if: ${{ inputs.coverage }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ sphinx_rtd_theme
 sphinx-autoapi < 3.4
 recommonmark
 pylint
+pytest-cov >= 6

--- a/docs/source/execution_tests.rst
+++ b/docs/source/execution_tests.rst
@@ -3,13 +3,11 @@
 Execution Tests
 ===============
 
-Toolbox contains *execution tests* that test entire workflows in the headless mode.
+Toolbox contains *execution tests* that test entire workflows in headless mode.
 The tests can be found in :literal:`<toolbox repository root>/execution_tests/`.
 Execution tests are otherwise normal Toolbox projects
-except that the project root directories contain :literal:`__init__.py` and :literal:`execution_test.py` files.
-:literal:`__init__.py` makes the directory part of the execution test suite
-while :literal:`execution_test.py` contains actual test code.
-The tests utilize Python's :literal:`unittest` package
+except that the project root directories contains a :literal:`execution_test.py` file.
+The tests utilize the :literal:`pytest` package
 so the test code is practically identical to any unit tests in Toolbox.
 
 Executing the tests
@@ -18,4 +16,4 @@ Executing the tests
 Tests are run as a GitHub action whenever a branch is pushed to GitHub.
 This process is configured by :literal:`<project root>/.github/workflows/executiontest_runner.yml`
 
-To execute the tests manually, run :literal:`python -munittest discover --pattern execution_test.py` in project's root.
+To execute the tests manually, run :literal:`pytest execution_test/` in project's root.

--- a/docs/source/unit_testing_guidelines.rst
+++ b/docs/source/unit_testing_guidelines.rst
@@ -6,15 +6,18 @@ Unit Testing Guidelines
 Test modules, directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spine project uses Python standard `unittest <https://docs.python.org/3/library/unittest.html>`_ framework for testing.
+Spine project uses the `pytest <https://docs.pytest.org/en/stable/index.html>`_ framework for testing.
 The tests are organized into Python modules starting with the prefix :literal:`test_`
 under :literal:`<project root>/tests/`.
 The structure of :literal:`tests/` mirrors that of the package being tested.
-Note that all subdirectories containing test modules under :literal:`tests/` must have an (empty) :literal:`__init__.py`
-which makes them part of the project's test package.
 
-While there are no strict rules on how to name the individual test modules except for the :literal:`test_` prefix,
-:literal:`test_<module_name>.py` is preferred.
+The naming convention for modules is :literal:`test_<module_name>.py`.
+Within those files, :literal:`pytest` will run `test` prefixed functions or methods
+outside of classes, and `test` prefixed functions or methods inside `Test` prefixed
+test classes (without an :literal:`__init__` method). Methods decorated with
+:literal:`@staticmethod` and :literal:`@classmethods` are also considered.
+
+Please consult the `conventions for python test discovery https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery` for further details.
 
 Running the tests
 ~~~~~~~~~~~~~~~~~
@@ -22,7 +25,7 @@ Running the tests
 Tests are run as a GitHub action whenever a branch is pushed to GitHub.
 This process is configured by :literal:`<project root>/.github/workflows/unittest_runner.yml`
 
-To execute the tests manually, run :literal:`python -munittest discover` in project's root.
+To execute the tests manually, run :literal:`pytest tests/` in project's root.
 
 Helpers
 ~~~~~~~

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -303,7 +303,7 @@ class MockInstantQProcess(mock.Mock):
             slot(*self._finished_args)
 
 
-class TestSpineDBManager(SpineDBManager):
+class MockSpineDBManager(SpineDBManager):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs, synchronous=True)
 

--- a/tests/spine_db_editor/helpers.py
+++ b/tests/spine_db_editor/helpers.py
@@ -14,7 +14,7 @@
 from unittest import mock
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 
 
 class TestBase(TestCaseWithQApplication):
@@ -38,7 +38,7 @@ class TestBase(TestCaseWithQApplication):
         ):
             mock_settings = mock.MagicMock()
             mock_settings.value.side_effect = lambda *args, **kwargs: 0
-            self._db_mngr = TestSpineDBManager(mock_settings, None)
+            self._db_mngr = MockSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()
             self._db_map = self._db_mngr.get_db_map(url, logger, create=create)
             self._db_mngr.name_registry.register(url, self.db_codename)

--- a/tests/spine_db_editor/mvcmodels/test_alternative_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_alternative_model.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.mvcmodels import mime_types
 from spinetoolbox.spine_db_editor.mvcmodels.alternative_model import AlternativeModel
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, model_data_to_dict
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, model_data_to_dict
 
 
 class TestAlternativeModel(TestCaseWithQApplication):
@@ -29,7 +29,7 @@ class TestAlternativeModel(TestCaseWithQApplication):
     def setUp(self):
         app_settings = MagicMock()
         logger = MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, self.db_codename)
         with patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"):
@@ -131,7 +131,7 @@ class TestAlternativeModelWithTwoDatabases(TestCaseWithQApplication):
         self._temp_dir = TemporaryDirectory()
         app_settings = MagicMock()
         logger = MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map1 = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         url2 = "sqlite:///" + str(Path(self._temp_dir.name, "db2.sqlite"))
         self._db_map2 = self._db_mngr.get_db_map(url2, logger, create=True)

--- a/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
+++ b/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
@@ -25,7 +25,7 @@ from spinedb_api import (
 from spinedb_api.parameter_value import join_value_and_type, to_database
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR, signal_waiter
 from spinetoolbox.spine_db_editor.mvcmodels.empty_models import EmptyParameterDefinitionModel, EmptyParameterValueModel
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, fetch_model, q_object
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model, q_object
 
 
 def _empty_indexes(model):
@@ -37,7 +37,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
         """Overridden method. Runs before each test."""
         app_settings = mock.MagicMock()
         logger = mock.MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, "mock_db")
         import_object_classes(self._db_map, ("dog", "fish"))

--- a/tests/spine_db_editor/mvcmodels/test_empty_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_empty_models.py
@@ -15,7 +15,7 @@ from unittest import mock
 from PySide6.QtGui import QUndoStack
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.mvcmodels.empty_models import EmptyModelBase
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, fetch_model
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model
 
 
 class TestEmptyModelBase(TestCaseWithQApplication):
@@ -23,7 +23,7 @@ class TestEmptyModelBase(TestCaseWithQApplication):
         """Overridden method. Runs before each test."""
         app_settings = mock.MagicMock()
         logger = mock.MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, "mock_db")
         self._undo_stack = QUndoStack()

--- a/tests/spine_db_editor/mvcmodels/test_frozen_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_frozen_table_model.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 from PySide6.QtCore import QModelIndex, QObject, Qt
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.mvcmodels.frozen_table_model import FrozenTableModel
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, model_data_to_table
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, model_data_to_table
 
 
 class TestFrozenTableModel(TestCaseWithQApplication):
@@ -25,7 +25,7 @@ class TestFrozenTableModel(TestCaseWithQApplication):
     def setUp(self):
         app_settings = MagicMock()
         logger = MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, self.db_codename)
         self._parent = QObject()

--- a/tests/spine_db_editor/mvcmodels/test_item_metadata_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_item_metadata_table_model.py
@@ -34,7 +34,7 @@ from spinedb_api import (
 )
 from spinetoolbox.spine_db_editor.mvcmodels.item_metadata_table_model import ItemMetadataTableModel
 from spinetoolbox.spine_db_editor.mvcmodels.metadata_table_model_base import Column
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, fetch_model
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model
 
 
 class TestItemMetadataTableModelWithExistingData(TestCaseWithQApplication):
@@ -76,7 +76,7 @@ class TestItemMetadataTableModelWithExistingData(TestCaseWithQApplication):
         db_map.close()
         mock_settings = mock.Mock()
         mock_settings.value.side_effect = lambda *args, **kwargs: 0
-        self._db_mngr = TestSpineDBManager(mock_settings, None)
+        self._db_mngr = MockSpineDBManager(mock_settings, None)
         logger = mock.MagicMock()
         self._db_map = self._db_mngr.get_db_map(self._url, logger)
         self._db_mngr.name_registry.register(self._db_map.sa_url, "database")

--- a/tests/spine_db_editor/mvcmodels/test_metadata_table_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_metadata_table_model.py
@@ -20,14 +20,14 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.mvcmodels.metadata_table_model import MetadataTableModel
 from spinetoolbox.spine_db_editor.mvcmodels.metadata_table_model_base import Column
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, fetch_model
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model
 
 
 class TestMetadataTableModel(TestCaseWithQApplication):
     def setUp(self):
         mock_settings = mock.Mock()
         mock_settings.value.side_effect = lambda *args, **kwargs: 0
-        self._db_mngr = TestSpineDBManager(mock_settings, None)
+        self._db_mngr = MockSpineDBManager(mock_settings, None)
         logger = mock.MagicMock()
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, "database")

--- a/tests/spine_db_editor/mvcmodels/test_scenario_model.py
+++ b/tests/spine_db_editor/mvcmodels/test_scenario_model.py
@@ -22,7 +22,7 @@ from spinetoolbox.helpers import signal_waiter
 from spinetoolbox.spine_db_editor.mvcmodels import mime_types
 from spinetoolbox.spine_db_editor.mvcmodels.scenario_model import ScenarioModel
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, model_data_to_dict
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, model_data_to_dict
 
 
 class _TestBase(TestCaseWithQApplication):
@@ -41,7 +41,7 @@ class TestScenarioModel(_TestBase):
     def setUp(self):
         app_settings = MagicMock()
         logger = MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.db_url, self.db_codename)
         with patch("spinetoolbox.spine_db_editor.widgets.spine_db_editor.SpineDBEditor.restore_ui"):
@@ -441,7 +441,7 @@ class TestScenarioModelWithTwoDatabases(_TestBase):
         self._temp_dir = TemporaryDirectory()
         app_settings = MagicMock()
         logger = MagicMock()
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map1 = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map1.sa_url, "test_db_1")
         url2 = "sqlite:///" + str(Path(self._temp_dir.name, "db_2.sqlite"))

--- a/tests/spine_db_editor/mvcmodels/test_single_parameter_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_single_parameter_models.py
@@ -23,7 +23,7 @@ from spinetoolbox.spine_db_editor.mvcmodels.single_models import (
     SingleParameterDefinitionModel,
     SingleParameterValueModel,
 )
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, fetch_model, q_object
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model, q_object
 
 ENTITY_PARAMETER_VALUE_HEADER = [
     "entity_class_name",
@@ -35,12 +35,12 @@ ENTITY_PARAMETER_VALUE_HEADER = [
 ]
 
 
-class TestSingleParameterDefinitionModel(SingleParameterDefinitionModel):
+class ExampleSingleParameterDefinitionModel(SingleParameterDefinitionModel):
     def __init__(self, db_mngr, db_map, entity_class_id, committed):
         super().__init__(CompoundParameterDefinitionModel(None, db_mngr), db_map, entity_class_id, committed)
 
 
-class TestSingleParameterValueModel(SingleParameterValueModel):
+class ExampleSingleParameterValueModel(SingleParameterValueModel):
     def __init__(self, db_mngr, db_map, entity_class_id, committed):
         super().__init__(CompoundParameterValueModel(None, db_mngr), db_map, entity_class_id, committed)
 
@@ -57,11 +57,11 @@ class TestEmptySingleParameterDefinitionModel(TestCaseWithQApplication):
     ]
 
     def test_rowCount_is_zero(self):
-        with q_object(TestSingleParameterDefinitionModel(None, None, 1, False)) as model:
+        with q_object(ExampleSingleParameterDefinitionModel(None, None, 1, False)) as model:
             self.assertEqual(model.rowCount(), 0)
 
     def test_columnCount_is_header_length(self):
-        with q_object(TestSingleParameterDefinitionModel(None, None, 1, False)) as model:
+        with q_object(ExampleSingleParameterDefinitionModel(None, None, 1, False)) as model:
             self.assertEqual(model.columnCount(), len(self.HEADER))
 
 
@@ -76,7 +76,7 @@ class TestSingleObjectParameterValueModel(TestCaseWithQApplication):
     ]
 
     def setUp(self):
-        self._db_mngr = TestSpineDBManager(None, None)
+        self._db_mngr = MockSpineDBManager(None, None)
         self._logger = MagicMock()
         self._db_map = self._db_mngr.get_db_map("sqlite:///", self._logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.db_url, "Test database")
@@ -118,7 +118,9 @@ class TestSingleObjectParameterValueModel(TestCaseWithQApplication):
             parameter_definition_id=definition["id"],
             alternative_id=alternative["id"],
         )
-        with q_object(TestSingleParameterValueModel(self._db_mngr, self._db_map, parameter_value["id"], True)) as model:
+        with q_object(
+            ExampleSingleParameterValueModel(self._db_mngr, self._db_map, parameter_value["id"], True)
+        ) as model:
             fetch_model(model)
             model.add_rows([parameter_value["id"]])
             self.assertEqual(model.index(0, 0).data(DB_MAP_ROLE), self._db_map)

--- a/tests/spine_db_editor/test_graphics_items.py
+++ b/tests/spine_db_editor/test_graphics_items.py
@@ -17,7 +17,7 @@ from PySide6.QtGui import QKeySequence, QShortcut
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.graphics_items import EntityItem
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 
 
 class TestEntityItem(TestCaseWithQApplication):
@@ -30,7 +30,7 @@ class TestEntityItem(TestCaseWithQApplication):
         ):
             mock_settings = mock.Mock()
             mock_settings.value.side_effect = lambda *args, **kwargs: 0
-            self._db_mngr = TestSpineDBManager(mock_settings, None)
+            self._db_mngr = MockSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()
             self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
             self._db_mngr.name_registry.register(self._db_map.sa_url, "database")

--- a/tests/spine_db_editor/widgets/spine_db_editor_test_base.py
+++ b/tests/spine_db_editor/widgets/spine_db_editor_test_base.py
@@ -15,7 +15,7 @@ from unittest import mock
 from PySide6.QtWidgets import QApplication
 from spinedb_api import to_database
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 
 
 class DBEditorTestBase(TestCaseWithQApplication):
@@ -29,7 +29,7 @@ class DBEditorTestBase(TestCaseWithQApplication):
         ):
             mock_settings = mock.Mock()
             mock_settings.value.side_effect = lambda *args, **kwargs: 0
-            self.db_mngr = TestSpineDBManager(mock_settings, None)
+            self.db_mngr = MockSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()
             self.mock_db_map = self.db_mngr.get_db_map("sqlite://", logger, create=True)
             self.db_mngr.name_registry.register("sqlite://", self.db_codename)

--- a/tests/spine_db_editor/widgets/test_SpineDBEditor.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditor.py
@@ -20,7 +20,7 @@ from spinedb_api import Duration
 from spinedb_api.helpers import name_from_elements
 from spinetoolbox.helpers import signal_waiter
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
 
@@ -260,7 +260,7 @@ class TestClosingDBEditors(TestCaseWithQApplication):
         ):
             mock_settings = mock.Mock()
             mock_settings.value.side_effect = lambda *args, **kwargs: 0
-            self._db_mngr = TestSpineDBManager(mock_settings, None)
+            self._db_mngr = MockSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()
             self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
 

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorBase.py
@@ -15,7 +15,7 @@ import unittest
 from unittest import mock
 from sqlalchemy.engine.url import make_url
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditorBase
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 
 
 class TestSpineDBEditorBase(TestCaseWithQApplication):
@@ -28,7 +28,7 @@ class TestSpineDBEditorBase(TestCaseWithQApplication):
         ):
             mock_settings = mock.Mock()
             mock_settings.value.side_effect = lambda *args, **kwards: 0
-            self.db_mngr = TestSpineDBManager(mock_settings, None)
+            self.db_mngr = MockSpineDBManager(mock_settings, None)
 
             def DBMapping_side_effect(url, upgrade=False, create=False):
                 mock_db_map = mock.MagicMock()

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorWithDBMapping.py
@@ -18,7 +18,7 @@ from unittest import mock
 from PySide6.QtCore import QItemSelectionModel
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 
 
 class TestSpineDBEditorWithDBMapping(TestCaseWithQApplication):
@@ -33,7 +33,7 @@ class TestSpineDBEditorWithDBMapping(TestCaseWithQApplication):
             mock_settings = mock.MagicMock()
             mock_settings.value = mock.MagicMock()
             mock_settings.value.side_effect = lambda *args, **kwards: 0
-            self.db_mngr = TestSpineDBManager(mock_settings, None)
+            self.db_mngr = MockSpineDBManager(mock_settings, None)
             logger = mock.MagicMock()
             self.db_map = self.db_mngr.get_db_map(url, logger, create=True)
             self.spine_db_editor = SpineDBEditor(self.db_mngr, [url])

--- a/tests/test_parameter_type_validation.py
+++ b/tests/test_parameter_type_validation.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import QApplication
 from spinedb_api import to_database
 from spinetoolbox.helpers import signal_waiter
 from spinetoolbox.parameter_type_validation import ValidationKey
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager
 
 
 class TestTypeValidator(TestCaseWithQApplication):
@@ -27,7 +27,7 @@ class TestTypeValidator(TestCaseWithQApplication):
     def setUp(self):
         mock_settings = mock.MagicMock()
         mock_settings.value.side_effect = lambda *args, **kwargs: 0
-        self._db_mngr = TestSpineDBManager(mock_settings, None)
+        self._db_mngr = MockSpineDBManager(mock_settings, None)
         logger = mock.MagicMock()
         self._db_map = self._db_mngr.get_db_map("sqlite://", logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, self.db_codename)

--- a/tests/test_project_item_icon.py
+++ b/tests/test_project_item_icon.py
@@ -26,7 +26,7 @@ from spinetoolbox.project_item.logging_connection import LoggingConnection
 from spinetoolbox.project_item_icon import ExclamationIcon, ProjectItemIcon, RankIcon
 from tests.mock_helpers import (
     TestCaseWithQApplication,
-    TestSpineDBManager,
+    MockSpineDBManager,
     add_view,
     clean_up_toolbox,
     create_toolboxui_with_project,
@@ -145,7 +145,7 @@ class TestLink(TestCaseWithQApplication):
     def setUp(self):
         self._temp_dir = TemporaryDirectory()
         self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
-        self._toolbox.db_mngr = TestSpineDBManager(MagicMock(), None)
+        self._toolbox.db_mngr = MockSpineDBManager(MagicMock(), None)
         source_item_icon = ProjectItemIcon(self._toolbox, ":/icons/home.svg", QColor(Qt.GlobalColor.gray))
         source_item_icon.update_name_item("source icon")
         destination_item_icon = ProjectItemIcon(self._toolbox, ":/icons/home.svg", QColor(Qt.GlobalColor.gray))

--- a/tests/test_spine_db_fetcher.py
+++ b/tests/test_spine_db_fetcher.py
@@ -18,10 +18,10 @@ from PySide6.QtGui import QIcon
 from spinedb_api import DatabaseMapping, to_database
 from spinedb_api.import_functions import import_data
 from spinetoolbox.fetch_parent import ItemTypeFetchParent
-from tests.mock_helpers import TestCaseWithQApplication, TestSpineDBManager, q_object
+from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, q_object
 
 
-class TestItemTypeFetchParent(ItemTypeFetchParent):
+class ExampleItemTypeFetchParent(ItemTypeFetchParent):
     def __init__(self, item_type, parent):
         super().__init__(item_type, owner=parent)
         self.handle_items_added = MagicMock()
@@ -31,7 +31,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
     def setUp(self):
         app_settings = MagicMock()
         self._logger = MagicMock()  # Collects error messages therefore handy for debugging.
-        self._db_mngr = TestSpineDBManager(app_settings, None)
+        self._db_mngr = MockSpineDBManager(app_settings, None)
         self._db_map = self._db_mngr.get_db_map("sqlite://", self._logger, create=True)
         self._db_mngr.name_registry.register(self._db_map.sa_url, "db_fetcher_test_db")
 
@@ -42,7 +42,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
     def test_fetch_empty_database(self):
         with q_object(QObject()) as parent:
             for item_type in DatabaseMapping.item_types():
-                fetcher = TestItemTypeFetchParent(item_type, parent)
+                fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 while self._db_mngr.can_fetch_more(self._db_map, fetcher):
                     self._db_mngr.fetch_more(self._db_map, fetcher)
                     qApp.processEvents()  # pylint: disable=undefined-variable
@@ -59,7 +59,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
     def test_fetch_alternatives(self):
         self._import_data(alternatives=("alt",))
         with q_object(QObject()) as parent:
-            fetcher = TestItemTypeFetchParent("alternative", parent)
+            fetcher = ExampleItemTypeFetchParent("alternative", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call(
@@ -109,7 +109,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
             "commit_id": 2,
         }
         with q_object(QObject()) as parent:
-            fetcher = TestItemTypeFetchParent("scenario", parent)
+            fetcher = ExampleItemTypeFetchParent("scenario", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -130,11 +130,11 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
         }
         with q_object(QObject()) as parent:
             for item_type in ("scenario", "alternative"):
-                dep_fetcher = TestItemTypeFetchParent(item_type, parent)
+                dep_fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 self._db_mngr.fetch_more(self._db_map, dep_fetcher)
                 dep_fetcher.set_obsolete(True)
                 dep_fetcher.deleteLater()
-            fetcher = TestItemTypeFetchParent("scenario_alternative", parent)
+            fetcher = ExampleItemTypeFetchParent("scenario_alternative", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -157,7 +157,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
             "dimension_id_list": (),
         }
         with q_object(QObject()) as parent:
-            fetcher = TestItemTypeFetchParent("entity_class", parent)
+            fetcher = ExampleItemTypeFetchParent("entity_class", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -177,12 +177,12 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
             "commit_id": 2,
         }
         with q_object(QObject()) as parent:
-            self._db_mngr.fetch_more(self._db_map, TestItemTypeFetchParent("entity_class", parent))
+            self._db_mngr.fetch_more(self._db_map, ExampleItemTypeFetchParent("entity_class", parent))
             for item_type in ("entity",):
-                dep_fetcher = TestItemTypeFetchParent(item_type, parent)
+                dep_fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 self._db_mngr.fetch_more(self._db_map, dep_fetcher)
                 dep_fetcher.set_obsolete(True)
-            fetcher = TestItemTypeFetchParent("entity", parent)
+            fetcher = ExampleItemTypeFetchParent("entity", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -209,10 +209,10 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
         }
         with q_object(QObject()) as parent:
             for item_type in ("entity_class",):
-                dep_fetcher = TestItemTypeFetchParent(item_type, parent)
+                dep_fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 self._db_mngr.fetch_more(self._db_map, dep_fetcher)
                 dep_fetcher.set_obsolete(True)
-            fetcher = TestItemTypeFetchParent("entity_class", parent)
+            fetcher = ExampleItemTypeFetchParent("entity_class", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -232,10 +232,10 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
         }
         with q_object(QObject()) as parent:
             for item_type in ("entity_class", "entity"):
-                dep_fetcher = TestItemTypeFetchParent(item_type, parent)
+                dep_fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 self._db_mngr.fetch_more(self._db_map, dep_fetcher)
                 dep_fetcher.set_obsolete(True)
-            fetcher = TestItemTypeFetchParent("entity", parent)
+            fetcher = ExampleItemTypeFetchParent("entity", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -254,7 +254,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
             "member_id": self._db_map.entity(entity_class_name="oc", name="obj")["id"],
         }
         with q_object(QObject()) as parent:
-            fetcher = TestItemTypeFetchParent("entity_group", parent)
+            fetcher = ExampleItemTypeFetchParent("entity_group", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -277,10 +277,10 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
         }
         with q_object(QObject()) as parent:
             for item_type in ("entity_class",):
-                dep_fetcher = TestItemTypeFetchParent(item_type, parent)
+                dep_fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 self._db_mngr.fetch_more(self._db_map, dep_fetcher)
                 dep_fetcher.set_obsolete(True)
-            fetcher = TestItemTypeFetchParent("parameter_definition", parent)
+            fetcher = ExampleItemTypeFetchParent("parameter_definition", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_called_once_with({self._db_map: [item]})
@@ -311,10 +311,10 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
         }
         with q_object(QObject()) as parent:
             for item_type in ("entity_class", "entity", "parameter_definition", "alternative"):
-                dep_fetcher = TestItemTypeFetchParent(item_type, parent)
+                dep_fetcher = ExampleItemTypeFetchParent(item_type, parent)
                 self._db_mngr.fetch_more(self._db_map, dep_fetcher)
                 dep_fetcher.set_obsolete(True)
-            fetcher = TestItemTypeFetchParent("parameter_value", parent)
+            fetcher = ExampleItemTypeFetchParent("parameter_value", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_called_once_with({self._db_map: [item]})
@@ -326,7 +326,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
         value_list_id = self._db_map.parameter_value_list(name="value_list")["id"]
         item = {"id": value_list_id, "name": "value_list", "commit_id": 2}
         with q_object(QObject()) as parent:
-            fetcher = TestItemTypeFetchParent("parameter_value_list", parent)
+            fetcher = ExampleItemTypeFetchParent("parameter_value_list", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})
@@ -341,7 +341,7 @@ class TestSpineDBFetcher(TestCaseWithQApplication):
                 "type": value_type,
                 "commit_id": 2,
             }
-            fetcher = TestItemTypeFetchParent("list_value", parent)
+            fetcher = ExampleItemTypeFetchParent("list_value", parent)
             if self._db_mngr.can_fetch_more(self._db_map, fetcher):
                 self._db_mngr.fetch_more(self._db_map, fetcher)
             fetcher.handle_items_added.assert_any_call({self._db_map: [item]})

--- a/tests/widgets/test_AddProjectItemWidget.py
+++ b/tests/widgets/test_AddProjectItemWidget.py
@@ -32,7 +32,7 @@ class TestAddProjectItemWidget(TestCaseWithQApplication):
             patch("spinetoolbox.ui_main.load_project_items") as mock_load_project_items,
         ):
             mock_jump_props_widget.return_value = QWidget()
-            mock_load_project_items.return_value = {TestProjectItem.item_type(): TestItemFactory}
+            mock_load_project_items.return_value = {ExampleProjectItem.item_type(): TestItemFactory}
             self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
 
     def tearDown(self):
@@ -41,11 +41,11 @@ class TestAddProjectItemWidget(TestCaseWithQApplication):
         self._temp_dir.cleanup()
 
     def test_name_field_initially_selected(self):
-        widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=TestProjectItem)
+        widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=ExampleProjectItem)
         self.assertEqual(widget.ui.lineEdit_name.selectedText(), "TestItemType")
 
     def test_find_item_is_used_to_create_prefix(self):
-        widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=TestProjectItem)
+        widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=ExampleProjectItem)
         self.assertEqual(widget.ui.lineEdit_name.text(), "TestItemType")
 
 
@@ -59,8 +59,8 @@ class TestAddProjectItemWidgetWithSpecifications(TestCaseWithQApplication):
             patch("spinetoolbox.ui_main.load_item_specification_factories") as mock_load_specification_factories,
         ):
             mock_jump_props_widget.return_value = QWidget()
-            mock_load_project_items.return_value = {TestProjectItem.item_type(): TestItemFactory}
-            mock_load_specification_factories.return_value = {TestProjectItem.item_type(): TestSpecificationFactory}
+            mock_load_project_items.return_value = {ExampleProjectItem.item_type(): TestItemFactory}
+            mock_load_specification_factories.return_value = {ExampleProjectItem.item_type(): TestSpecificationFactory}
             self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
 
     def tearDown(self):
@@ -69,11 +69,11 @@ class TestAddProjectItemWidgetWithSpecifications(TestCaseWithQApplication):
         self._temp_dir.cleanup()
 
     def test_specifications_combo_box_enabled_if_item_supports_specifications(self):
-        widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=TestProjectItem)
+        widget = AddProjectItemWidget(self._toolbox, 0.0, 0.0, class_=ExampleProjectItem)
         self.assertTrue(widget.ui.comboBox_specification.isEnabled())
 
 
-class TestProjectItem(ProjectItem):
+class ExampleProjectItem(ProjectItem):
     def __init__(self, project):
         super().__init__("item name", "item description", 0.0, 0.0, project)
 
@@ -83,7 +83,7 @@ class TestProjectItem(ProjectItem):
 
     @staticmethod
     def from_dict(name, item_dict, toolbox, project):
-        return TestProjectItem(project)
+        return ExampleProjectItem(project)
 
     def update_name_label(self):
         return
@@ -92,7 +92,7 @@ class TestProjectItem(ProjectItem):
 class TestItemFactory(ProjectItemFactory):
     @staticmethod
     def item_class():
-        return TestProjectItem
+        return ExampleProjectItem
 
     @staticmethod
     def icon():
@@ -112,7 +112,7 @@ class TestItemFactory(ProjectItemFactory):
 
     @staticmethod
     def make_item(name, item_dict, toolbox, project):
-        return TestProjectItem(project)
+        return ExampleProjectItem(project)
 
     @staticmethod
     def make_properties_widget(toolbox):


### PR DESCRIPTION
Add `pytest` to `dev-requirements.txt` and rename test helpers according to `pytest` conventions. `pytest` can now be used in place of `unittest`. The CI also runs `pytest`. The testing documentation is updated.

Fixes #3114

## Future Proofing
To keep the `pytest` compatibility, I would suggest following the [pytest naming conventions](https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery) for tests. Brief summary:

- In the `tests` directory, files are named `test_*.py` or `*_test.py`. We do that already.
- Within those files, `test` prefixed test functions or methods outside of class, and `test` prefixed test functions or methods inside `Test` prefixed test classes (without an `__init__` method) are run.

Rule of thumb: Keeping `test*` prefixes to things that are supposed to be run by the testing framework.


## Related Issues
- https://github.com/spine-tools/spine-items/issues/262
- https://github.com/spine-tools/Spine-Database-API/issues/535
- https://github.com/spine-tools/spine-engine/issues/171

## Related PRs
- https://github.com/spine-tools/spine-items/pull/263
- https://github.com/spine-tools/spine-items/pull/264
- https://github.com/spine-tools/Spine-Database-API/pull/536
- https://github.com/spine-tools/spine-engine/pull/172

## Checklist before merging
- [x] Documentation is up-to-date
- [ ] Release notes have been updated (not applicable)
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass