### PR TITLE
Keyboard navigation between compound and empty tables

### DIFF
--- a/spinetoolbox/spine_db_editor/stacked_table_seam.py
+++ b/spinetoolbox/spine_db_editor/stacked_table_seam.py
@@ -1,0 +1,59 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from PySide6.QtCore import Signal
+from PySide6.QtGui import QKeyEvent, Qt
+
+
+class AboveSeam:
+    focus_to_bottom_table_requested = Signal(int)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Down and event.modifiers() == Qt.KeyboardModifier.NoModifier:
+            current_index = self.currentIndex()
+            if current_index.row() == self.model().rowCount() - 1:
+                self.focus_to_bottom_table_requested.emit(current_index.column())
+                return
+        super().keyPressEvent(event)
+
+
+class BelowSeam:
+    focus_to_top_table_requested = Signal(int)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Up and event.modifiers() == Qt.KeyboardModifier.NoModifier:
+            current_index = self.currentIndex()
+            if current_index.row() == 0:
+                self.focus_to_top_table_requested.emit(current_index.column())
+                return
+        super().keyPressEvent(event)
+
+
+class StackedTableSeam:
+    """'Glues' a stacked table and corresponding empty table together
+    so that keyboard navigation is possible between them."""
+
+    def __init__(self, top_table: AboveSeam, bottom_table: BelowSeam):
+        self._top_table = top_table
+        self._top_table.focus_to_bottom_table_requested.connect(self._focus_to_bottom)
+        self._bottom_table = bottom_table
+        self._bottom_table.focus_to_top_table_requested.connect(self._focus_to_top)
+
+    def _focus_to_top(self, column: int) -> None:
+        top_model = self._top_table.model()
+        last_row = top_model.rowCount() - 1
+        self._top_table.setCurrentIndex(top_model.index(last_row, column))
+        self._top_table.setFocus()
+
+    def _focus_to_bottom(self, column: int) -> None:
+        bottom_model = self._bottom_table.model()
+        self._bottom_table.setCurrentIndex(bottom_model.index(0, column))
+        self._bottom_table.setFocus()

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -14,8 +14,8 @@
 from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any, ClassVar, Optional, Union
-from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, QPoint, Qt, QTimer, Signal, Slot
-from PySide6.QtGui import QAction, QKeySequence, QUndoStack
+from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, QPoint, QSize, Qt, QTimer, Signal, Slot
+from PySide6.QtGui import QAction, QKeyEvent, QKeySequence, QUndoStack
 from PySide6.QtWidgets import QHeaderView, QMenu, QTableView, QWidget
 from ...helpers import DB_ITEM_SEPARATOR, preferred_row_height, rows_to_row_count_tuples
 from ...mvcmodels.minimal_table_model import MinimalTableModel
@@ -51,6 +51,7 @@ from ..mvcmodels.pivot_table_models import (
 )
 from ..mvcmodels.single_models import SingleModelBase
 from ..mvcmodels.utils import height_limited_size_hint
+from ..stacked_table_seam import AboveSeam, BelowSeam
 from .custom_delegates import (
     AlternativeNameDelegate,
     BooleanValueDelegate,
@@ -376,7 +377,7 @@ class WithUndoStack:
         self.request_reset_undo_redo_actions.emit()
 
 
-class EmptyParameterDefinitionTableView(WithUndoStack, ParameterDefinitionTableViewBase):
+class EmptyParameterDefinitionTableView(BelowSeam, WithUndoStack, ParameterDefinitionTableViewBase):
     def sizeHint(self, /):
         return height_limited_size_hint(super().sizeHint(), self.parent().size())
 
@@ -384,7 +385,7 @@ class EmptyParameterDefinitionTableView(WithUndoStack, ParameterDefinitionTableV
         return
 
 
-class ParameterDefinitionTableView(ParameterDefinitionTableViewBase):
+class ParameterDefinitionTableView(AboveSeam, ParameterDefinitionTableViewBase):
 
     def _plot_selection(self, selection, plot_widget=None):
         """See base class"""
@@ -416,7 +417,7 @@ class ParameterValueTableViewBase(ParameterTableView):
         delegate.element_name_list_editor_requested.connect(self._spine_db_editor.show_element_name_list_editor)
 
 
-class EmptyParameterValueTableView(WithUndoStack, ParameterValueTableViewBase):
+class EmptyParameterValueTableView(BelowSeam, WithUndoStack, ParameterValueTableViewBase):
     def sizeHint(self, /):
         return height_limited_size_hint(super().sizeHint(), self.parent().size())
 
@@ -424,7 +425,7 @@ class EmptyParameterValueTableView(WithUndoStack, ParameterValueTableViewBase):
         return
 
 
-class ParameterValueTableView(ParameterValueTableViewBase):
+class ParameterValueTableView(AboveSeam, ParameterValueTableViewBase):
     _private_key_fields: ClassVar[tuple[str, str, str, str]] = (
         "entity_class_name",
         "entity_byname",
@@ -492,15 +493,16 @@ class EntityAlternativeTableViewBase(StackedTableView):
         return super()._convert_pasted(row, column, str_value, model)
 
 
-class EmptyEntityAlternativeTableView(WithUndoStack, EntityAlternativeTableViewBase):
-    def sizeHint(self, /):
+class EmptyEntityAlternativeTableView(BelowSeam, WithUndoStack, EntityAlternativeTableViewBase):
+
+    def sizeHint(self) -> QSize:
         return height_limited_size_hint(super().sizeHint(), self.parent().size())
 
     def _plot_selection(self, selection, plot_widget=None):
         return
 
 
-class EntityAlternativeTableView(EntityAlternativeTableViewBase):
+class EntityAlternativeTableView(AboveSeam, EntityAlternativeTableViewBase):
     """Visualize entities and their alternatives."""
 
 

--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -24,6 +24,7 @@ from ..mvcmodels.empty_models import (
     EmptyParameterDefinitionModel,
     EmptyParameterValueModel,
 )
+from ..stacked_table_seam import StackedTableSeam
 from .custom_qwidgets import AddedEntitiesPopup
 from .element_name_list_editor import ElementNameListEditor
 
@@ -63,6 +64,13 @@ class StackedViewMixin:
             view.connect_spine_db_editor(self)
             view.request_replace_undo_redo_actions.connect(self._replace_undo_redo_actions)
             view.request_reset_undo_redo_actions.connect(self.update_undo_redo_actions)
+        self._seams: list[StackedTableSeam] = []
+        for top_table, bottom_table in (
+            (self.ui.tableView_parameter_value, self.ui.empty_parameter_value_table_view),
+            (self.ui.tableView_parameter_definition, self.ui.empty_parameter_definition_table_view),
+            (self.ui.tableView_entity_alternative, self.ui.empty_entity_alternative_table_view),
+        ):
+            self._seams.append(StackedTableSeam(top_table, bottom_table))
 
     def connect_signals(self):
         """Connects signals to slots."""

--- a/tests/spine_db_editor/test_stacked_table_seam.py
+++ b/tests/spine_db_editor/test_stacked_table_seam.py
@@ -1,0 +1,53 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+from PySide6.QtCore import QModelIndex, Qt
+from PySide6.QtGui import QStandardItem, QStandardItemModel
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QTableView, QWidget
+import pytest
+from spinetoolbox.spine_db_editor.stacked_table_seam import AboveSeam, BelowSeam, StackedTableSeam
+
+
+class TopTable(AboveSeam, QTableView):
+    pass
+
+
+class Bottomtable(BelowSeam, QTableView):
+    pass
+
+
+@pytest.fixture
+def parent(application):
+    parent_widget = QWidget()
+    yield parent_widget
+    parent_widget.deleteLater()
+
+
+class TestStackedTableSeam:
+    def test_navigating_from_top_to_bottom_and_back(self, parent):
+        top_table = TopTable(parent)
+        top_model = QStandardItemModel(parent)
+        top_model.appendRow([QStandardItem("top A"), QStandardItem("top B")])
+        top_table.setModel(top_model)
+        bottom_table = Bottomtable(parent)
+        bottom_model = QStandardItemModel(parent)
+        bottom_model.appendRow([QStandardItem("bottom A"), QStandardItem("bottom B")])
+        bottom_table.setModel(bottom_model)
+        seam = StackedTableSeam(top_table, bottom_table)
+        assert bottom_table.currentIndex() == QModelIndex()
+        top_table.setCurrentIndex(top_model.index(0, 0))
+        QTest.keyClick(top_table, Qt.Key.Key_Down)
+        assert bottom_table.currentIndex() == bottom_model.index(0, 0)
+        QTest.keyClick(bottom_table, Qt.Key.Key_Right)
+        assert bottom_table.currentIndex() == bottom_model.index(0, 1)
+        QTest.keyClick(bottom_table, Qt.Key.Key_Up)
+        assert top_table.currentIndex() == top_model.index(0, 1)


### PR DESCRIPTION
The up and down keys now work seamlessly between the compound and empty tables in DB editor.

Re #3102

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
