### PR TITLE
Fix copy/pasting issues in DB editor

### DIFF
--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -13,7 +13,8 @@
 """General helper functions and classes."""
 from __future__ import annotations
 import bisect
-from collections.abc import Callable, Iterable
+import collections
+from collections.abc import Callable, Iterable, Mapping
 from contextlib import contextmanager
 import datetime
 from enum import Enum, unique
@@ -421,7 +422,9 @@ def recursive_overwrite(logger: LoggerInterface, src: str, dst: str, silent: boo
         shutil.copyfile(src, dst)
 
 
-def tuple_itemgetter(itemgetter_func: Callable[..., Any], num_indexes: int) -> Callable[..., tuple]:
+def tuple_itemgetter(
+    itemgetter_func: Callable[[Union[Sequence, Mapping]], Any], num_indexes: int
+) -> Callable[[Union[Sequence, Mapping]], tuple]:
     """Change output of itemgetter to always be a tuple even for a single index.
 
     Args:
@@ -1428,6 +1431,7 @@ def disconnect(signal, *slots):
     try:
         yield
     finally:
+        # PyCharm thinks this code is unreachable; however, unit tests show that it works just fine.
         for slot in slots:
             signal.connect(slot)
 
@@ -1447,6 +1451,10 @@ class SignalWaiter(QObject):
         self._condition = condition
         self._timeout = timeout
         self._start = time.monotonic() if self._timeout is not None else None
+
+    @property
+    def triggered(self) -> bool:
+        return self._triggered
 
     def trigger(self, *args):
         """Signal receiving slot."""
@@ -1513,7 +1521,7 @@ class CustomSyntaxHighlighter(QSyntaxHighlighter):
 
     def yield_formats(self, text):
         if self.lexer is None:
-            return ()
+            return
         for start, ttype, subtext in self.lexer.get_tokens_unprocessed(text):
             while True:
                 text_format = self._formats.get(ttype)

--- a/spinetoolbox/mvcmodels/empty_row_model.py
+++ b/spinetoolbox/mvcmodels/empty_row_model.py
@@ -22,7 +22,7 @@ class EmptyRowModel(MinimalTableModel):
     def __init__(self, parent: Optional[QObject] = None, header: Optional[list[str]] = None):
         super().__init__(parent, header=header)
         self.default_row = {}  # A row of default values to put in any newly inserted row
-        self.force_default = False  # Whether or not default values are editable
+        self.force_default = False  # Whether default values are editable
         self._fetched = False
         self.dataChanged.connect(self._handle_data_changed)
         self.rowsInserted.connect(self._handle_rows_inserted)

--- a/spinetoolbox/spine_db_editor/graphics_items.py
+++ b/spinetoolbox/spine_db_editor/graphics_items.py
@@ -370,7 +370,7 @@ class EntityItem(QGraphicsRectItem):
             return {}
         return {
             "entity_class_name": self.entity_class_name,
-            "entity_byname": DB_ITEM_SEPARATOR.join(self.byname),
+            "entity_byname": self.byname,
             "database": self.db_mngr.name_registry.display_name(self.first_db_map.sa_url),
         }
 

--- a/spinetoolbox/spine_db_editor/helpers.py
+++ b/spinetoolbox/spine_db_editor/helpers.py
@@ -11,19 +11,21 @@
 ######################################################################################################################
 
 """Helpers and utilities for Spine Database editor."""
-from typing import Union
+import locale
+from typing import Any, Optional, Union
 from PySide6.QtGui import QColor
 from spinedb_api.helpers import string_to_bool as base_string_to_bool
+from spinetoolbox.helpers import DB_ITEM_SEPARATOR
 
 
-def string_to_display_icon(x):
+def string_to_display_icon(x: str) -> Optional[int]:
     """Converts a 'foreign' string (from e.g. Excel) to entity class display icon.
 
     Args:
-        x (str): string to convert
+        x: string to convert
 
     Returns:
-        int: display icon or None if conversion failed
+        display icon or None if conversion failed
     """
     try:
         return int(x)
@@ -52,7 +54,65 @@ def string_to_bool(x: Union[str, bytes]) -> bool:
         return False
 
 
-def table_name_from_item_type(item_type):
+def bool_to_string(x: bool) -> str:
+    return TRUE_STRING if x else FALSE_STRING
+
+
+def optional_to_string(x: Optional[Any]) -> Optional[str]:
+    return str(x) if x is not None else None
+
+
+def group_to_string(types: Union[str, tuple[str, ...]]) -> Optional[str]:
+    if not types:
+        return None
+    if isinstance(types, str):
+        return types
+    return DB_ITEM_SEPARATOR.join(types)
+
+
+def string_to_group(types: Optional[str]) -> Union[str, tuple[str, ...]]:
+    if not types:
+        return ()
+    separator = DB_ITEM_SEPARATOR if DB_ITEM_SEPARATOR in types else ","
+    return tuple(stripped for t in types.split(separator) if (stripped := t.strip()))
+
+
+def parameter_value_to_string(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    try:
+        number = float(value)
+        return locale.str(number)
+    except ValueError:
+        return str(value)
+
+
+def string_to_parameter_value(str_value: str) -> Any:
+    try:
+        return float(str_value)
+    except ValueError:
+        try:
+            return locale.atof(str_value)
+        except ValueError:
+            pass
+    if str_value == TRUE_STRING:
+        return True
+    if str_value == FALSE_STRING:
+        return False
+    return str_value
+
+
+def input_string_to_int(str_value: str) -> int:
+    try:
+        x = float(str_value)
+    except ValueError:
+        x = locale.atof(str_value)
+    return int(round(x))
+
+
+def table_name_from_item_type(item_type: str) -> str:
     """Returns the dock widgets headers text for the given item type"""
     return {
         "parameter_value": "Parameter value",

--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -245,6 +245,11 @@ class EmptyModelBase(EmptyRowModel):
                 iter(x for x in self.db_mngr.db_maps if self.db_mngr.name_registry.display_name(x.sa_url) == database),
                 None,
             )
+        if (role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.ToolTipRole) and self.header[
+            index.column()
+        ] in self.group_fields:
+            data = super().data(index, role)
+            return DB_ITEM_SEPARATOR.join(data) if data else None
         return super().data(index, role)
 
     def _convert_to_db(self, item: dict) -> dict:

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -268,7 +268,7 @@ class EntityItem(MultiDBTreeItem):
             return {"database": db_name}
         return {
             "entity_class_name": item["entity_class_name"],
-            "entity_byname": DB_ITEM_SEPARATOR.join(item["entity_byname"]),
+            "entity_byname": item["entity_byname"],
             "database": db_name,
         }
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_models.py
@@ -36,7 +36,7 @@ class EntityTreeModel(MultiDBTreeModel):
         # Get all ancestors
         el_item = ent_item.parent_item
         if el_item.item_type != "entity":
-            return
+            return None
         for db_map in ent_item.db_maps:
             # Get data from ancestors
             ent_data = ent_item.db_map_data(db_map)
@@ -54,6 +54,7 @@ class EntityTreeModel(MultiDBTreeModel):
             for parent_item in self.find_items(db_map, (dimension_id, element_id), fetch=True):
                 for item in parent_item.find_children(lambda child: child.display_id == ent_item.display_id):
                     return self.index_from_item(item)
+        return None
 
     def save_hide_empty_classes(self):
         hide_empty_classes = "true" if self.hide_empty_classes else "false"

--- a/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model_base.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/metadata_table_model_base.py
@@ -124,7 +124,7 @@ class MetadataTableModelBase(QAbstractTableModel):
     def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         column = index.column()
         row = index.row()
-        if role == Qt.ItemDataRole.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.EditRole:
             if column == Column.DB_MAP:
                 db_map = self._data[row][column] if row < len(self._data) else self._adder_row[column]
                 return self._db_mngr.name_registry.display_name(db_map.sa_url) if db_map is not None else ""
@@ -487,3 +487,9 @@ class MetadataTableModelBase(QAbstractTableModel):
                 continue
             reserved.setdefault(db_map, {})[name] = value
         return reserved
+
+    def begin_paste(self):
+        pass
+
+    def end_paste(self):
+        pass

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_model.py
@@ -11,7 +11,9 @@
 ######################################################################################################################
 
 """Provides PivotModel."""
+from collections.abc import Callable, Mapping, Sequence
 import operator
+from typing import Optional, Union
 from ...helpers import tuple_itemgetter
 
 
@@ -25,7 +27,8 @@ class PivotModel:
         self.pivot_columns = ()  # current selected columns indexes
         self.pivot_frozen = ()  # current filtered frozen indexes
         self.frozen_value = ()  # current selected value of index_frozen
-        self._key_getter = None  # operator.itemgetter placeholder used to translate pivot to keys in _data
+        # operator.itemgetter placeholder used to translate pivot to keys in _data
+        self._key_getter: Optional[Callable[[Union[Mapping, Sequence]], tuple]] = None
         self._row_data_header = []  # header values for row data
         self._column_data_header = []  # header values for column data
 

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -212,7 +212,7 @@ class SingleModelBase(HalfSortedTableModel):
                     return plain_to_rich(description)
             mapped_field = self._mapped_field(field)
             data = item.get(mapped_field)
-            if field in self.group_fields:
+            if field in self.group_fields and role != Qt.ItemDataRole.EditRole:
                 data = DB_ITEM_SEPARATOR.join(data) if data else None
             return data
         if role == Qt.ItemDataRole.DecorationRole and field == "entity_class_name":

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -37,10 +37,10 @@ from spinedb_api import DatabaseMapping
 from spinedb_api.helpers import name_from_dimensions, name_from_elements
 from ...helpers import DB_ITEM_SEPARATOR
 from ...mvcmodels.minimal_table_model import MinimalTableModel
-from ..helpers import string_to_bool, string_to_display_icon
 from ..mvcmodels.compound_table_model import CompoundTableModel
 from ..mvcmodels.empty_models import EmptyAddEntityOrClassRowModel
 from .custom_delegates import ManageEntitiesDelegate, ManageEntityClassesDelegate
+from .custom_qtableview import ManageEntityClassesTable
 from .manage_items_dialogs import (
     DialogWithTableAndButtons,
     GetEntitiesMixin,
@@ -90,12 +90,12 @@ class AddReadyEntitiesDialog(DialogWithTableAndButtons):
         self.table_view.verticalHeader().hide()
         for row, entity in enumerate(self.entities):
             item = QTableWidgetItem()
-            item.setFlags(Qt.ItemIsEnabled)
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled)
             item.setCheckState(Qt.CheckState.Checked)
             self.table_view.setItem(row, 0, item)
             for column, element_byname in enumerate(entity):
                 item = QTableWidgetItem(DB_ITEM_SEPARATOR.join(element_byname))
-                item.setFlags(Qt.ItemIsEnabled)
+                item.setFlags(Qt.ItemFlag.ItemIsEnabled)
                 self.table_view.setItem(row, column + 1, item)
         self.table_view.resizeColumnsToContents()
         self.resize_window_to_columns()
@@ -152,7 +152,7 @@ class AddItemsDialog(ManageItemsDialog):
         self.db_maps = db_maps
         self.keyed_db_maps = db_mngr.name_registry.map_display_names_to_db_maps(db_maps)
         self.remove_rows_button = QToolButton(self)
-        self.remove_rows_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.remove_rows_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.remove_rows_button.setText("Remove selected rows")
 
     def _populate_layout(self):
@@ -189,8 +189,6 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
         """
         super().__init__(parent, db_mngr, *db_maps)
         self.setWindowTitle("Add entity classes")
-        self.table_view.set_column_converter_for_pasting("display icon", string_to_display_icon)
-        self.table_view.set_column_converter_for_pasting("active by default", string_to_bool)
         self.model = EmptyAddEntityOrClassRowModel(self)
         self.model.force_default = force_default
         self.table_view.setModel(self.model)
@@ -221,6 +219,11 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
             }
         )
         self.model.clear()
+
+    def make_table_view(self):
+        table_view = ManageEntityClassesTable(self)
+        table_view.init_copy_and_paste_actions()
+        return table_view
 
     def _populate_layout(self):
         self.layout().addWidget(self.dimension_count_widget, 0, 0, 1, -1)

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -13,11 +13,12 @@
 """Custom QTableView classes that support copy-paste and the like."""
 from collections.abc import Iterable
 from dataclasses import replace
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional, Union
 from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, QPoint, Qt, QTimer, Signal, Slot
 from PySide6.QtGui import QAction, QKeySequence, QUndoStack
 from PySide6.QtWidgets import QHeaderView, QMenu, QTableView, QWidget
 from ...helpers import DB_ITEM_SEPARATOR, preferred_row_height, rows_to_row_count_tuples
+from ...mvcmodels.minimal_table_model import MinimalTableModel
 from ...plotting import (
     ParameterTableHeaderSection,
     PlottingError,
@@ -28,14 +29,27 @@ from ...widgets.custom_qtableview import AutoFilterCopyPasteTableView, CopyPaste
 from ...widgets.custom_qwidgets import TitleWidgetAction
 from ...widgets.plot_widget import PlotWidget, prepare_plot_in_window_menu
 from ...widgets.report_plotting_failure import report_plotting_failure
-from ..helpers import string_to_bool
+from ..helpers import (
+    bool_to_string,
+    group_to_string,
+    input_string_to_int,
+    optional_to_string,
+    parameter_value_to_string,
+    string_to_bool,
+    string_to_display_icon,
+    string_to_group,
+    string_to_parameter_value,
+)
+from ..mvcmodels.empty_models import EmptyModelBase
 from ..mvcmodels.metadata_table_model_base import Column as MetadataColumn
 from ..mvcmodels.pivot_table_models import (
     ElementPivotTableModel,
     IndexExpansionPivotTableModel,
     ParameterValuePivotTableModel,
+    PivotTableSortFilterProxy,
     ScenarioAlternativePivotTableModel,
 )
+from ..mvcmodels.single_models import SingleModelBase
 from ..mvcmodels.utils import height_limited_size_hint
 from .custom_delegates import (
     AlternativeNameDelegate,
@@ -92,10 +106,12 @@ class StackedTableView(AutoFilterCopyPasteTableView):
         self.create_delegates()
         self.selectionModel().selectionChanged.connect(self._refresh_copy_paste_actions)
 
-    def setModel(self, model):
-        super().setModel(model)
-        for field in model.group_fields:
-            self.set_column_converter_for_pasting(field, convert_pasted_group_fields)
+    def _convert_copied(
+        self, row: int, column: int, value: Any, model: Union[SingleModelBase, EmptyModelBase]
+    ) -> Optional[str]:
+        if model.header[column] in model.group_fields:
+            return group_to_string(value)
+        return super()._convert_copied(row, column, value, model)
 
     def _make_delegate(self, column_name, delegate_class):
         """Creates a delegate for the given column and returns it.
@@ -224,13 +240,6 @@ class StackedTableView(AutoFilterCopyPasteTableView):
         self.setColumnHidden(self._EXPECTED_COLUMN_COUNT - 1, not visible)
 
 
-def convert_pasted_group_fields(types: Optional[str]) -> tuple[str, ...]:
-    if not types:
-        return ()
-    separator = DB_ITEM_SEPARATOR if DB_ITEM_SEPARATOR in types else ","
-    return tuple(t.strip() for t in types.split(separator))
-
-
 class ParameterTableView(StackedTableView):
     value_column_header: ClassVar[str] = NotImplemented
     """Either "default_value" or "value". Used to identify the value column for advanced editing and plotting."""
@@ -241,6 +250,22 @@ class ParameterTableView(StackedTableView):
         self._plot_action = None
         self._plot_separator = None
         self.pinned_values = []
+
+    def _convert_copied(self, row: int, column: int, value: Any, model: MinimalTableModel) -> Optional[str]:
+        header = model.header[column]
+        if header == self.value_column_header:
+            return parameter_value_to_string(value)
+        if header == "entity_byname":
+            return group_to_string(value)
+        return super()._convert_copied(row, column, value, model)
+
+    def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
+        header = model.header[column]
+        if header == self.value_column_header:
+            return string_to_parameter_value(str_value)
+        if header == "entity_byname":
+            return string_to_group(str_value)
+        return super()._convert_pasted(row, column, str_value, model)
 
     def populate_context_menu(self):
         """Creates a context menu for this view."""
@@ -451,12 +476,24 @@ class EntityAlternativeTableViewBase(StackedTableView):
         self._make_delegate("alternative_name", AlternativeNameDelegate)
         self._make_delegate("active", BooleanValueDelegate)
 
+    def _convert_copied(self, row: int, column: int, value: Any, model: MinimalTableModel) -> Optional[str]:
+        header = model.header[column]
+        if header == "entity_byname":
+            return group_to_string(value)
+        if header == "active":
+            return bool_to_string(value) if value is not None else None
+        return super()._convert_copied(row, column, value, model)
+
+    def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
+        header = model.header[column]
+        if header == "entity_byname":
+            return string_to_group(str_value)
+        if header == "active":
+            return string_to_bool(str_value)
+        return super()._convert_pasted(row, column, str_value, model)
+
 
 class EmptyEntityAlternativeTableView(WithUndoStack, EntityAlternativeTableViewBase):
-    def __init__(self, parent):
-        super().__init__(parent)
-        self.set_column_converter_for_pasting("active", string_to_bool)
-
     def sizeHint(self, /):
         return height_limited_size_hint(super().sizeHint(), self.parent().size())
 
@@ -466,10 +503,6 @@ class EmptyEntityAlternativeTableView(WithUndoStack, EntityAlternativeTableViewB
 
 class EntityAlternativeTableView(EntityAlternativeTableViewBase):
     """Visualize entities and their alternatives."""
-
-    def __init__(self, parent):
-        super().__init__(parent)
-        self.set_column_converter_for_pasting("active", string_to_bool)
 
 
 class PivotTableView(CopyPasteTableView):
@@ -559,6 +592,14 @@ class PivotTableView(CopyPasteTableView):
             """Enables/disables context menu entries before the menu is shown."""
             raise NotImplementedError()
 
+        def convert_copied(self, row: int, column: int, value: Any, model: PivotTableSortFilterProxy) -> Optional[str]:
+            return value if value is not None else ""
+
+        def convert_pasted(
+            self, row: int, column: int, str_value: Optional[str], model: PivotTableSortFilterProxy
+        ) -> Any:
+            return str_value
+
     class _EntityContextBase(_ContextBase):
         """Base class for contexts that contain entities and entity classes."""
 
@@ -596,6 +637,22 @@ class PivotTableView(CopyPasteTableView):
         def _update_actions_availability(self):
             """See base class."""
             raise NotImplementedError()
+
+        def convert_copied(self, row: int, column: int, value: Any, model: PivotTableSortFilterProxy) -> Optional[str]:
+            if value is None:
+                return None
+            pivot_model = model.sourceModel()
+            if pivot_model.index_in_data_or_empty_data(pivot_model.index(row, column)):
+                return bool_to_string(value)
+            return super().convert_copied(row, column, value, model)
+
+        def convert_pasted(
+            self, row: int, column: int, str_value: Optional[str], model: PivotTableSortFilterProxy
+        ) -> Any:
+            pivot_model = model.sourceModel()
+            if pivot_model.index_in_data_or_empty_data(pivot_model.index(row, column)):
+                return string_to_bool(str_value)
+            return super().convert_pasted(row, column, str_value, model)
 
     class _ParameterValueContext(_EntityContextBase):
         """Context for showing parameter values in the pivot table."""
@@ -734,6 +791,20 @@ class PivotTableView(CopyPasteTableView):
             self._remove_entities_action.setEnabled(has_selection)
             self._remove_alternatives_action.setEnabled(has_selection)
 
+        def convert_copied(self, row: int, column: int, value: Any, model: PivotTableSortFilterProxy) -> Optional[str]:
+            pivot_model = model.sourceModel()
+            if pivot_model.index_in_data_or_empty_data(pivot_model.index(row, column)):
+                return parameter_value_to_string(value)
+            return super().convert_copied(row, column, value, model)
+
+        def convert_pasted(
+            self, row: int, column: int, str_value: Optional[str], model: PivotTableSortFilterProxy
+        ) -> Any:
+            pivot_model = model.sourceModel()
+            if pivot_model.index_in_data_or_empty_data(pivot_model.index(row, column)):
+                return string_to_parameter_value(str_value)
+            return super().convert_pasted(row, column, str_value, model)
+
     class _IndexExpansionContext(_ParameterValueContext):
         """Context for expanded parameter values"""
 
@@ -859,6 +930,27 @@ class PivotTableView(CopyPasteTableView):
             checked = len(selected) * [not all(selected)]
             source_model.batch_set_data(self._selected_scenario_alternative_indexes, checked)
 
+        def convert_copied(self, row: int, column: int, value: Any, model: PivotTableSortFilterProxy) -> Optional[str]:
+            if value is None:
+                return None
+            pivot_model = model.sourceModel()
+            if pivot_model.index_in_data_or_empty_data(pivot_model.index(row, column)):
+                if isinstance(value, bool):
+                    return bool_to_string(value)
+                return str(value)
+            return super().convert_copied(row, column, value, model)
+
+        def convert_pasted(
+            self, row: int, column: int, str_value: Optional[str], model: PivotTableSortFilterProxy
+        ) -> Any:
+            pivot_model = model.sourceModel()
+            if pivot_model.index_in_data_or_empty_data(pivot_model.index(row, column)):
+                try:
+                    return input_string_to_int(str_value)
+                except ValueError:
+                    return False
+            return super().convert_pasted(row, column, str_value, model)
+
     def __init__(self, parent=None):
         """
         Args:
@@ -873,7 +965,7 @@ class PivotTableView(CopyPasteTableView):
         self._top_header_table.setObjectName("top")
         self._top_left_header_table.setObjectName("top-left")
         self._spine_db_editor = None
-        self._context = None
+        self._context: Optional[PivotTableView._ContextBase] = None
         self._fetch_more_timer = QTimer(self)
         self._fetch_more_timer.setSingleShot(True)
         self._fetch_more_timer.setInterval(100)
@@ -884,10 +976,10 @@ class PivotTableView(CopyPasteTableView):
         self.horizontalScrollBar().valueChanged.connect(self._top_header_table.horizontalScrollBar().setValue)
         # NOTE: order of the iteration below is important for calls to stackUnder
         for header_table in (self._top_left_header_table, self._top_header_table, self._left_header_table):
-            header_table.setFocusPolicy(Qt.NoFocus)
+            header_table.setFocusPolicy(Qt.FocusPolicy.NoFocus)
             header_table.setStyleSheet(self.styleSheet())
-            header_table.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-            header_table.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+            header_table.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            header_table.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
             header_table.show()
             header_table.verticalHeader().hide()
             header_table.horizontalHeader().hide()
@@ -896,7 +988,7 @@ class PivotTableView(CopyPasteTableView):
             header_table.setStyleSheet("QTableView { border: none;}")
             self.viewport().stackUnder(header_table)
         for header_table in (self._top_header_table, self._left_header_table):
-            header_table.setAttribute(Qt.WA_TransparentForMouseEvents)
+            header_table.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
         header = self.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
 
@@ -1060,14 +1152,20 @@ class PivotTableView(CopyPasteTableView):
     def _refresh_copy_paste_actions(self, _, __):
         self._spine_db_editor.refresh_copy_paste_actions()
 
+    def _convert_copied(self, row: int, column: int, value: Any, model: MinimalTableModel) -> Optional[str]:
+        return self._context.convert_copied(row, column, value, model)
+
+    def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
+        return self._context.convert_pasted(row, column, str_value, model)
+
 
 class FrozenTableView(QTableView):
     header_dropped = Signal(QWidget, QWidget)
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional[QWidget] = None):
         """
         Args:
-            parent (QWidget): parent widget
+            parent: parent widget
         """
         super().__init__(parent)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
@@ -1091,10 +1189,10 @@ class FrozenTableView(QTableView):
 class MetadataTableViewBase(CopyPasteTableView):
     """Base for metadata and item metadata table views."""
 
-    def __init__(self, parent):
+    def __init__(self, parent: Optional[QWidget]):
         """
         Args:
-            parent (QWidget, optional): parent widget
+            parent: parent widget
         """
         super().__init__(parent)
         horizontal_header = self.horizontalHeader()
@@ -1213,3 +1311,21 @@ class ItemMetadataTableView(MetadataTableViewBase):
         database_column_delegate = DatabaseNameDelegate(self, db_editor.db_mngr)
         self.setItemDelegateForColumn(MetadataColumn.DB_MAP, database_column_delegate)
         database_column_delegate.data_committed.connect(self._set_model_data)
+
+
+class ManageEntityClassesTable(CopyPasteTableView):
+    def _convert_copied(self, row: int, column: int, value: Any, model: MinimalTableModel) -> Optional[str]:
+        header = model.header[column]
+        if header == "display icon":
+            return optional_to_string(value)
+        if header == "active by default":
+            return bool_to_string(value) if value is not None else None
+        return super()._convert_copied(row, column, value, model)
+
+    def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
+        header = model.header[column]
+        if header == "display icon":
+            return string_to_display_icon(str_value)
+        if header == "active by default":
+            return string_to_bool(str_value)
+        return super()._convert_pasted(row, column, str_value, model)

--- a/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/edit_or_remove_items_dialogs.py
@@ -15,8 +15,9 @@ from PySide6.QtCore import Slot
 from PySide6.QtWidgets import QComboBox, QTabWidget, QVBoxLayout
 from ...helpers import DB_ITEM_SEPARATOR, default_icon_id
 from ...mvcmodels.minimal_table_model import MinimalTableModel
-from ..helpers import string_to_bool, string_to_display_icon
+from ..helpers import bool_to_string, optional_to_string, string_to_bool, string_to_display_icon
 from .custom_delegates import ManageEntitiesDelegate, ManageEntityClassesDelegate, RemoveEntitiesDelegate
+from .custom_qtableview import ManageEntityClassesTable
 from .manage_items_dialogs import (
     DialogWithButtons,
     GetEntitiesMixin,
@@ -49,8 +50,6 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
         """
         super().__init__(parent, db_mngr)
         self.setWindowTitle("Edit entity classes")
-        self.table_view.set_column_converter_for_pasting("display icon", string_to_display_icon)
-        self.table_view.set_column_converter_for_pasting("active by default", string_to_bool)
         self.model = MinimalTableModel(self)
         self.table_view.setModel(self.model)
         self.table_view.setItemDelegate(ManageEntityClassesDelegate(self))
@@ -69,6 +68,11 @@ class EditEntityClassesDialog(ShowIconColorEditorMixin, EditOrRemoveItemsDialog)
             model_data.append(row_data)
             self.items.append(item)
         self.model.reset_model(model_data)
+
+    def make_table_view(self):
+        table_view = ManageEntityClassesTable(self)
+        table_view.init_copy_and_paste_actions()
+        return table_view
 
     def connect_signals(self):
         super().connect_signals()

--- a/spinetoolbox/spine_db_editor/widgets/element_name_list_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/element_name_list_editor.py
@@ -88,6 +88,6 @@ class ElementNameListEditor(ManageItemsDialog):
     @Slot()
     def accept(self):
         self._index.model().setData(
-            self._index, DB_ITEM_SEPARATOR.join(self.model.index(0, j).data() for j in range(self.model.columnCount()))
+            self._index, tuple(self.model.index(0, j).data() for j in range(self.model.columnCount()))
         )
         super().accept()

--- a/spinetoolbox/spine_db_editor/widgets/metadata_editor.py
+++ b/spinetoolbox/spine_db_editor/widgets/metadata_editor.py
@@ -28,7 +28,7 @@ class MetadataEditor:
         self._db_editor = db_editor
         self._metadata_table_view = metadata_table_view
         self._metadata_table_model = MetadataTableModel(db_mngr, db_editor.db_maps, db_editor)
-        self._metadata_table_view.sortByColumn(-1, Qt.AscendingOrder)
+        self._metadata_table_view.sortByColumn(-1, Qt.SortOrder.AscendingOrder)
         self._metadata_table_view.setModel(self._metadata_table_model)
         self._metadata_table_view.connect_spine_db_editor(db_editor)
 

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -121,7 +121,7 @@ class StackedViewMixin:
             entity = db_map.get_item(
                 "entity",
                 entity_class_name=entity_class["name"],
-                entity_byname=tuple(entity_byname.split(DB_ITEM_SEPARATOR)),
+                entity_byname=tuple(entity_byname),
             )
             current_element_byname_list = entity["element_byname_list"] if entity else []
         else:

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -14,16 +14,20 @@
 from collections import namedtuple
 from contextlib import contextmanager
 from itertools import chain
+from typing import ClassVar, Optional
 from PySide6.QtCore import QModelIndex, Qt, QTimer, Slot
 from PySide6.QtGui import QAction, QActionGroup
 from PySide6.QtWidgets import QWidget
+from spinedb_api import DatabaseMapping
 from spinedb_api.helpers import fix_name_ambiguity
+from spinedb_api.temp_id import TempId
 from ...helpers import busy_effect, disconnect, preferred_row_height
 from ..mvcmodels.frozen_table_model import FrozenTableModel
 from ..mvcmodels.pivot_table_models import (
     ElementPivotTableModel,
     IndexExpansionPivotTableModel,
     ParameterValuePivotTableModel,
+    PivotTableModelBase,
     PivotTableSortFilterProxy,
     ScenarioAlternativePivotTableModel,
 )
@@ -34,14 +38,14 @@ from .tabular_view_header_widget import TabularViewHeaderWidget
 class TabularViewMixin:
     """Provides the pivot table and its frozen table for the Database editor."""
 
-    _PARAMETER_VALUE = "&Value"
-    _INDEX_EXPANSION = "&Index"
-    _ELEMENT = "E&lement"
-    _SCENARIO_ALTERNATIVE = "&Scenario"
+    _PARAMETER_VALUE: ClassVar[str] = "&Value"
+    _INDEX_EXPANSION: ClassVar[str] = "&Index"
+    _ELEMENT: ClassVar[str] = "E&lement"
+    _SCENARIO_ALTERNATIVE: ClassVar[str] = "&Scenario"
 
-    _PARAMETER = "parameter"
-    _ALTERNATIVE = "alternative"
-    _INDEX = "index"
+    _PARAMETER: ClassVar[str] = "parameter"
+    _ALTERNATIVE: ClassVar[str] = "alternative"
+    _INDEX: ClassVar[str] = "index"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -52,8 +56,8 @@ class TabularViewMixin:
             self._SCENARIO_ALTERNATIVE: ScenarioAlternativePivotTableModel(self),
         }
         self._pending_reload = False
-        self.current_class_id = {}  # Mapping from db_map to class_id
-        self.current_class_name = None
+        self.current_class_id: dict[DatabaseMapping, TempId] = {}  # Mapping from db_map to class_id
+        self.current_class_name: Optional[str] = None
         self.current_input_type = self._PARAMETER_VALUE
         self.filter_menus = {}
         self.class_pivot_preferences = {}
@@ -62,7 +66,7 @@ class TabularViewMixin:
         self.pivot_actions = {}
         self.populate_pivot_action_group()
         self.pivot_table_proxy = PivotTableSortFilterProxy()
-        self.pivot_table_model = None
+        self.pivot_table_model: Optional[PivotTableModelBase] = None
         self.frozen_table_model = FrozenTableModel(self.db_mngr, self)
         self._disable_frozen_table_reload = False
         self.ui.pivot_table.setModel(self.pivot_table_proxy)

--- a/spinetoolbox/widgets/custom_qtableview.py
+++ b/spinetoolbox/widgets/custom_qtableview.py
@@ -11,7 +11,6 @@
 ######################################################################################################################
 
 """Custom QTableView classes that support copy-paste and the like."""
-from collections.abc import Callable, Iterable
 from contextlib import contextmanager, suppress
 import csv
 import ctypes
@@ -24,7 +23,7 @@ import re
 from typing import Any, Optional
 from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, QPoint, Qt, Slot
 from PySide6.QtGui import QAction, QIcon, QKeySequence
-from PySide6.QtWidgets import QAbstractItemView, QApplication, QTableView
+from PySide6.QtWidgets import QAbstractItemView, QApplication, QTableView, QWidget
 from spinedb_api import (
     DateTime,
     Duration,
@@ -35,8 +34,8 @@ from spinedb_api import (
     to_database,
 )
 from spinedb_api.parameter_value import FLOAT_VALUE_TYPE, join_value_and_type, split_value_and_type
-from ..helpers import busy_effect
 from ..mvcmodels.empty_row_model import EmptyRowModel
+from ..mvcmodels.minimal_table_model import MinimalTableModel
 from .paste_excel import EXCEL_CLIPBOARD_MIME_TYPE, clipboard_excel_as_table
 
 _ = csv.field_size_limit(int(ctypes.c_ulong(-1).value // 2))
@@ -45,14 +44,13 @@ _ = csv.field_size_limit(int(ctypes.c_ulong(-1).value // 2))
 class CopyPasteTableView(QTableView):
     """Custom QTableView class with copy and paste methods."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(parent)
         self._copy_action = None
         self._paste_action = None
         self._delete_action = QAction("Delete", self)
         self._delete_action.setShortcut(QKeySequence.StandardKey.Delete)
         self.addAction(self._delete_action)
-        self._pasted_data_converters = {}
         self._delete_action.triggered.connect(self.delete_content)
 
     def moveCursor(self, cursor_action, modifiers):
@@ -97,11 +95,11 @@ class CopyPasteTableView(QTableView):
         self._paste_action = paste_action
 
     @property
-    def copy_action(self):
+    def copy_action(self) -> QAction:
         return self._copy_action
 
     @property
-    def paste_action(self):
+    def paste_action(self) -> QAction:
         return self._paste_action
 
     @Slot(bool)
@@ -118,10 +116,9 @@ class CopyPasteTableView(QTableView):
     def can_copy(self):
         return not self.selectionModel().selection().isEmpty()
 
-    @busy_effect
     @Slot(bool)
     def copy(self, _=False):
-        """Copies current selection to clipboard in excel format."""
+        """Copies current selection to clipboard in Excel format."""
         selection = self.selectionModel().selection()
         if not selection:
             return False
@@ -129,6 +126,7 @@ class CopyPasteTableView(QTableView):
         h_header = self.horizontalHeader()
         row_dict = {}
         with system_lc_numeric():
+            model = self.model()
             for rng in sorted(selection, key=lambda x: h_header.visualIndex(x.left())):
                 for i in range(rng.top(), rng.bottom() + 1):
                     if v_header.isSectionHidden(i):
@@ -138,20 +136,7 @@ class CopyPasteTableView(QTableView):
                         if h_header.isSectionHidden(j):
                             continue
                         data = self.model().index(i, j).data(Qt.ItemDataRole.EditRole)
-                        if data is not None:
-                            if isinstance(data, bool):
-                                str_data = "true" if data else "false"
-                            elif isinstance(data, int):
-                                str_data = str(data)
-                            else:
-                                try:
-                                    number = float(data)
-                                    str_data = locale.str(number)
-                                except ValueError:
-                                    str_data = str(data)
-                        else:
-                            str_data = ""
-                        row.append(str_data)
+                        row.append(self._convert_copied(i, j, data, model))
         with io.StringIO() as output:
             writer = csv.writer(output, delimiter="\t", quotechar="'")
             for key in sorted(row_dict):
@@ -164,7 +149,9 @@ class CopyPasteTableView(QTableView):
             not self.selectionModel().selection().isEmpty() or self.currentIndex().isValid()
         )
 
-    @busy_effect
+    def _convert_copied(self, row: int, column: int, value: Any, model: MinimalTableModel) -> Optional[str]:
+        return value if value is not None else ""
+
     @Slot(bool)
     def paste(self, _=False):
         """Paste data from clipboard."""
@@ -174,41 +161,11 @@ class CopyPasteTableView(QTableView):
         return self.paste_normal()
 
     @staticmethod
-    def _read_pasted_text(text):
-        """Parses a tab separated CSV text table.
-
-        Args:
-            text (str): a CSV formatted table
-
-        Returns:
-            list: a list of rows
-        """
-
-        def _process_value(value):
-            """Delocalizes value, except when it's one of our 'complex' value types.
-
-            We need this exception because our complex values are json strings, so they have commas,
-            and ``locale.delocalize`` might remove those commas.
-            """
-            new_value = locale.delocalize(value)
-            try:
-                float(new_value)
-                return new_value
-            except ValueError:
-                # The new delocalized value is not even a number, so ignore it
-                # This prevents comma separated strings to become dot separated strings
-                return value
-
-        with io.StringIO(text) as input_stream:
-            reader = csv.reader(input_stream, delimiter="\t", quotechar="'")
-            with system_lc_numeric():
-                return [[_process_value(element) for element in row] for row in reader]
-
-    def _get_data_from_clipboard(self):
+    def _get_data_from_clipboard() -> list[list[Any]]:
         """Gets data from clipboard converting it to Python table.
 
         Returns:
-            list of list: data table
+            data table
         """
         clipboard = QApplication.clipboard()
         mime_data = clipboard.mimeData()
@@ -218,10 +175,12 @@ class CopyPasteTableView(QTableView):
             with suppress(Exception):
                 data = clipboard_excel_as_table(bytes(mime_data.data(EXCEL_CLIPBOARD_MIME_TYPE)))
         if data is None and "text/plain" in data_formats:
-            text = clipboard.text().strip()
+            text = clipboard.text()
             if text:
                 with suppress(ValueError):
-                    data = self._read_pasted_text(text)
+                    with io.StringIO(text) as input_stream:
+                        reader = csv.reader(input_stream, delimiter="\t", quotechar="'")
+                        data = list(reader)
         return data
 
     def paste_on_selection(self):
@@ -239,23 +198,19 @@ class CopyPasteTableView(QTableView):
         rows = [x for r in selection for x in range(r.top(), r.bottom() + 1) if not is_row_hidden(x)]
         is_column_hidden = self.horizontalHeader().isSectionHidden
         columns = [x for r in selection for x in range(r.left(), r.right() + 1) if not is_column_hidden(x)]
-        converters = self._converters() if self._pasted_data_converters else {}
-        model_index = self.model().index
-        for row in rows:
-            for column in columns:
-                index = model_index(row, column)
-                if index.flags() & Qt.ItemIsEditable:
-                    i = (row - rows[0]) % len(data)
-                    j = (column - columns[0]) % len(data[i])
-                    value = data[i][j]
-                    indexes.append(index)
-                    if converters:
-                        convert = converters.get(column)
-                        if convert is not None:
-                            values.append(convert(value))
-                            continue
-                    values.append(value)
-        self.model().batch_set_data(indexes, values)
+        model = self.model()
+        model_index = model.index
+        with system_lc_numeric():
+            for row in rows:
+                for column in columns:
+                    index = model_index(row, column)
+                    if index.flags() & Qt.ItemFlag.ItemIsEditable:
+                        i = (row - rows[0]) % len(data)
+                        j = (column - columns[0]) % len(data[i])
+                        value = data[i][j]
+                        indexes.append(index)
+                        values.append(self._convert_pasted(row, column, value, model))
+        model.batch_set_data(indexes, values)
         return True
 
     def paste_normal(self):
@@ -303,31 +258,29 @@ class CopyPasteTableView(QTableView):
         column_count = model.columnCount()
         if last_column >= column_count:
             model.insertColumns(column_count, last_column - column_count + 1)
-        converters = self._converters() if self._pasted_data_converters else {}
         model_index = model.index
-        for i, row in enumerate(rows):
-            try:
-                line = data[i]
-            except IndexError:
-                break
-            for j, column in enumerate(columns):
+        with system_lc_numeric():
+            for i, row in enumerate(rows):
                 try:
-                    value = line[j]
+                    line = data[i]
                 except IndexError:
                     break
-                index = model_index(row, column)
-                if index.flags() & Qt.ItemFlag.ItemIsEditable:
-                    indexes.append(index)
-                    if converters:
-                        convert = converters.get(column)
-                        if convert is not None:
-                            values.append(convert(value))
-                            continue
-                    values.append(value)
+                for j, column in enumerate(columns):
+                    try:
+                        value = line[j]
+                    except IndexError:
+                        break
+                    index = model_index(row, column)
+                    if index.flags() & Qt.ItemFlag.ItemIsEditable:
+                        indexes.append(index)
+                        values.append(self._convert_pasted(row, column, value, model))
         model.begin_paste()
         model.batch_set_data(indexes, values)
         model.end_paste()
         return True
+
+    def _convert_pasted(self, row: int, column: int, str_value: Optional[str], model: MinimalTableModel) -> Any:
+        return str_value
 
     @staticmethod
     def _cull_rows(model_row_count: int, rows: list[int], data: list) -> tuple[list[int], list]:
@@ -340,32 +293,15 @@ class CopyPasteTableView(QTableView):
             culled_data.append(data[i])
         return culled_rows, culled_data
 
-    def set_column_converter_for_pasting(self, header: str, converter: Callable[[Optional[str]], Any]) -> None:
-        self._pasted_data_converters[header] = converter
-
-    def _converters(self) -> dict[str, Callable[[Optional[str]], Any]]:
-        converters = {}
-        model = self.model()
-        for column in range(model.columnCount()):
-            label = model.headerData(column, Qt.Orientation.Horizontal)
-            converter = self._pasted_data_converters.get(label)
-            if converter is not None:
-                converters[column] = converter
-        return converters
-
 
 class AutoFilterCopyPasteTableView(CopyPasteTableView):
     """Custom QTableView class with autofilter functionality."""
 
-    def __init__(self, parent):
-        """
-        Args:
-            parent (QObject)
-        """
+    def __init__(self, parent: Optional[QWidget]):
         super().__init__(parent=parent)
         self._show_filter_menu_action = QAction(self)
         self._show_filter_menu_action.setShortcut(QKeySequence(Qt.Modifier.ALT.value | Qt.Key.Key_Down.value))
-        self._show_filter_menu_action.setShortcutContext(Qt.WidgetShortcut)
+        self._show_filter_menu_action.setShortcutContext(Qt.ShortcutContext.WidgetShortcut)
         self._show_filter_menu_action.triggered.connect(self._trigger_filter_menu)
         self.addAction(self._show_filter_menu_action)
         self.horizontalHeader().sectionClicked.connect(self.show_auto_filter_menu)

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -12,9 +12,10 @@
 
 """Classes and functions that can be shared among unit test modules."""
 from contextlib import contextmanager
+from typing import Any
 import unittest
 from unittest import mock
-from PySide6.QtCore import QMimeData, QModelIndex, Qt, QTimer
+from PySide6.QtCore import QAbstractTableModel, QMimeData, QModelIndex, Qt, QTimer
 from PySide6.QtWidgets import QApplication
 import spinetoolbox.resources_icons_rc  # pylint: disable=unused-import
 from spinetoolbox.spine_db_manager import SpineDBManager
@@ -355,6 +356,20 @@ def model_data_to_table(model, parent=QModelIndex(), role=Qt.ItemDataRole.Displa
     for row in range(model.rowCount()):
         data.append([model.index(row, column, parent).data(role) for column in range(model.columnCount())])
     return data
+
+
+def assert_table_model_data(
+    model: QAbstractTableModel,
+    expected: list[list[Any]],
+    test_case: unittest.TestCase,
+    role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole,
+) -> None:
+    test_case.assertEqual(model.rowCount(), len(expected))
+    for row in range(model.rowCount()):
+        test_case.assertEqual(model.columnCount(), len(expected[row]))
+        for column in range(model.columnCount()):
+            with test_case.subTest(row=row, column=column, role=role):
+                test_case.assertEqual(model.index(row, column).data(role), expected[row][column])
 
 
 def fetch_model(model):

--- a/tests/spine_db_editor/test_helpers.py
+++ b/tests/spine_db_editor/test_helpers.py
@@ -12,7 +12,19 @@
 
 """Unit tests for Database editor's ``helpers`` module."""
 import unittest
-from spinetoolbox.spine_db_editor.helpers import string_to_bool, string_to_display_icon
+from unittest import mock
+from spinetoolbox.helpers import DB_ITEM_SEPARATOR
+from spinetoolbox.spine_db_editor.helpers import (
+    bool_to_string,
+    group_to_string,
+    input_string_to_int,
+    optional_to_string,
+    parameter_value_to_string,
+    string_to_bool,
+    string_to_display_icon,
+    string_to_group,
+    string_to_parameter_value,
+)
 
 
 class TestStringToDisplayIcon(unittest.TestCase):
@@ -20,6 +32,12 @@ class TestStringToDisplayIcon(unittest.TestCase):
         self.assertEqual(string_to_display_icon("23"), 23)
         self.assertIsNone(string_to_display_icon(""))
         self.assertIsNone(string_to_display_icon("rubbish"))
+
+
+class TestBoolToString(unittest.TestCase):
+    def test_converts_correctly(self):
+        self.assertEqual(bool_to_string(True), "true")
+        self.assertEqual(bool_to_string(False), "false")
 
 
 class TestStringToBool(unittest.TestCase):
@@ -30,6 +48,72 @@ class TestStringToBool(unittest.TestCase):
         self.assertFalse(string_to_bool(""))
         self.assertTrue(string_to_bool(b"true"))
         self.assertFalse(string_to_bool(b"false"))
+
+
+class TestOptionalToString(unittest.TestCase):
+    def test_converts_correctly(self):
+        self.assertIsNone(optional_to_string(None))
+        self.assertEqual(optional_to_string(23), "23")
+
+
+class TestGroupsToString(unittest.TestCase):
+    def test_functionality(self):
+        self.assertIsNone(group_to_string(()))
+        self.assertEqual(group_to_string(("item1",)), "item1")
+        self.assertEqual(group_to_string(("item1", "item2")), "item1" + DB_ITEM_SEPARATOR + "item2")
+
+
+class TestStringToGroup(unittest.TestCase):
+    def test_functionality(self):
+        self.assertEqual(string_to_group(""), ())
+        self.assertEqual(string_to_group("item"), ("item",))
+        self.assertEqual(string_to_group("item,"), ("item",))
+        self.assertEqual(string_to_group("item1, item2"), ("item1", "item2"))
+        self.assertEqual(string_to_group("item1" + DB_ITEM_SEPARATOR + "item2"), ("item1", "item2"))
+
+
+class TestParameterValueToString(unittest.TestCase):
+    def test_non_numeric_values(self):
+        self.assertEqual(parameter_value_to_string("is_string"), "is_string")
+        self.assertEqual(parameter_value_to_string(True), "true")
+        self.assertEqual(parameter_value_to_string(False), "false")
+
+    def test_numeric_values(self):
+        self.assertEqual(parameter_value_to_string(23), str(23))
+        with mock.patch("spinetoolbox.spine_db_editor.helpers.locale.str") as mock_str:
+            mock_str.side_effect = lambda x: str(x).replace(".", ",")
+            self.assertEqual(parameter_value_to_string(2.3), "2,3")
+
+
+class TestStringToParameterValue(unittest.TestCase):
+    def test_booleans(self):
+        self.assertTrue(string_to_parameter_value("true"))
+        self.assertFalse(string_to_parameter_value("false"))
+
+    def test_non_numeric_values(self):
+        self.assertEqual(string_to_parameter_value("random text"), "random text")
+
+    def test_numeric_values(self):
+        with mock.patch("spinetoolbox.spine_db_editor.helpers.locale.atof") as mock_atof:
+            mock_atof.side_effect = lambda x: float(x.replace(",", "."))
+            self.assertEqual(string_to_parameter_value("2,3"), 2.3)
+            self.assertEqual(string_to_parameter_value("2.3"), 2.3)
+        self.assertEqual(string_to_parameter_value("2.3"), 2.3)
+
+
+class TestInputStringToInt(unittest.TestCase):
+    def test_numeric_values(self):
+        self.assertEqual(input_string_to_int("23"), 23)
+        self.assertEqual(input_string_to_int("23.0"), 23)
+        self.assertEqual(input_string_to_int("2.49"), 2)
+        self.assertEqual(input_string_to_int("2.51"), 3)
+        with mock.patch("spinetoolbox.spine_db_editor.helpers.locale.atof") as mock_atof:
+            mock_atof.side_effect = lambda x: float(x.replace(",", "."))
+            self.assertEqual(input_string_to_int("2,3"), 2)
+
+    def test_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            input_string_to_int("aaa")
 
 
 if __name__ == "__main__":

--- a/tests/spine_db_editor/widgets/helpers.py
+++ b/tests/spine_db_editor/widgets/helpers.py
@@ -45,7 +45,7 @@ class EditorDelegateMocking:
             view.model().setData(index, value)
             return
         if isinstance(self._cell_editor, SearchBarEditor):
-            key_press_event = QKeyEvent(QEvent.KeyPress, Qt.Key_Down, Qt.NoModifier, 0, 0, 0)
+            key_press_event = QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Down, Qt.KeyboardModifier.NoModifier, 0, 0, 0)
             i = 0
             while self._cell_editor.data() != value:
                 if i == self._cell_editor._model.rowCount():
@@ -53,7 +53,7 @@ class EditorDelegateMocking:
                 self._cell_editor.keyPressEvent(key_press_event)
                 i += 1
         else:
-            self._cell_editor.setText(str(value))
+            self._cell_editor.setText(str(value) if not isinstance(value, tuple) else ",".join(value))
         delegate.commitData.emit(self._cell_editor)
         delegate.closeEditor.emit(self._cell_editor)
 

--- a/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
+++ b/tests/spine_db_editor/widgets/test_SpineDBEditorFilter.py
@@ -15,7 +15,6 @@ from unittest import mock
 from PySide6.QtCore import QItemSelectionModel, Qt
 from PySide6.QtGui import QColor, QPen
 from PySide6.QtWidgets import QApplication
-from spinetoolbox.helpers import DB_ITEM_SEPARATOR
 from tests.spine_db_editor.widgets.helpers import select_item_with_index
 from tests.spine_db_editor.widgets.spine_db_editor_test_base import DBEditorTestBase
 
@@ -66,11 +65,11 @@ class TestSpineDBEditorStackedFilter(DBEditorTestBase):
         fish_item = next(x for x in root_item.children if x.display_data == "fish")
         fish_index = self.spine_db_editor.entity_tree_model.index_from_item(fish_item)
         selection_model = self.spine_db_editor.ui.treeView_entity.selectionModel()
-        selection_model.setCurrentIndex(fish_index, QItemSelectionModel.NoUpdate)
-        selection_model.select(fish_index, QItemSelectionModel.Select)
+        selection_model.setCurrentIndex(fish_index, QItemSelectionModel.SelectionFlag.NoUpdate)
+        selection_model.select(fish_index, QItemSelectionModel.SelectionFlag.Select)
         filtered_values = {
             self.spine_db_editor.parameter_definition_model: [("dog",)],
-            self.spine_db_editor.parameter_value_model: [("dog", "pluto"), ("dog", "scooby")],
+            self.spine_db_editor.parameter_value_model: [("dog", ("pluto",)), ("dog", ("scooby",))],
         }
         self._assert_filter(filtered_values)
 
@@ -85,15 +84,15 @@ class TestSpineDBEditorStackedFilter(DBEditorTestBase):
         fish_dog_item = next(x for x in root_item.children if x.display_data == "fish__dog")
         fish_dog_index = self.spine_db_editor.entity_tree_model.index_from_item(fish_dog_item)
         selection_model = self.spine_db_editor.ui.treeView_entity.selectionModel()
-        selection_model.setCurrentIndex(fish_dog_index, QItemSelectionModel.NoUpdate)
-        selection_model.select(fish_dog_index, QItemSelectionModel.Select)
+        selection_model.setCurrentIndex(fish_dog_index, QItemSelectionModel.SelectionFlag.NoUpdate)
+        selection_model.select(fish_dog_index, QItemSelectionModel.SelectionFlag.Select)
         filtered_values = {
             self.spine_db_editor.parameter_definition_model: [("dog",), ("fish",), ("dog__fish",)],
             self.spine_db_editor.parameter_value_model: [
-                ("dog__fish", DB_ITEM_SEPARATOR.join(["pluto", "nemo"])),
-                ("fish", "nemo"),
-                ("dog", "pluto"),
-                ("dog", "scooby"),
+                ("dog__fish", ("pluto", "nemo")),
+                ("fish", ("nemo",)),
+                ("dog", ("pluto",)),
+                ("dog", ("scooby",)),
             ],
         }
         self._assert_filter(filtered_values)
@@ -111,22 +110,22 @@ class TestSpineDBEditorStackedFilter(DBEditorTestBase):
         dog_item = next(x for x in root_item.children if x.display_data == "dog")
         scooby_item = next(x for x in dog_item.children if x.display_data == "scooby")
         scooby_index = self.spine_db_editor.entity_tree_model.index_from_item(scooby_item)
-        selection_model.setCurrentIndex(fish_index, QItemSelectionModel.NoUpdate)
-        selection_model.select(fish_index, QItemSelectionModel.Select)
-        selection_model.setCurrentIndex(scooby_index, QItemSelectionModel.NoUpdate)
-        selection_model.select(scooby_index, QItemSelectionModel.Select)
+        selection_model.setCurrentIndex(fish_index, QItemSelectionModel.SelectionFlag.NoUpdate)
+        selection_model.select(fish_index, QItemSelectionModel.SelectionFlag.Select)
+        selection_model.setCurrentIndex(scooby_index, QItemSelectionModel.SelectionFlag.NoUpdate)
+        selection_model.select(scooby_index, QItemSelectionModel.SelectionFlag.Select)
         filtered_values = {
             self.spine_db_editor.parameter_definition_model: [],
             self.spine_db_editor.parameter_value_model: [
-                ("dog", "pluto"),
-                ("fish__dog", "nemo ǀ pluto"),
-                ("dog__fish", "pluto ǀ nemo"),
+                ("dog", ("pluto",)),
+                ("fish__dog", ("nemo", "pluto")),
+                ("dog__fish", ("pluto", "nemo")),
             ],
         }
         self._assert_filter(filtered_values)
 
     def test_filter_parameter_tables_per_entity(self):
-        """Test that parameter tables are filtered when selecting objects in the object tree."""
+        """Test that parameter tables are filtered when selecting entities in the entity tree."""
         for model in self._filtered_fields:
             if model.canFetchMore(None):
                 model.fetchMore(None)
@@ -137,14 +136,14 @@ class TestSpineDBEditorStackedFilter(DBEditorTestBase):
         pluto_item = next(x for x in dog_item.children if x.display_data == "pluto")
         pluto_index = self.spine_db_editor.entity_tree_model.index_from_item(pluto_item)
         selection_model = self.spine_db_editor.ui.treeView_entity.selectionModel()
-        selection_model.setCurrentIndex(pluto_index, QItemSelectionModel.NoUpdate)
-        selection_model.select(pluto_index, QItemSelectionModel.Select)
+        selection_model.setCurrentIndex(pluto_index, QItemSelectionModel.SelectionFlag.NoUpdate)
+        selection_model.select(pluto_index, QItemSelectionModel.SelectionFlag.Select)
         filtered_values = {
             self.spine_db_editor.parameter_definition_model: [("fish",)],
             self.spine_db_editor.parameter_value_model: [
-                ("fish__dog", DB_ITEM_SEPARATOR.join(["nemo", "scooby"])),
-                ("fish", "nemo"),
-                ("dog", "scooby"),
+                ("fish__dog", ("nemo", "scooby")),
+                ("fish", ("nemo",)),
+                ("dog", ("scooby",)),
             ],
         }
         self._assert_filter(filtered_values)
@@ -162,16 +161,16 @@ class TestSpineDBEditorGraphFilter(DBEditorTestBase):
 
     @classmethod
     def _create_highlights(cls):
-        pen = QPen(Qt.SolidLine)
+        pen = QPen(Qt.PenStyle.SolidLine)
         pen.setColor(QColor.fromRgbF(0, 0, 0, 0))
         cls.ACTIVE = pen
-        pen = QPen(Qt.SolidLine)
+        pen = QPen(Qt.PenStyle.SolidLine)
         pen.setColor(QColor.fromRgbF(0, 0, 0, 1))
         cls.INACTIVE = pen
-        pen = QPen(Qt.DashLine)
+        pen = QPen(Qt.PenStyle.DashLine)
         pen.setColor(QColor.fromRgbF(0, 0, 0, 1))
         cls.CONFLICTED = pen
-        pen = QPen(Qt.DotLine)
+        pen = QPen(Qt.PenStyle.DotLine)
         pen.setColor(QColor.fromRgbF(0, 0, 0, 1))
         cls.PARAMETER = pen
 

--- a/tests/spine_db_editor/widgets/test_custom_editors.py
+++ b/tests/spine_db_editor/widgets/test_custom_editors.py
@@ -159,19 +159,19 @@ class TestParameterTypeEditor(TestCaseWithQApplication):
             with self.subTest(check_box_text=check_box.text()):
                 self.assertTrue(check_box.isChecked())
         self.assertEqual(self._editor._ui.map_rank_line_edit.text(), "1")
-        self.assertEqual(self._editor.data(), "")
+        self.assertEqual(self._editor.data(), ())
 
     def test_select_single_type(self):
         expected_data = {
-            "a&rray": "array",
-            "&bool": "bool",
-            "&date_time": "date_time",
-            "d&uration": "duration",
-            "&float": "float",
-            "&map": DB_ITEM_SEPARATOR.join(("2d_map", "3d_map")),
-            "&str": "str",
-            "time_&pattern": "time_pattern",
-            "&time_series": "time_series",
+            "a&rray": ("array",),
+            "&bool": ("bool",),
+            "&date_time": ("date_time",),
+            "d&uration": ("duration",),
+            "&float": ("float",),
+            "&map": ("2d_map", "3d_map"),
+            "&str": ("str",),
+            "time_&pattern": ("time_pattern",),
+            "&time_series": ("time_series",),
         }
         for check_box in self._editor._check_box_iter():
             self._editor._clear_all()

--- a/tests/spine_db_editor/widgets/test_custom_qtableview.py
+++ b/tests/spine_db_editor/widgets/test_custom_qtableview.py
@@ -18,12 +18,11 @@ import os
 from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock
-from PySide6.QtCore import QItemSelectionModel, QModelIndex
+from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, Qt
 from PySide6.QtWidgets import QApplication, QMessageBox
 from spinedb_api import Array, DatabaseMapping, import_functions
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR
-from spinetoolbox.spine_db_editor.widgets.custom_qtableview import convert_pasted_group_fields
-from tests.mock_helpers import fetch_model, mock_clipboard_patch
+from tests.mock_helpers import assert_table_model_data, fetch_model, mock_clipboard_patch
 from tests.spine_db_editor.helpers import TestBase
 from tests.spine_db_editor.widgets.helpers import EditorDelegateMocking, add_entity, add_zero_dimension_entity_class
 
@@ -113,11 +112,7 @@ class TestParameterDefinitionTableView(TestBase):
         expected = [
             ["Object", "X", "bool" + DB_ITEM_SEPARATOR + "str", None, "None", None, self.db_codename],
         ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), len(expected[0]))
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            with self.subTest(row=row, column=column):
-                self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
 
 class TestParameterValueTableView(TestBase):
@@ -142,15 +137,19 @@ class TestParameterValueTableView(TestBase):
         self.assertTrue(table_view.currentIndex().isValid())
         with mock_clipboard_patch("''", "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(table_view.paste())
-        expected = [
-            ["Object", "my_object", "X", "Base", "2.3", "TestParameterValueTableView_db"],
-        ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 6)
-        for row in range(model.rowCount()):
-            for column in range(model.columnCount()):
-                with self.subTest(row=row, column=column):
-                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+        expected = {
+            Qt.ItemDataRole.DisplayRole: [
+                ["Object", "my_object", "X", "Base", "2.3", self.db_codename],
+            ],
+            Qt.ItemDataRole.ToolTipRole: [
+                ["Object", "my_object", "X", "<qt>Base alternative</qt>", None, self.db_codename],
+            ],
+            Qt.ItemDataRole.EditRole: [
+                ["Object", ("my_object",), "X", "Base", "2.3", self.db_codename],
+            ],
+        }
+        for role, expected_for_role in expected.items():
+            assert_table_model_data(model, expected_for_role, self, role)
 
     def test_removing_row_does_not_allow_fetching_more_data(self):
         tree_view = self._db_editor.ui.treeView_entity
@@ -167,12 +166,12 @@ class TestParameterValueTableView(TestBase):
         empty_model = empty_table_view.model()
         self.assertEqual(empty_model.rowCount(), 1)
         _set_row_data(
-            empty_table_view, empty_model, 0, ["an_object_class", "object_1", "a_parameter", "Base"], delegate_mock
+            empty_table_view, empty_model, 0, ["an_object_class", ("object_1",), "a_parameter", "Base"], delegate_mock
         )
         delegate_mock.reset()
         delegate_mock.write_to_index(empty_table_view, empty_model.index(0, 4), "value_1")
         _set_row_data(
-            empty_table_view, empty_model, 1, ["an_object_class", "object_2", "a_parameter", "Base"], delegate_mock
+            empty_table_view, empty_model, 1, ["an_object_class", ("object_2",), "a_parameter", "Base"], delegate_mock
         )
         delegate_mock.reset()
         delegate_mock.write_to_index(empty_table_view, empty_model.index(1, 4), "value_2")
@@ -182,10 +181,7 @@ class TestParameterValueTableView(TestBase):
             ["an_object_class", "object_1", "a_parameter", "Base", "value_1", self.db_codename],
             ["an_object_class", "object_2", "a_parameter", "Base", "value_2", self.db_codename],
         ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 6)
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
         selection_model = table_view.selectionModel()
         selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.ClearAndSelect)
         table_view.remove_selected()
@@ -193,10 +189,7 @@ class TestParameterValueTableView(TestBase):
         expected = [
             ["an_object_class", "object_2", "a_parameter", "Base", "value_2", self.db_codename],
         ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 6)
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
     def test_receiving_uncommitted_but_existing_value_does_not_create_duplicate_entry(self):
         tree_view = self._db_editor.ui.treeView_entity
@@ -212,7 +205,7 @@ class TestParameterValueTableView(TestBase):
         empty_model = empty_table_view.model()
         self.assertEqual(empty_model.rowCount(), 1)
         _set_row_data(
-            empty_table_view, empty_model, 0, ["an_object_class", "an_object", "a_parameter", "Base"], delegate_mock
+            empty_table_view, empty_model, 0, ["an_object_class", ("an_object",), "a_parameter", "Base"], delegate_mock
         )
         delegate_mock.reset()
         delegate_mock.write_to_index(empty_table_view, empty_model.index(0, 4), "value_1")
@@ -221,10 +214,7 @@ class TestParameterValueTableView(TestBase):
         expected = [
             ["an_object_class", "an_object", "a_parameter", "Base", "value_1", self.db_codename],
         ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 6)
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
     @mock.patch("spinetoolbox.spine_db_worker._CHUNK_SIZE", new=1)
     def test_incremental_fetching_groups_values_by_entity_class(self):
@@ -246,21 +236,21 @@ class TestParameterValueTableView(TestBase):
             empty_table_view,
             empty_model,
             0,
-            ["object_1_class", "an_object_1", "parameter_1", "Base", "a_value"],
+            ["object_1_class", ("an_object_1",), "parameter_1", "Base", "a_value"],
             delegate_mock,
         )
         _set_row_data(
             empty_table_view,
             empty_model,
             1,
-            ["object_2_class", "an_object_2", "parameter_2", "Base", "b_value"],
+            ["object_2_class", ("an_object_2",), "parameter_2", "Base", "b_value"],
             delegate_mock,
         )
         _set_row_data(
             empty_table_view,
             empty_model,
             2,
-            ["object_1_class", "another_object_1", "parameter_1", "Base", "c_value"],
+            ["object_1_class", ("another_object_1",), "parameter_1", "Base", "c_value"],
             delegate_mock,
         )
         table_view = self._db_editor.ui.tableView_parameter_value
@@ -438,10 +428,8 @@ class TestParameterValueTableWithExistingData(TestBase):
                 for entity_name, parameter_n in itertools.product(nd_entity_names, range(self._n_ND_parameters))
             ]
         )
-        expected.append([None, None, None, None, None, self.db_codename])
         self.assertEqual(model.rowCount(), self._whole_model_rowcount())
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
     def test_rolling_back_purge(self):
         table_view = self._db_editor.ui.tableView_parameter_value
@@ -471,10 +459,8 @@ class TestParameterValueTableWithExistingData(TestBase):
             ]
         )
         QApplication.processEvents()
-        expected.append([None, None, None, None, None, self.db_codename])
         self.assertEqual(model.rowCount(), self._whole_model_rowcount())
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
     def test_sorting(self):
         """Test that the parameter value table sorts in an expected order."""
@@ -526,11 +512,8 @@ class TestParameterValueTableWithExistingData(TestBase):
                 for entity_name, parameter_n in itertools.product(nd_entity_names, range(self._n_ND_parameters))
             ]
         )
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 6)
         self.assertEqual(model.rowCount(), self._whole_model_rowcount() + 4)
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
 
 class TestEntityAlternativeTableView(TestBase):
@@ -551,12 +534,7 @@ class TestEntityAlternativeTableView(TestBase):
         expected = [
             ["Object", "spoon", "Base", False, "TestEntityAlternativeTableView_db"],
         ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 5)
-        for row in range(model.rowCount()):
-            for column in range(model.columnCount()):
-                with self.subTest(row=row, column=column):
-                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
     def test_pasting_sane_date_to_the_active_column_converts_to_boolean_correctly(self):
         self._db_map.add_entity_class(name="Object")
@@ -575,12 +553,7 @@ class TestEntityAlternativeTableView(TestBase):
         expected = [
             ["Object", "spoon", "Base", True, "TestEntityAlternativeTableView_db"],
         ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 5)
-        for row in range(model.rowCount()):
-            for column in range(model.columnCount()):
-                with self.subTest(row=row, column=column):
-                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(model, expected, self)
 
     def test_set_db_column_visible(self):
         table_view = self._db_editor.ui.tableView_parameter_definition
@@ -644,15 +617,19 @@ class TestEmptyParameterValueTableView(TestBase):
         )
         with mock_clipboard_patch("''", "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(table_view.paste())
-        expected = [
-            [None, (), None, None, None, "TestEmptyParameterValueTableView_db"],
-        ]
-        self.assertEqual(model.rowCount(), len(expected))
-        self.assertEqual(model.columnCount(), 6)
-        for row in range(model.rowCount()):
-            for column in range(model.columnCount()):
-                with self.subTest(row=row, column=column):
-                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+        expected = {
+            Qt.ItemDataRole.DisplayRole: [
+                [None, None, None, None, None, self.db_codename],
+            ],
+            Qt.ItemDataRole.ToolTipRole: [
+                [None, None, None, None, None, None],
+            ],
+            Qt.ItemDataRole.EditRole: [
+                [None, (), None, None, None, self.db_codename],
+            ],
+        }
+        for role, expected_for_role in expected.items():
+            assert_table_model_data(model, expected_for_role, self, role)
 
     def test_purging_value_data_leaves_empty_rows_intact(self):
         self._db_map.add_entity_class(name="object_class")
@@ -663,16 +640,29 @@ class TestEmptyParameterValueTableView(TestBase):
         self.assertEqual(model.rowCount(), 1)
         delegate_mock = EditorDelegateMocking()
         _set_row_data(
-            table_view, model, model.rowCount() - 1, ["object_class", "object_1", "parameter_1", "Base"], delegate_mock
+            table_view,
+            model,
+            model.rowCount() - 1,
+            ["object_class", ("object_1",), "parameter_1", "Base"],
+            delegate_mock,
         )
         self._db_mngr.purge_items({self._db_map: ["parameter_value"]})
-        expected = [
-            ["object_class", "object_1", "parameter_1", "Base", None, self.db_codename],
-            [None, None, None, None, None, self.db_codename],
-        ]
-        self.assertEqual(model.rowCount(), len(expected))
-        for row, column in itertools.product(range(model.rowCount()), range(model.columnCount())):
-            self.assertEqual(model.index(row, column).data(), expected[row][column])
+        expected = {
+            Qt.ItemDataRole.DisplayRole: [
+                ["object_class", "object_1", "parameter_1", "Base", None, self.db_codename],
+                [None, None, None, None, None, self.db_codename],
+            ],
+            Qt.ItemDataRole.ToolTipRole: [
+                [None, None, None, None, None, None],
+                [None, None, None, None, None, None],
+            ],
+            Qt.ItemDataRole.EditRole: [
+                ["object_class", ("object_1",), "parameter_1", "Base", None, self.db_codename],
+                [None, None, None, None, None, self.db_codename],
+            ],
+        }
+        for role, expected_for_role in expected.items():
+            assert_table_model_data(model, expected_for_role, self, role)
 
 
 class TestEmptyEntityAlternativeTableView(TestBase):
@@ -688,25 +678,76 @@ class TestEmptyEntityAlternativeTableView(TestBase):
             "Object\tspoon\tBase\tGIBBERISH", "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"
         ):
             self.assertTrue(empty_table_view.paste())
-        expected = [
-            [None, None, None, None, "TestEmptyEntityAlternativeTableView_db"],
-        ]
-        while empty_model.rowCount() != len(expected):
+        expected = {
+            Qt.ItemDataRole.DisplayRole: [
+                [None, None, None, None, self.db_codename],
+            ],
+            Qt.ItemDataRole.ToolTipRole: [
+                [None, None, None, None, None],
+            ],
+            Qt.ItemDataRole.EditRole: [
+                [None, None, None, None, self.db_codename],
+            ],
+        }
+        while empty_model.rowCount() != len(expected[Qt.ItemDataRole.DisplayRole]):
             QApplication.processEvents()
-        self.assertEqual(empty_model.columnCount(), 5)
-        for row in range(empty_model.rowCount()):
-            for column in range(empty_model.columnCount()):
-                with self.subTest(row=row, column=column):
-                    self.assertEqual(empty_model.index(row, column).data(), expected[row][column])
+        for role, expected_for_role in expected.items():
+            assert_table_model_data(empty_model, expected_for_role, self, role)
         table_view = self._db_editor.ui.tableView_entity_alternative
         model = table_view.model()
+        expected = {
+            Qt.ItemDataRole.DisplayRole: [
+                ["Object", "spoon", "Base", False, self.db_codename],
+            ],
+            Qt.ItemDataRole.ToolTipRole: [
+                ["Object", "spoon", "<qt>Base alternative</qt>", False, self.db_codename],
+            ],
+            Qt.ItemDataRole.EditRole: [
+                ["Object", ("spoon",), "Base", False, self.db_codename],
+            ],
+        }
+        for role, expected_for_role in expected.items():
+            assert_table_model_data(model, expected_for_role, self, role)
+
+
+class TestMetadataTableView(TestBase):
+    def test_copy_name_and_value_from_single_row(self):
+        self._db_map.add_metadata(name="Title", value="Catalogue of things")
+        metadata_table_view = self._db_editor.ui.metadata_table_view
+        metadata_model = metadata_table_view.model()
+        fetch_model(metadata_model)
         expected = [
-            ["Object", "spoon", "Base", False, "TestEmptyEntityAlternativeTableView_db"],
+            ["Title", "Catalogue of things", self.db_codename],
+            ["", "", self.db_codename],
         ]
-        for row in range(model.rowCount()):
-            for column in range(model.columnCount()):
-                with self.subTest(row=row, column=column):
-                    self.assertEqual(model.index(row, column).data(), expected[row][column])
+        assert_table_model_data(metadata_model, expected, self)
+        selection_model = metadata_table_view.selectionModel()
+        selection_model.select(metadata_model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(metadata_model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as get_clipboard:
+            clipboard = mock.MagicMock()
+            get_clipboard.return_value = clipboard
+            self.assertTrue(metadata_table_view.copy())
+            clipboard.setText.assert_called_once_with("Title\tCatalogue of things\r\n")
+
+    def test_copy_name_and_value_to_single_row(self):
+        metadata_table_view = self._db_editor.ui.metadata_table_view
+        metadata_model = metadata_table_view.model()
+        fetch_model(metadata_model)
+        self.assertEqual(metadata_model.rowCount(), 1)
+        metadata_table_view.setCurrentIndex(metadata_model.index(0, 0))
+        selection_model = metadata_table_view.selectionModel()
+        selection_model.select(metadata_model.index(0, 0), QItemSelectionModel.SelectionFlag.ClearAndSelect)
+        with mock_clipboard_patch(
+            "Title\tA catalogue of things that should be",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(metadata_table_view.paste())
+        expected = [
+            ["Title", "A catalogue of things that should be", self.db_codename],
+            ["", "", self.db_codename],
+        ]
+        assert_table_model_data(metadata_model, expected, self)
 
 
 def _set_row_data(view, model, row, data, delegate_mock):
@@ -715,12 +756,325 @@ def _set_row_data(view, model, row, data, delegate_mock):
         delegate_mock.write_to_index(view, model.index(row, column), cell_data)
 
 
-class TestConvertPastedGroupFields(unittest.TestCase):
-    def test_functionality(self):
-        self.assertEqual(convert_pasted_group_fields(""), ())
-        self.assertEqual(convert_pasted_group_fields("item"), ("item",))
-        self.assertEqual(convert_pasted_group_fields("item1, item2"), ("item1", "item2"))
-        self.assertEqual(convert_pasted_group_fields("item1" + DB_ITEM_SEPARATOR + "item2"), ("item1", "item2"))
+class TestPivotTableView(TestBase):
+    def test_copy_element_data(self):
+        self._db_map.add_entity_class(name="A")
+        self._db_map.add_entity(entity_class_name="A", name="a1")
+        self._db_map.add_entity(entity_class_name="A", name="a2")
+        self._db_map.add_entity_class(name="B")
+        self._db_map.add_entity(entity_class_name="B", name="b1")
+        self._db_map.add_entity(entity_class_name="B", name="b2")
+        self._db_map.add_entity_class(dimension_name_list=("B", "A"))
+        self._db_editor.current_input_type = self._db_editor._ELEMENT
+        entity_tree_view = self._db_editor.ui.treeView_entity
+        entity_tree_model = entity_tree_view.model()
+        entity_tree_root_index = entity_tree_model.index(0, 0)
+        while entity_tree_model.rowCount(entity_tree_root_index) != 3:
+            entity_tree_model.fetchMore(entity_tree_root_index)
+            QApplication.processEvents()
+        relationship_index = entity_tree_model.index(2, 0, entity_tree_root_index)
+        self.assertEqual(relationship_index.data(), "B__A")
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            entity_tree_view.setCurrentIndex(relationship_index)
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            ["b1", "a2", False],
+            ["b2", "a1", False],
+            ["b2", "a2", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        selection = QItemSelection(
+            pivot_model.index(0, 0), pivot_model.index(pivot_model.rowCount() - 1, pivot_model.columnCount() - 1)
+        )
+        pivot_table_view.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.ClearAndSelect)
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as get_clipboard:
+            clipboard = mock.MagicMock()
+            get_clipboard.return_value = clipboard
+            self.assertTrue(pivot_table_view.copy())
+            expected = [
+                ["B", "A", ""],
+                ["b1", "a1", "false"],
+                ["b1", "a2", "false"],
+                ["b2", "a1", "false"],
+                ["b2", "a2", "false"],
+                ["", "", ""],
+            ]
+            str_out = io.StringIO()
+            writer = csv.writer(str_out, delimiter="\t")
+            writer.writerows(expected)
+            clipboard.setText.assert_called_once_with(str_out.getvalue())
+
+    def test_create_relationship_by_pasting(self):
+        self._db_map.add_entity_class(name="A")
+        self._db_map.add_entity(entity_class_name="A", name="a1")
+        self._db_map.add_entity(entity_class_name="A", name="a2")
+        self._db_map.add_entity_class(name="B")
+        self._db_map.add_entity(entity_class_name="B", name="b1")
+        self._db_map.add_entity(entity_class_name="B", name="b2")
+        self._db_map.add_entity_class(dimension_name_list=("B", "A"))
+        self._db_editor.current_input_type = self._db_editor._ELEMENT
+        entity_tree_view = self._db_editor.ui.treeView_entity
+        entity_tree_model = entity_tree_view.model()
+        entity_tree_root_index = entity_tree_model.index(0, 0)
+        while entity_tree_model.rowCount(entity_tree_root_index) != 3:
+            entity_tree_model.fetchMore(entity_tree_root_index)
+            QApplication.processEvents()
+        relationship_index = entity_tree_model.index(2, 0, entity_tree_root_index)
+        self.assertEqual(relationship_index.data(), "B__A")
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            entity_tree_view.setCurrentIndex(relationship_index)
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            ["b1", "a2", False],
+            ["b2", "a1", False],
+            ["b2", "a2", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        pivot_table_view.setCurrentIndex(pivot_model.index(3, 2))
+        with mock_clipboard_patch(
+            "yes",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(pivot_table_view.paste())
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            ["b1", "a2", False],
+            ["b2", "a1", True],
+            ["b2", "a2", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+
+    def test_destroy_relationship_by_pasting(self):
+        self._db_map.add_entity_class(name="A")
+        self._db_map.add_entity(entity_class_name="A", name="a1")
+        self._db_map.add_entity(entity_class_name="A", name="a2")
+        self._db_map.add_entity_class(name="B")
+        self._db_map.add_entity(entity_class_name="B", name="b1")
+        self._db_map.add_entity(entity_class_name="B", name="b2")
+        self._db_map.add_entity_class(dimension_name_list=("B", "A"))
+        self._db_map.add_entity(entity_class_name="B__A", entity_byname=("b2", "a1"))
+        self._db_editor.current_input_type = self._db_editor._ELEMENT
+        entity_tree_view = self._db_editor.ui.treeView_entity
+        entity_tree_model = entity_tree_view.model()
+        entity_tree_root_index = entity_tree_model.index(0, 0)
+        while entity_tree_model.rowCount(entity_tree_root_index) != 3:
+            entity_tree_model.fetchMore(entity_tree_root_index)
+            QApplication.processEvents()
+        relationship_index = entity_tree_model.index(2, 0, entity_tree_root_index)
+        self.assertEqual(relationship_index.data(), "B__A")
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            entity_tree_view.setCurrentIndex(relationship_index)
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            ["b1", "a2", False],
+            ["b2", "a1", True],
+            ["b2", "a2", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        pivot_table_view.setCurrentIndex(pivot_model.index(3, 2))
+        with mock_clipboard_patch(
+            "no",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(pivot_table_view.paste())
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            ["b1", "a2", False],
+            ["b2", "a1", False],
+            ["b2", "a2", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+
+    def test_create_entities_by_pasting(self):
+        self._db_map.add_entity_class(name="A")
+        self._db_map.add_entity(entity_class_name="A", name="a1")
+        self._db_map.add_entity_class(name="B")
+        self._db_map.add_entity(entity_class_name="B", name="b1")
+        self._db_map.add_entity_class(dimension_name_list=("B", "A"))
+        self._db_editor.current_input_type = self._db_editor._ELEMENT
+        entity_tree_view = self._db_editor.ui.treeView_entity
+        entity_tree_model = entity_tree_view.model()
+        entity_tree_root_index = entity_tree_model.index(0, 0)
+        while entity_tree_model.rowCount(entity_tree_root_index) != 3:
+            entity_tree_model.fetchMore(entity_tree_root_index)
+            QApplication.processEvents()
+        relationship_index = entity_tree_model.index(2, 0, entity_tree_root_index)
+        self.assertEqual(relationship_index.data(), "B__A")
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            entity_tree_view.setCurrentIndex(relationship_index)
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        selection = QItemSelection(pivot_model.index(2, 0), pivot_model.index(2, 2))
+        pivot_table_view.selectionModel().select(selection, QItemSelectionModel.SelectionFlag.ClearAndSelect)
+        with mock_clipboard_patch(
+            "b2\ta2\t\r\n",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(pivot_table_view.paste())
+        expected = [
+            ["B", "A", None],
+            ["b1", "a1", False],
+            ["b1", "a2", False],
+            ["b2", "a1", False],
+            ["b2", "a2", False],
+            [None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+
+    def test_copy_scenario_data(self):
+        self._db_map.add_scenario(name="Scen1")
+        self._db_map.add_alternatives([{"name": "alt1"}, {"name": "alt2"}, {"name": "alt3"}, {"name": "alt4"}])
+        self._db_map.add_scenario_alternative(scenario_name="Scen1", alternative_name="alt3", rank=1)
+        self._db_map.add_scenario_alternative(scenario_name="Scen1", alternative_name="alt1", rank=2)
+        self._db_editor.current_input_type = self._db_editor._SCENARIO_ALTERNATIVE
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            self._db_editor.do_reload_pivot_table()
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, 2, False, 1, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        selection_model = pivot_table_view.selectionModel()
+        selection = QItemSelection(pivot_model.index(2, 1), pivot_model.index(2, 5))
+        selection_model.select(selection, QItemSelectionModel.SelectionFlag.ClearAndSelect)
+        with mock.patch("spinetoolbox.widgets.custom_qtableview.QApplication.clipboard") as get_clipboard:
+            clipboard = mock.MagicMock()
+            get_clipboard.return_value = clipboard
+            self.assertTrue(pivot_table_view.copy())
+            clipboard.setText.assert_called_once_with("false\t2\tfalse\t1\tfalse\r\n")
+
+    def test_paste_new_scenario_alternative_data(self):
+        self._db_map.add_scenario(name="Scen1")
+        self._db_map.add_alternatives([{"name": "alt1"}, {"name": "alt2"}, {"name": "alt3"}, {"name": "alt4"}])
+        self._db_editor.current_input_type = self._db_editor._SCENARIO_ALTERNATIVE
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            self._db_editor.do_reload_pivot_table()
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, False, False, False, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        pivot_table_view.setCurrentIndex(pivot_model.index(2, 1))
+        with mock_clipboard_patch(
+            "false\t2\tfalse\t1",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(pivot_table_view.paste())
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, 2, False, 1, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+
+    def test_remove_alternative_from_scenario_by_pasting(self):
+        self._db_map.add_scenario(name="Scen1")
+        self._db_map.add_alternatives([{"name": "alt1"}, {"name": "alt2"}, {"name": "alt3"}, {"name": "alt4"}])
+        self._db_map.add_scenario_alternative(scenario_name="Scen1", alternative_name="alt3", rank=1)
+        self._db_map.add_scenario_alternative(scenario_name="Scen1", alternative_name="alt2", rank=2)
+        self._db_editor.current_input_type = self._db_editor._SCENARIO_ALTERNATIVE
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            self._db_editor.do_reload_pivot_table()
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, False, 2, 1, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        pivot_table_view.setCurrentIndex(pivot_model.index(2, 4))
+        with mock_clipboard_patch(
+            "false",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(pivot_table_view.paste())
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, False, 1, False, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+
+    def test_modify_scenario_alternatives_by_pasting(self):
+        self._db_map.add_scenario(name="Scen1")
+        self._db_map.add_alternatives([{"name": "alt1"}, {"name": "alt2"}, {"name": "alt3"}, {"name": "alt4"}])
+        self._db_map.add_scenario_alternative(scenario_name="Scen1", alternative_name="alt3", rank=1)
+        self._db_map.add_scenario_alternative(scenario_name="Scen1", alternative_name="alt2", rank=2)
+        self._db_editor.current_input_type = self._db_editor._SCENARIO_ALTERNATIVE
+        with mock.patch.object(self._db_editor.ui.dockWidget_pivot_table, "isVisible") as is_pivot_visible:
+            is_pivot_visible.return_value = True
+            self._db_editor.do_reload_pivot_table()
+        fetch_model(self._db_editor.pivot_table_model)
+        pivot_table_view = self._db_editor.ui.pivot_table
+        pivot_model = pivot_table_view.model()
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, False, 2, 1, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
+        pivot_table_view.setCurrentIndex(pivot_model.index(2, 1))
+        with mock_clipboard_patch(
+            "false\tfalse\t1\t2\tFalse",
+            "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard",
+        ):
+            self.assertTrue(pivot_table_view.paste())
+        expected = [
+            ["alternative", "Base", "alt1", "alt2", "alt3", "alt4", None],
+            ["scenario", None, None, None, None, None, None],
+            ["Scen1", False, False, 1, 2, False, None],
+            [None, None, None, None, None, None, None],
+        ]
+        assert_table_model_data(pivot_model, expected, self)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is an omnibus PR that fixes all kinds of problems with copy/pasting in DB editor, including:

- Tracebacks when pasting to metadata or pivot tables
- Problems when copying/pasting"valid types" in Parameter definition table
- Issues when pasting to pivot table in Element or Scenario mode
- Issues when pasting to the empty row in pivot table
- Inconsistencies in copied data
- More truth values like "yes" or "FALSE" are now accepted when pasting

Fixes #2993

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
