### PR TITLE
Fix Traceback from FrozenTableModel when closing DB editor

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/frozen_table_model.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/frozen_table_model.py
@@ -370,7 +370,12 @@ class FrozenTableModel(QAbstractTableModel):
             table_name = "alternative"
         else:
             table_name = "entity"
-        with self.db_mngr.get_lock(db_map):
+        try:
+            db_lock = self.db_mngr.get_lock(db_map)
+        except KeyError:
+            # Happens when closing the DB editor after the frozen table dock has been shown, then hidden.
+            return ""
+        with db_lock:
             return db_map.mapped_table(table_name)[id_]["name"]
 
     @property

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -129,11 +129,11 @@ class StackedViewMixin:
         editor = ElementNameListEditor(self, index, dimension_names, entity_byname_lists, current_element_byname_list)
         editor.show()
 
-    def _set_default_parameter_data(self, index=None):
+    def _set_default_parameter_data(self, index: Optional[QModelIndex] = None) -> None:
         """Sets default rows for parameter models according to given index.
 
         Args:
-            index (QModelIndex): an index of the entity tree
+            index: an index of the entity tree
         """
         if index is None or not index.isValid():
             default_db_map = next(iter(self.db_maps))


### PR DESCRIPTION
No associated issue.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
