### PR TITLE
Fix using parameter value editor on empty rows

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/compound_models.py
@@ -643,14 +643,14 @@ class EditParameterValueMixin:
                 bottom_right = self.index(first_row + count - 1, column_count - 1)
                 self.dataChanged.emit(top_left, bottom_right, [Qt.ItemDataRole.DisplayRole])
 
-    def index_name(self, index):
+    def index_name(self, index: QModelIndex) -> str:
         """Generates a name for data at given index.
 
         Args:
-            index (QModelIndex): index to model
+            index to model
 
         Returns:
-            str: label identifying the data
+            label identifying the data
         """
         item = self.db_item(index)
         if item is None:
@@ -659,16 +659,15 @@ class EditParameterValueMixin:
         if self.item_type == "parameter_definition":
             parameter_name = item["name"]
             names = [item["entity_class_name"]]
+            alternative_name = None
         elif self.item_type == "parameter_value":
             parameter_name = item["parameter_name"]
             names = list(item["entity_byname"])
+            alternative_name = item["alternative_name"]
         else:
             raise ValueError(
                 f"invalid item_type: expected parameter_definition or parameter_value, got {self.item_type}"
             )
-        alternative_name = {"parameter_definition": lambda x: None, "parameter_value": lambda x: x["alternative_name"]}[
-            self.item_type
-        ](item)
         return parameter_identifier(database, parameter_name, names, alternative_name)
 
     def get_set_data_delayed(self, index):
@@ -683,9 +682,8 @@ class EditParameterValueMixin:
         """
         sub_model = self.sub_model_at_row(index.row())
         id_ = self.item_at_row(index.row())
-        value_field = {"parameter_value": "value", "parameter_definition": "default_value"}[self.item_type]
         return lambda value_and_type, sub_model=sub_model, id_=id_: sub_model.update_items_in_db(
-            [{"id": id_, value_field: join_value_and_type(*value_and_type)}]
+            [{"id": id_, sub_model.value_field: join_value_and_type(*value_and_type)}]
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from unittest import mock
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+import pytest
+from tests.mock_helpers import MockSpineDBManager
+
+
+@pytest.fixture(scope="module")
+def application():
+    if QApplication.instance() is None:
+        QApplication()
+    application_instance = QApplication.instance()
+    yield application_instance
+    QTimer.singleShot(0, lambda: application_instance.quit())
+    application_instance.exec()
+
+
+@pytest.fixture
+def app_settings():
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def logger():
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def db_mngr(application, app_settings, logger):
+    mngr = MockSpineDBManager(app_settings, None)
+    yield mngr
+    mngr.close_all_sessions()
+    mngr.clean_up()
+    mngr.deleteLater()
+
+
+@pytest.fixture
+def db_map(db_mngr, logger):
+    db_map = db_mngr.get_db_map("sqlite://", logger, create=True)
+    db_mngr.name_registry.register(db_map.sa_url, "mock_db")
+    return db_map

--- a/tests/spine_db_editor/mvcmodels/test_empty_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_empty_models.py
@@ -12,10 +12,18 @@
 from itertools import product
 import unittest
 from unittest import mock
+from PySide6.QtCore import QModelIndex
 from PySide6.QtGui import QUndoStack
 from PySide6.QtWidgets import QApplication
-from spinetoolbox.spine_db_editor.mvcmodels.empty_models import EmptyModelBase
-from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model
+from spinedb_api import to_database
+from spinetoolbox.mvcmodels.minimal_table_model import MinimalTableModel
+from spinetoolbox.spine_db_editor.mvcmodels.empty_models import (
+    DelayedDataSetter,
+    EmptyModelBase,
+    EmptyParameterDefinitionModel,
+    EmptyParameterValueModel,
+)
+from tests.mock_helpers import MockSpineDBManager, TestCaseWithQApplication, fetch_model, q_object
 
 
 class TestEmptyModelBase(TestCaseWithQApplication):
@@ -266,6 +274,98 @@ class TestEmptyModelBase(TestCaseWithQApplication):
         for row, column in product(range(model.rowCount()), range(len(expected[0]))):
             with self.subTest(row=row, column=column):
                 self.assertEqual(model.index(row, column).data(), expected[row][column])
+
+
+class TestDelayedDataSetter:
+    def test_sets_data_for_model(self, application):
+        with q_object(MinimalTableModel(header=["col 1"])) as model:
+            model.insertRows(0, 1, QModelIndex())
+            index = model.index(0, 0)
+            data_setter = DelayedDataSetter(model, index)
+            value_and_type = to_database(2.3)
+            data_setter(value_and_type)
+            assert model.index(0, 0).data() == 2.3
+
+    def test_moves_set_row_if_previous_row_is_removed(self, application):
+        with q_object(MinimalTableModel(header=["col 1"])) as model:
+            model.insertRows(0, 2)
+            index = model.index(1, 0)
+            data_setter = DelayedDataSetter(model, index)
+            model.removeRows(0, 1)
+            value_and_type = to_database(2.3)
+            data_setter(value_and_type)
+            assert model.index(0, 0).data() == 2.3
+
+    def test_gets_invalidated_when_row_is_removed(self, application):
+        with q_object(MinimalTableModel(header=["col 1"])) as model:
+            model.insertRows(0, 2)
+            index = model.index(1, 0)
+            data_setter = DelayedDataSetter(model, index)
+            model.removeRows(1, 1)
+            value_and_type = to_database(2.3)
+            data_setter(value_and_type)
+            assert model.index(0, 0).data() is None
+
+    def test_removing_succeeding_row_has_no_effect(self, application):
+        with q_object(MinimalTableModel(header=["col 1"])) as model:
+            model.insertRows(0, 2)
+            index = model.index(0, 0)
+            data_setter = DelayedDataSetter(model, index)
+            model.removeRows(1, 1)
+            value_and_type = to_database(2.3)
+            data_setter(value_and_type)
+            assert model.index(0, 0).data() == 2.3
+
+    def test_resetting_model_invalidates_setter(self):
+        with q_object(MinimalTableModel(header=["col 1"])) as model:
+            model.insertRows(0, 2)
+            index = model.index(1, 0)
+            data_setter = DelayedDataSetter(model, index)
+            model.clear()
+            value_and_type = to_database(2.3)
+            data_setter(value_and_type)
+            assert model.rowCount() == 0
+
+
+class TestEmptyParameterDefinitionModel:
+    def test_value_index_name_when_row_is_empty(self, db_mngr):
+        with q_object(EmptyParameterDefinitionModel(db_mngr, parent=None)) as model:
+            model.append_empty_row()
+            index = model.index(0, model.columnCount() - 2)
+            assert model.index_name(index) == "<database> - <entity_class_name> - <parameter_name>"
+
+    def test_value_index_name_when_row_has_data(self, db_mngr):
+        with q_object(EmptyParameterDefinitionModel(db_mngr, parent=None)) as model:
+            undo_stack = QUndoStack(model)
+            model.set_undo_stack(undo_stack)
+            model.append_empty_row()
+            indexes = [model.index(0, 0), model.index(0, 1), model.index(0, 6)]
+            data = ["my class", "my parameter", "my database"]
+            model.batch_set_data(indexes, data)
+            index = model.index(0, model.columnCount() - 2)
+            assert model.index_name(index) == "my database - my class - my parameter"
+
+
+class TestEmptyParameterValueModel:
+    def test_value_index_name_when_row_is_empty(self, db_mngr):
+        with q_object(EmptyParameterValueModel(db_mngr, parent=None)) as model:
+            model.append_empty_row()
+            index = model.index(0, model.columnCount() - 2)
+            assert (
+                model.index_name(index)
+                == "<database> - <entity_class_name> - <entity_byname> - <parameter_name> - <alternative_name>"
+            )
+
+    def test_value_index_name_when_row_has_data(self, db_mngr):
+        with q_object(EmptyParameterValueModel(db_mngr, parent=None)) as model:
+            undo_stack = QUndoStack(model)
+            model.set_undo_stack(undo_stack)
+            model.append_empty_row()
+            indexes = [model.index(0, 0), model.index(0, 1), model.index(0, 2), model.index(0, 3), model.index(0, 5)]
+            data = ["my class", "my entity", "my parameter", "my alternative", "my database"]
+            model.batch_set_data(indexes, data)
+            index = model.index(0, model.columnCount() - 2)
+            assert model.index_name(index) == "my database - my class - my entity - my parameter - my alternative"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed a bug where opening parameter value editor on the empty rows would cause a Traceback.

Fixes #3134

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
