### PR TITLE
Limit pivot table data so DB editor won't hang for a long period

### DIFF
--- a/spinetoolbox/fetch_parent.py
+++ b/spinetoolbox/fetch_parent.py
@@ -32,7 +32,9 @@ class FetchParent(QObject):
 
     _changes_pending = Signal()
 
-    def __init__(self, index: Optional[FetchIndex] = None, owner: Optional[object] = None, chunk_size: int = 1000):
+    def __init__(
+        self, index: Optional[FetchIndex] = None, owner: Optional[object] = None, chunk_size: int | None = 1000
+    ):
         """
         Args:
             index: an index to speedup looking up fetched items
@@ -261,7 +263,7 @@ class ItemTypeFetchParent(FetchParent):
         fetch_item_type: str,
         index: Optional[FetchIndex] = None,
         owner: Optional[object] = None,
-        chunk_size: int = 1000,
+        chunk_size: int | None = 1000,
     ):
         super().__init__(index=index, owner=owner, chunk_size=chunk_size)
         self._fetch_item_type = fetch_item_type
@@ -299,7 +301,7 @@ class FlexibleFetchParent(ItemTypeFetchParent):
         key_for_index: Optional[Callable[[DatabaseMapping], TempId]] = None,
         index: Optional[FetchIndex] = None,
         owner: Optional[object] = None,
-        chunk_size: int = 1000,
+        chunk_size: int | None = 1000,
     ):
         super().__init__(fetch_item_type, index=index, owner=owner, chunk_size=chunk_size)
         self._handle_items_added = handle_items_added

--- a/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/pivot_table_models.py
@@ -11,12 +11,13 @@
 ######################################################################################################################
 
 """Provides pivot table models for the Tabular View."""
+from __future__ import annotations
 from collections import defaultdict
 from contextlib import suppress
 from functools import partial
 from itertools import product
 from operator import itemgetter
-from typing import Iterable, Union
+from typing import TYPE_CHECKING, Iterable, Union
 from PySide6.QtCore import QAbstractTableModel, QModelIndex, QSortFilterProxyModel, Qt, QTimer, Signal, Slot
 from PySide6.QtGui import QFont
 from spinedb_api import DatabaseMapping
@@ -24,7 +25,7 @@ from spinedb_api.helpers import name_from_elements
 from spinedb_api.parameter_value import IndexedValue, join_value_and_type, split_value_and_type
 from spinedb_api.temp_id import TempId
 from spinetoolbox.fetch_parent import FlexibleFetchParent
-from spinetoolbox.helpers import DB_ITEM_SEPARATOR, DBMapTypedDictItems, parameter_identifier, plain_to_tool_tip
+from spinetoolbox.helpers import DB_ITEM_SEPARATOR, parameter_identifier, plain_to_tool_tip
 from ...mvcmodels.shared import PARSED_ROLE
 from ..widgets.custom_delegates import (
     ParameterPivotTableDelegate,
@@ -34,24 +35,24 @@ from ..widgets.custom_delegates import (
 from .colors import FIXED_FIELD_COLOR, PIVOT_TABLE_HEADER_COLOR
 from .pivot_model import PivotModel
 
+if TYPE_CHECKING:
+    from spinetoolbox.spine_db_manager import SpineDBManager
+    from ..widgets.spine_db_editor import SpineDBEditor
+
 
 class TopLeftHeaderItem:
     """Base class for all 'top left pivot headers'.
     Represents a header located in the top left area of the pivot table."""
 
-    def __init__(self, model):
-        """
-        Args:
-            model (PivotTableModelBase)
-        """
+    def __init__(self, model: PivotTableModelBase):
         self._model = model
 
     @property
-    def model(self):
+    def model(self) -> PivotTableModelBase:
         return self._model
 
     @property
-    def db_mngr(self):
+    def db_mngr(self) -> SpineDBManager:
         return self._model.db_mngr
 
     def _get_header_data_from_db(self, item_type, header_id, field_name, role):
@@ -332,12 +333,9 @@ class PivotTableModelBase(QAbstractTableModel):
     model_data_changed = Signal()
     frozen_values_added = Signal(set)
     frozen_values_removed = Signal(set)
+    big_data_refused = Signal()
 
-    def __init__(self, db_editor):
-        """
-        Args:
-            db_editor (SpineDBEditor)
-        """
+    def __init__(self, db_editor: SpineDBEditor):
         super().__init__(db_editor)
         self._parent = db_editor
         self.db_mngr = db_editor.db_mngr
@@ -1506,6 +1504,7 @@ class IndexExpansionPivotTableModel(ParameterValuePivotTableModel):
             db_map_parameter_values = self._get_db_map_parameter_values_or_defs("parameter_value")
         full_data = {}
         get_id = _make_get_id(action)
+        big_data_refused = False
         for db_map, items in db_map_parameter_values.items():
             for item in items:
                 element_ids = tuple((db_map, id_) for id_ in item["element_id_list"])
@@ -1522,6 +1521,11 @@ class IndexExpansionPivotTableModel(ParameterValuePivotTableModel):
                     full_data[element_ids + ((None, value_index), parameter_id, alternative_ids, db_map)] = get_id(
                         db_map, item
                     )
+                if len(full_data) > 100000:
+                    big_data_refused = True
+                    break
+        if big_data_refused:
+            self.big_data_refused.emit()
         return full_data
 
     def _data(self, index, role):
@@ -1599,6 +1603,7 @@ class ElementPivotTableModel(PivotTableModelBase):
             for item in items:
                 class_entities.setdefault(item["class_id"], []).append(item)
         data = {}
+        big_data_refused = False
         for db_map in self.db_maps:
             element_id_lists = []
             all_given_ids = set()
@@ -1612,12 +1617,16 @@ class ElementPivotTableModel(PivotTableModelBase):
                     ids.update(given_ids)
                     all_given_ids.update(given_ids.keys())
                 element_id_lists.append(list(ids.keys()))
-            db_map_data = {
-                tuple((db_map, id_) for id_ in element_ids) + (db_map,): None
-                for element_ids in product(*element_id_lists)
-                if not all_given_ids or all_given_ids.intersection(element_ids)
-            }
+            db_map_data = {}
+            for i, element_ids in enumerate(product(*element_id_lists)):
+                if i == 100000:
+                    big_data_refused = True
+                    break
+                if not all_given_ids or not all_given_ids.isdisjoint(element_ids):
+                    db_map_data[tuple((db_map, id_) for id_ in element_ids) + (db_map,)] = None
             data.update(db_map_data)
+        if big_data_refused:
+            self.big_data_refused.emit()
         return data
 
     def _handle_elements_added(self, db_map_data):

--- a/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
+++ b/spinetoolbox/spine_db_editor/widgets/tabular_view_mixin.py
@@ -17,7 +17,7 @@ from itertools import chain
 from typing import ClassVar, Optional
 from PySide6.QtCore import QModelIndex, Qt, QTimer, Slot
 from PySide6.QtGui import QAction, QActionGroup
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QMessageBox, QWidget
 from spinedb_api import DatabaseMapping
 from spinedb_api.helpers import fix_name_ambiguity
 from spinedb_api.temp_id import TempId
@@ -291,12 +291,14 @@ class TabularViewMixin:
                 self.pivot_table_model.modelReset.disconnect(self.reload_frozen_table)
                 self.pivot_table_model.frozen_values_added.disconnect(self._add_values_to_frozen_table)
                 self.pivot_table_model.frozen_values_removed.disconnect(self._remove_values_from_frozen_table)
+                self.pivot_table_model.big_data_refused.disconnect(self._warn_big_data_refused)
             self.pivot_table_model = pivot_table_model
             self.pivot_table_proxy.setSourceModel(self.pivot_table_model)
             self.pivot_table_model.modelReset.connect(self.make_pivot_headers)
             self.pivot_table_model.modelReset.connect(self.reload_frozen_table)
             self.pivot_table_model.frozen_values_added.connect(self._add_values_to_frozen_table)
             self.pivot_table_model.frozen_values_removed.connect(self._remove_values_from_frozen_table)
+            self.pivot_table_model.big_data_refused.connect(self._warn_big_data_refused)
             delegate = self.pivot_table_model.make_delegate(self)
             self.ui.pivot_table.setItemDelegate(delegate)
         pivot = self.get_pivot_preferences()
@@ -634,6 +636,12 @@ class TabularViewMixin:
             yield
         finally:
             self._disable_frozen_table_reload = False
+
+    @Slot()
+    def _warn_big_data_refused(self):
+        QMessageBox.warning(
+            self, "Too much data to show", "The data contains too many elements to show. Some data was dropped."
+        )
 
     def closeEvent(self, event):
         super().closeEvent(event)


### PR DESCRIPTION
Place a limit for how many items we are going to show in pivot table (Index and Element views), so users do not have to wait tens of minutes/hours for their data to appear on screen. If the limit is reached, we show a warning dialog and clip the data.

This is just a stopgap solution. Hopefully one day we can make large datasets manageable in the pivot view.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
