### PR TITLE
Fix entity byname editors in DB Editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_delegates.py
@@ -30,7 +30,7 @@ from spinetoolbox.spine_db_editor.widgets.custom_editors import (
     SearchBarEditorWithCreation,
 )
 from ...font import TOOLBOX_FONT
-from ...helpers import object_icon
+from ...helpers import DB_ITEM_SEPARATOR, object_icon
 from ...mvcmodels.shared import DB_MAP_ROLE, INVALID_TYPE, PARAMETER_TYPE_VALIDATION_ROLE, PARSED_ROLE
 from ...spine_db_manager import SpineDBManager
 from ...widgets.custom_delegates import CheckBoxDelegate, RankDelegate
@@ -488,13 +488,15 @@ class EntityBynameDelegate(TableDelegate):
             entity_class = self.db_mngr.get_item(db_map, "entity_class", entity_class_id)
             if entity_class["dimension_id_list"]:
                 self.element_name_list_editor_requested.emit(index, entity_class_id, db_map)
-                return
+                return None
             entities = self.db_mngr.get_items_by_field(db_map, "entity", "class_id", entity_class_id)
         else:
             entities = self.db_mngr.get_items(db_map, "entity")
         editor = GroupEditor(self.parent(), parent)
         name_list = list({x["name"]: None for x in entities})
-        editor.set_data(index.data(Qt.ItemDataRole.EditRole), name_list)
+        current_byname = index.data(Qt.ItemDataRole.EditRole)
+        current_name = current_byname[0] if current_byname else None
+        editor.set_data(current_name, name_list)
         editor.data_committed.connect(lambda *_: self._close_editor(editor, index))
         return editor
 

--- a/spinetoolbox/spine_db_editor/widgets/custom_editors.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_editors.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """Custom editors for model/view programming."""
+from collections.abc import Iterable
 from contextlib import suppress
 from typing import Optional
 from PySide6.QtCore import (
@@ -202,12 +203,12 @@ class SearchBarEditor(QTableView):
         hover_color = self.palette().color(QPalette.ColorGroup.Active, QPalette.ColorRole.Highlight).lighter(220)
         self.setStyleSheet(f"QTableView::item:hover {{background: {hover_color.name()};}}")
 
-    def set_data(self, current, items):
+    def set_data(self, current: str, items: Iterable[str]):
         """Populates model.
 
         Args:
-            current (str): item that is currently selected from given items
-            items (Sequence of str): items to show in the list
+            current: item that is currently selected from given items
+            items: items to show in the list
         """
         item_list = [QStandardItem(current)]
         for item in sorted(items, key=lambda x: order_key(x.casefold())):

--- a/tests/spine_db_editor/widgets/test_custom_delegates.py
+++ b/tests/spine_db_editor/widgets/test_custom_delegates.py
@@ -14,9 +14,11 @@
 import unittest
 from unittest import mock
 from PySide6.QtGui import QStandardItem, QStandardItemModel
+from PySide6.QtWidgets import QStyleOptionViewItem
 from spinetoolbox.helpers import signal_waiter
-from spinetoolbox.spine_db_editor.widgets.custom_delegates import BooleanValueDelegate
-from tests.mock_helpers import TestCaseWithQApplication
+from spinetoolbox.spine_db_editor.widgets.custom_delegates import BooleanValueDelegate, EntityBynameDelegate
+from spinetoolbox.spine_db_editor.widgets.custom_editors import GroupEditor
+from tests.mock_helpers import TestCaseWithQApplication, assert_table_model_data_pytest
 
 
 class TestBooleanValueDelegate(TestCaseWithQApplication):
@@ -55,5 +57,77 @@ class TestBooleanValueDelegate(TestCaseWithQApplication):
             data_committed_signal.emit.assert_not_called()
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestEntityBynameDelegate:
+    def test_create_editor_for_undefined_entity_with_empty_model(self, db_map, db_mngr, db_editor):
+        db_map.add_entity_class(name="Object")
+        db_map.add_entity(entity_class_name="Object", name="cube")
+        db_map.add_entity(entity_class_name="Object", name="sphere")
+        table_view = db_editor.ui.empty_entity_alternative_table_view
+        model = table_view.model()
+        entity_class_column = model.header.index("entity_class_name")
+        entity_byname_column = model.header.index("entity_byname")
+        model.batch_set_data([model.index(0, entity_class_column)], ["Object"])
+        delegate = EntityBynameDelegate(db_editor, db_mngr)
+        editor = delegate.createEditor(db_editor, QStyleOptionViewItem(), model.index(0, entity_byname_column))
+        assert isinstance(editor, GroupEditor)
+        assert editor.data() is ()
+        expected = [[""], ["cube"], ["sphere"]]
+        assert_table_model_data_pytest(editor.proxy_model, expected)
+
+    def test_create_editor_for_empty_byname_with_empty_model(self, db_map, db_mngr, db_editor):
+        db_map.add_entity_class(name="Object")
+        db_map.add_entity(entity_class_name="Object", name="cube")
+        db_map.add_entity(entity_class_name="Object", name="sphere")
+        table_view = db_editor.ui.empty_entity_alternative_table_view
+        model = table_view.model()
+        entity_class_column = model.header.index("entity_class_name")
+        entity_byname_column = model.header.index("entity_byname")
+        model.batch_set_data([model.index(0, entity_class_column)], ["Object"])
+        model.batch_set_data([model.index(0, entity_byname_column)], [()])
+        delegate = EntityBynameDelegate(db_editor, db_mngr)
+        editor = delegate.createEditor(db_editor, QStyleOptionViewItem(), model.index(0, entity_byname_column))
+        assert isinstance(editor, GroupEditor)
+        assert editor.data() == ()
+        expected = [[""], ["cube"], ["sphere"]]
+        assert_table_model_data_pytest(editor.proxy_model, expected)
+
+    def test_create_editor_for_preselected_0_dimensional_entity_with_empty_model(self, db_map, db_mngr, db_editor):
+        db_map.add_entity_class(name="Object")
+        db_map.add_entity(entity_class_name="Object", name="cube")
+        db_map.add_entity(entity_class_name="Object", name="sphere")
+        table_view = db_editor.ui.empty_entity_alternative_table_view
+        model = table_view.model()
+        entity_class_column = model.header.index("entity_class_name")
+        entity_byname_column = model.header.index("entity_byname")
+        model.batch_set_data([model.index(0, entity_class_column)], ["Object"])
+        model.batch_set_data([model.index(0, entity_byname_column)], [("cube",)])
+        delegate = EntityBynameDelegate(db_editor, db_mngr)
+        editor = delegate.createEditor(db_editor, QStyleOptionViewItem(), model.index(0, entity_byname_column))
+        assert isinstance(editor, GroupEditor)
+        assert editor.data() == ("cube",)
+        expected = [["cube"], ["cube"], ["sphere"]]
+        assert_table_model_data_pytest(editor.proxy_model, expected)
+
+    def test_create_editor_for_preselected_multi_dimensional_entity_with_empty_model(self, db_map, db_mngr, db_editor):
+        db_map.add_entity_class(name="Source")
+        db_map.add_entity(entity_class_name="Source", name="source")
+        db_map.add_entity_class(name="Target")
+        db_map.add_entity(entity_class_name="Target", name="target1")
+        db_map.add_entity(entity_class_name="Target", name="target2")
+        relationship = db_map.add_entity_class(dimension_name_list=["Source", "Target"])
+        db_map.add_entity(entity_class_name="Source__Target", entity_byname=("source", "target1"))
+        db_map.add_entity(entity_class_name="Source__Target", entity_byname=("source", "target2"))
+        table_view = db_editor.ui.empty_entity_alternative_table_view
+        model = table_view.model()
+        model.set_default_row(
+            entity_class_name="Source__Target", database=db_mngr.name_registry.display_name(db_map.db_url)
+        )
+        model.set_rows_to_default(0)
+        entity_byname_column = model.header.index("entity_byname")
+        model.batch_set_data([model.index(0, entity_byname_column)], [("source", "target1")])
+        delegate = EntityBynameDelegate(db_editor, db_mngr)
+        index = model.index(0, entity_byname_column)
+        with signal_waiter(delegate.element_name_list_editor_requested) as waiter:
+            editor = delegate.createEditor(db_editor, QStyleOptionViewItem(), index)
+        assert editor is None
+        assert waiter.args == (index, relationship["id"], db_map)


### PR DESCRIPTION
This PR fixes a bug where trying to edit entity byname in DB editor would result in a Traceback.

No associated issue.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Release notes have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
