### PR TITLE
Fix removing multiple rows from empty tables

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/empty_models.py
@@ -109,7 +109,7 @@ class EmptyModelBase(EmptyRowModel):
 
     def remove_rows(self, rows: Iterable[int]) -> None:
         self._undo_stack.beginMacro("remove rows")
-        for row in rows:
+        for row in sorted(rows, reverse=True):
             self._undo_stack.push(RemoveEmptyModelRow(self, row))
         self._undo_stack.endMacro()
 


### PR DESCRIPTION
This PR fixes a bug where wrong rows got removed and some rows were not removed at all in DB editor's empty tables when multiple rows were selected for removal.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
