### PR TITLE
Fix deadlock in unit tests

### DIFF
--- a/spinetoolbox/widgets/notification.py
+++ b/spinetoolbox/widgets/notification.py
@@ -94,7 +94,7 @@ class Notification(QFrame):
         self.fade_out_anim.valueChanged.connect(self.update_opacity)
         self.fade_out_anim.finished.connect(self.close)
         # Start fade in animation
-        self.fade_in_anim.start(QPropertyAnimation.DeleteWhenStopped)
+        self.fade_in_anim.start(QPropertyAnimation.DeletionPolicy.DeleteWhenStopped)
 
     def show(self):
         """Shows widget and moves it to the selected corner of the parent widget."""


### PR DESCRIPTION
For unknown reason, notification animations stopped proceeding in GitHub actions (ubuntu-latest Python 3.13 at least).
We now forcefully set animation timer to total duration which also makes the test much faster.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
