### PR TITLE
Fix pasting into variable resolution time series editor

### DIFF
--- a/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/stacked_view_mixin.py
@@ -13,6 +13,8 @@
 """Contains the StackedViewMixin class."""
 from typing import Optional
 from PySide6.QtCore import QItemSelection, QModelIndex, Qt, Slot
+from spinedb_api import DatabaseMapping
+from spinedb_api.temp_id import TempId
 from ...helpers import preferred_row_height
 from ..empty_table_size_hint_provider import EmptyTableSizeHintProvider
 from ..mvcmodels.compound_models import (
@@ -114,14 +116,8 @@ class StackedViewMixin:
         self._set_default_parameter_data()
 
     @Slot(QModelIndex, object, object)
-    def show_element_name_list_editor(self, index, entity_class_id, db_map):
-        """Shows the element name list editor.
-
-        Args:
-            index (QModelIndex)
-            entity_class_id (int)
-            db_map (DatabaseMapping)
-        """
+    def show_element_name_list_editor(self, index: QModelIndex, entity_class_id: TempId, db_map: DatabaseMapping):
+        """Shows the element name list editor."""
         entity_class = self.db_mngr.get_item(db_map, "entity_class", entity_class_id)
         dimension_id_list = entity_class.get("dimension_id_list", ())
         dimension_names = []

--- a/tests/widgets/test_IndexedValueTableView.py
+++ b/tests/widgets/test_IndexedValueTableView.py
@@ -39,9 +39,9 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_copy(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 0), QItemSelectionModel.Select)
-        selection_model.select(model.index(1, 1), QItemSelectionModel.Select)
-        selection_model.select(model.index(2, 0), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(1, 1), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(2, 0), QItemSelectionModel.SelectionFlag.Select)
         self._table_view.copy()
         copied = QApplication.clipboard().text()
         with system_lc_numeric():
@@ -52,7 +52,7 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
         model = self._table_view.model()
         for column in range(model.columnCount()):
             for row in range(model.rowCount()):
-                selection_model.select(model.index(row, column), QItemSelectionModel.Select)
+                selection_model.select(model.index(row, column), QItemSelectionModel.SelectionFlag.Select)
         self._table_view.copy()
         copied = QApplication.clipboard().text()
         with system_lc_numeric():
@@ -66,7 +66,7 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_paste_single_value(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -81,7 +81,7 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_paste_single_index(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 0), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
         copied_data = "2019-08-08T00:00"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -93,10 +93,45 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
         )
         self.assertEqual(model.value, series)
 
+    def test_pasting_multirow_multicolumn_data_to_single_index(self):
+        selection_model = self._table_view.selectionModel()
+        model = self._table_view.model()
+        selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
+        copied_data = """2018-03-31T00:00:00\t434
+        2018-03-31T00:01:00\t424
+        2018-03-31T00:02:00\t414
+        2018-03-31T00:03:00\t404
+        2018-03-31T00:04:00\t411
+        2018-03-31T00:05:00\t422
+        2018-03-31T00:06:00\t433
+        2018-03-31T00:07:00\t444
+        2018-03-31T00:08:00\t455
+        2018-03-31T00:09:00\t466"""
+        with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
+            self.assertTrue(self._table_view.paste())
+        series = TimeSeriesVariableResolution(
+            [
+                "2018-03-31T00:00",
+                "2018-03-31T00:01",
+                "2018-03-31T00:02",
+                "2018-03-31T00:03",
+                "2018-03-31T00:04",
+                "2018-03-31T00:05",
+                "2018-03-31T00:06",
+                "2018-03-31T00:07",
+                "2018-03-31T00:08",
+                "2018-03-31T00:09",
+            ],
+            [434.0, 424.0, 414.0, 404.0, 411.0, 422.0, 433.0, 444.0, 455.0, 466.0],
+            False,
+            False,
+        )
+        self.assertEqual(model.value, series)
+
     def test_pasting_multiple_columns_to_last_row_expands_model(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(3, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(3, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = f"2019-08-08T17:00\t{-4.4}\n2019-08-08T18:00\t{-5.5}"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -111,7 +146,7 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_pasting_single_column_to_last_row_expands_model(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(3, 0), QItemSelectionModel.Select)
+        selection_model.select(model.index(3, 0), QItemSelectionModel.SelectionFlag.Select)
         copied_data = "2019-08-08T17:00\n2019-08-08T18:00"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -126,10 +161,10 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_paste_to_multirow_selection_limits_pasted_data(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(1, 0), QItemSelectionModel.Select)
-        selection_model.select(model.index(1, 1), QItemSelectionModel.Select)
-        selection_model.select(model.index(2, 0), QItemSelectionModel.Select)
-        selection_model.select(model.index(2, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(1, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(1, 1), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(2, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(2, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = f"2019-08-08T12:30\t{-2.2}\n2019-08-08T13:30\t{-3.3}\n2019-08-08T14:30\t{-4.4}"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -144,12 +179,12 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_paste_to_larger_selection_cycles_data(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 0), QItemSelectionModel.Select)
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
-        selection_model.select(model.index(1, 0), QItemSelectionModel.Select)
-        selection_model.select(model.index(1, 1), QItemSelectionModel.Select)
-        selection_model.select(model.index(2, 0), QItemSelectionModel.Select)
-        selection_model.select(model.index(2, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(1, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(1, 1), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(2, 0), QItemSelectionModel.SelectionFlag.Select)
+        selection_model.select(model.index(2, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = f"2019-08-08T12:30\t{-1.1}\n2019-08-08T13:30\t{-2.2}"
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())
@@ -164,7 +199,7 @@ class TestIndexedValueTableView(TestCaseWithQApplication):
     def test_pasted_cells_are_selected(self):
         selection_model = self._table_view.selectionModel()
         model = self._table_view.model()
-        selection_model.select(model.index(0, 1), QItemSelectionModel.Select)
+        selection_model.select(model.index(0, 1), QItemSelectionModel.SelectionFlag.Select)
         copied_data = locale.str(-1.1) + "\n" + locale.str(-2.2)
         with mock_clipboard_patch(copied_data, "spinetoolbox.widgets.custom_qtableview.QApplication.clipboard"):
             self.assertTrue(self._table_view.paste())


### PR DESCRIPTION
This PR fixes a bug where data was sometime pasted only partially into variable resolution time series editor.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
