### PR TITLE
Replace unsupported cp-1252 characters

### DIFF
--- a/spinetoolbox/server/engine_client.py
+++ b/spinetoolbox/server/engine_client.py
@@ -236,7 +236,7 @@ class EngineClient:
                 f.write(file_data)
         except Exception as e:
             return "fail", f"Saving the received file to '{dst_fpath}' failed. [{type(e).__name__}: {e}"
-        return "neutral", f"<b>{fname}</b> saved to  <b>&#x227A;project_dir&#x227B;/{rel_path_wo_fname}</b>"
+        return "neutral", f"<b>{fname}</b> saved to  <b>[project_dir]/{rel_path_wo_fname}</b>"
 
     def retrieve_project(self, job_id):
         """Retrieves a zipped project file from server.


### PR DESCRIPTION
This PR replaces two characters that produced a traceback when running an execution in headless remote mode on Windows. The characters were sent to the Event Log by the EngineClient class.

No reported issue. 

## Checklist before merging
- [x] Unit tests pass
