### PR TITLE
Fix issues with copy/pasting and empty rows in tabular view

### DIFF
--- a/spinetoolbox/mvcmodels/minimal_table_model.py
+++ b/spinetoolbox/mvcmodels/minimal_table_model.py
@@ -77,6 +77,7 @@ class MinimalTableModel(QAbstractTableModel, Generic[T]):
                 return None
         if orientation == Qt.Orientation.Vertical:
             return section + 1
+        raise RuntimeError(f"logic error: unknown orientation {orientation}")
 
     def set_horizontal_header_labels(self, labels: list[str]) -> None:
         """Sets horizontal header labels."""

--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """Helpers and utilities for Spine Database editor."""
+from typing import Union
 from PySide6.QtGui import QColor
 from spinedb_api.helpers import string_to_bool as base_string_to_bool
 
@@ -34,15 +35,17 @@ TRUE_STRING = "true"
 FALSE_STRING = "false"
 
 
-def string_to_bool(x):
+def string_to_bool(x: Union[str, bytes]) -> bool:
     """Converts a 'foreign' string (from e.g. Excel) to boolean.
 
     Args:
-        x (str): string to convert
+        string to convert
 
     Returns:
-        bool: boolean value
+        boolean value
     """
+    if isinstance(x, bytes):
+        x = x.decode()
     try:
         return base_string_to_bool(x)
     except ValueError:

--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -13,7 +13,7 @@
 """Compound models. These models concatenate several 'single' models and one 'empty' model."""
 import bisect
 from collections.abc import Iterable
-from typing import ClassVar
+from typing import ClassVar, Type
 from PySide6.QtCore import QModelIndex, Qt, QTimer, Slot
 from PySide6.QtGui import QFont
 from spinedb_api.parameter_value import join_value_and_type
@@ -80,13 +80,12 @@ class CompoundStackedModel(CompoundTableModel):
         return self._column_filters
 
     @property
-    def _single_model_type(self):
-        """
-        Returns a constructor for the single models.
+    def group_fields(self) -> Iterable[str]:
+        return self._single_model_type.group_fields
 
-        Returns:
-            SingleParameterModel
-        """
+    @property
+    def _single_model_type(self) -> Type[SingleModelBase]:
+        """Returns a constructor for the single models."""
         raise NotImplementedError()
 
     def canFetchMore(self, _parent):

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -150,30 +150,7 @@ class EmptyModelBase(EmptyRowModel):
                 removed_rows.append(row)
         for row, count in sorted(rows_to_row_count_tuples(removed_rows), reverse=True):
             self.do_remove_rows(row, count)
-        clean_index = self._undo_stack.cleanIndex()
-        removed_row_set = set(removed_rows)
-        new_clean_index = -1
-        for command_index in range(self._undo_stack.count()):
-            command = self._undo_stack.command(command_index)
-            if command_index > clean_index:
-                command.setObsolete(True)
-            else:
-                if hasattr(command, "rows_dropped"):
-                    command.rows_dropped(removed_row_set)
-                    if not command.isObsolete():
-                        new_clean_index = command_index
-                else:
-                    children_obsolete = True
-                    for child_index in range(command.childCount()):
-                        child_command = command.child(child_index)
-                        if hasattr(child_command, "rows_dropped"):
-                            child_command.rows_dropped(removed_row_set)
-                            if not child_command.isObsolete():
-                                new_clean_index = command_index
-                                children_obsolete = False
-                    if children_obsolete:
-                        command.setObsolete(True)
-        self._undo_stack.setIndex(new_clean_index)
+        self._undo_stack.clear()
 
     def batch_set_data(self, indexes, data):
         """Sets data for indexes in batch. If successful, add items to db."""

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -212,8 +212,8 @@ class SingleModelBase(HalfSortedTableModel):
                     return plain_to_rich(description)
             mapped_field = self._mapped_field(field)
             data = item.get(mapped_field)
-            if data and field in self.group_fields:
-                data = DB_ITEM_SEPARATOR.join(data)
+            if field in self.group_fields:
+                data = DB_ITEM_SEPARATOR.join(data) if data else None
             return data
         if role == Qt.ItemDataRole.DecorationRole and field == "entity_class_name":
             return self.db_mngr.entity_class_icon(self.db_map, self.entity_class_id)
@@ -226,17 +226,11 @@ class SingleModelBase(HalfSortedTableModel):
         Sets data directly in database using db mngr. If successful, updated data will be
         automatically seen by the data method.
         """
-
-        def split_value(value, column):
-            if self.header[column] in self.group_fields:
-                return tuple(value.split(DB_ITEM_SEPARATOR)) if value else ()
-            return value
-
         if not indexes or not data:
             return False
         row_data = {}
         for index, value in zip(indexes, data):
-            row_data.setdefault(index.row(), {})[self.header[index.column()]] = split_value(value, index.column())
+            row_data.setdefault(index.row(), {})[self.header[index.column()]] = value
         items = [{"id": self._main_data[row], **data} for row, data in row_data.items()]
         self.update_items_in_db(items)
         return True

--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
@@ -1,17 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-######################################################################################################################
-# Copyright (C) 2017-2022 Spine project consortium
-# Copyright Spine Toolbox contributors
-# This file is part of Spine Toolbox.
-# Spine Toolbox is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
-# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
-# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
-# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
-# this program. If not, see <http:\/\/www.gnu.org\/licenses\/>.
-######################################################################################################################
--->
 <ui version="4.0">
  <class>MainWindow</class>
  <widget class="QMainWindow" name="MainWindow">
@@ -856,6 +843,36 @@
    <addaction name="menuEdit"/>
    <addaction name="menuSession"/>
    <addaction name="menuHelp"/>
+  </widget>
+  <widget class="QDockWidget" name="entity_dock_widget">
+   <property name="windowTitle">
+    <string>Entity</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_4">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QTableView" name="entity_table_view"/>
+     </item>
+    </layout>
+   </widget>
   </widget>
   <action name="actionCommit">
    <property name="enabled">

--- a/tests/spine_db_editor/mvcmodels/test_compound_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_compound_models.py
@@ -47,7 +47,7 @@ class TestCompoundParameterDefinitionModel(TestBase):
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.columnCount(), 7)
         row = [model.index(0, column).data() for column in range(model.columnCount())]
-        expected = ["oc", "p", (), None, "None", None, self.db_codename]
+        expected = ["oc", "p", None, None, "None", None, self.db_codename]
         self.assertEqual(row, expected)
 
     def test_data_for_single_parameter_definition_in_multidimensional_entity_class(self):
@@ -61,7 +61,7 @@ class TestCompoundParameterDefinitionModel(TestBase):
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.columnCount(), 7)
         row = [model.index(0, column).data() for column in range(model.columnCount())]
-        expected = ["rc", "p", (), None, "None", None, self.db_codename]
+        expected = ["rc", "p", None, None, "None", None, self.db_codename]
         self.assertEqual(row, expected)
 
     def test_model_updates_when_entity_class_is_removed(self):

--- a/tests/spine_db_editor/test_helpers.py
+++ b/tests/spine_db_editor/test_helpers.py
@@ -28,6 +28,8 @@ class TestStringToBool(unittest.TestCase):
         self.assertTrue(string_to_bool("TRUE"))
         self.assertFalse(string_to_bool("false"))
         self.assertFalse(string_to_bool(""))
+        self.assertTrue(string_to_bool(b"true"))
+        self.assertFalse(string_to_bool(b"false"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes copy/pasting issues in Parameter definition table (due to "valid types" column). Also, the undo stack of the empty tables get cleared every time rows are filled fixing some issues and simplifying code considerably.

Fixes #3008

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
