### PR TITLE
Fix Traceback when editing entity byname in empty tables

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -436,9 +436,7 @@ class EntityMixin:
         byname = row_data[cls.entity_byname_column]
         if not byname:
             return []
-        return [
-            x["entity_class_name"] for x in db_map.find_entities(entity_byname=tuple(byname.split(DB_ITEM_SEPARATOR)))
-        ]
+        return [x["entity_class_name"] for x in db_map.find_entities(entity_byname=byname)]
 
 
 class EmptyParameterDefinitionModel(SplitValueAndTypeMixin, ParameterMixin, EmptyModelBase):

--- a/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_qtableview.py
@@ -15,7 +15,7 @@ from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any, ClassVar, Optional, Union
 from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, QPoint, QSize, Qt, QTimer, Signal, Slot
-from PySide6.QtGui import QAction, QKeyEvent, QKeySequence, QUndoStack
+from PySide6.QtGui import QAction, QKeySequence, QUndoStack
 from PySide6.QtWidgets import QHeaderView, QMenu, QTableView, QWidget
 from ...helpers import DB_ITEM_SEPARATOR, preferred_row_height, rows_to_row_count_tuples
 from ...mvcmodels.minimal_table_model import MinimalTableModel

--- a/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
+++ b/tests/spine_db_editor/mvcmodels/test_emptyParameterModels.py
@@ -25,7 +25,7 @@ from spinedb_api import (
 from spinedb_api.parameter_value import join_value_and_type, to_database
 from spinetoolbox.helpers import DB_ITEM_SEPARATOR, signal_waiter
 from spinetoolbox.spine_db_editor.mvcmodels.empty_models import EmptyParameterDefinitionModel, EmptyParameterValueModel
-from tests.mock_helpers import TestCaseWithQApplication, MockSpineDBManager, fetch_model, q_object
+from tests.mock_helpers import MockSpineDBManager, TestCaseWithQApplication, fetch_model, q_object
 
 
 def _empty_indexes(model):
@@ -65,7 +65,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
             self.assertTrue(
                 model.batch_set_data(
                     _empty_indexes(model),
-                    ["dog", "pluto", "breed", "Base", join_value_and_type(value, value_type), "mock_db"],
+                    ["dog", ("pluto",), "breed", "Base", join_value_and_type(value, value_type), "mock_db"],
                 )
             )
             values = self._db_map.get_items("parameter_value")
@@ -82,7 +82,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
             model.set_undo_stack(self._undo_stack)
             fetch_model(model)
             self.assertTrue(
-                model.batch_set_data(_empty_indexes(model), ["fish", "nemo", "water", "Base", "salty", "mock_db"])
+                model.batch_set_data(_empty_indexes(model), ["fish", ("nemo",), "water", "Base", "salty", "mock_db"])
             )
             values = [x for x in self._db_map.get_items("parameter_value") if not x["dimension_id_list"]]
             self.assertEqual(values, [])
@@ -97,7 +97,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
             value, value_type = to_database("bloodhound")
             self.assertTrue(
                 model.batch_set_data(
-                    indexes, ["cat", "pluto", "breed", "Base", join_value_and_type(value, value_type), "mock_db"]
+                    indexes, ["cat", ("pluto",), "breed", "Base", join_value_and_type(value, value_type), "mock_db"]
                 )
             )
             self.assertEqual(indexes[0].data(), "dog")
@@ -120,7 +120,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
                     _empty_indexes(model),
                     [
                         "dog__fish",
-                        DB_ITEM_SEPARATOR.join(["pluto", "nemo"]),
+                        ("pluto", "nemo"),
                         "relative_speed",
                         "Base",
                         join_value_and_type(value, value_type),
@@ -232,7 +232,7 @@ class TestEmptyParameterModel(TestCaseWithQApplication):
                 self.assertTrue(
                     model.batch_set_data(
                         _empty_indexes(model),
-                        ["dog", "plato", "breed", "Base", join_value_and_type(value, value_type), "mock_db"],
+                        ["dog", ("plato",), "breed", "Base", join_value_and_type(value, value_type), "mock_db"],
                     )
                 )
                 self.assertEqual(


### PR DESCRIPTION
No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
