### PR TITLE
Remove accidentally added Entity dock from DB editor

### DIFF
--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'spine_db_editor_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -30,7 +30,7 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
 from PySide6.QtWidgets import (QAbstractItemView, QAbstractScrollArea, QApplication, QDockWidget,
     QFrame, QGraphicsView, QHBoxLayout, QHeaderView,
     QMainWindow, QMenu, QMenuBar, QSizePolicy,
-    QSpacerItem, QTableView, QVBoxLayout, QWidget)
+    QSpacerItem, QVBoxLayout, QWidget)
 
 from spinetoolbox.spine_db_editor.widgets.custom_qgraphicsviews import EntityQGraphicsView
 from spinetoolbox.spine_db_editor.widgets.custom_qtableview import (EmptyEntityAlternativeTableView, EmptyParameterDefinitionTableView, EmptyParameterValueTableView, EntityAlternativeTableView,
@@ -547,21 +547,6 @@ class Ui_MainWindow(object):
         self.menuFile_2 = QMenu(self.menuBar)
         self.menuFile_2.setObjectName(u"menuFile_2")
         MainWindow.setMenuBar(self.menuBar)
-        self.entity_dock_widget = QDockWidget(MainWindow)
-        self.entity_dock_widget.setObjectName(u"entity_dock_widget")
-        self.dockWidgetContents_4 = QWidget()
-        self.dockWidgetContents_4.setObjectName(u"dockWidgetContents_4")
-        self.verticalLayout_3 = QVBoxLayout(self.dockWidgetContents_4)
-        self.verticalLayout_3.setSpacing(0)
-        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
-        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
-        self.entity_table_view = QTableView(self.dockWidgetContents_4)
-        self.entity_table_view.setObjectName(u"entity_table_view")
-
-        self.verticalLayout_3.addWidget(self.entity_table_view)
-
-        self.entity_dock_widget.setWidget(self.dockWidgetContents_4)
-        MainWindow.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self.entity_dock_widget)
 
         self.menuBar.addAction(self.menuFile_2.menuAction())
         self.menuBar.addAction(self.menuEdit.menuAction())
@@ -751,6 +736,5 @@ class Ui_MainWindow(object):
         self.menuEdit.setTitle(QCoreApplication.translate("MainWindow", u"&Edit", None))
         self.menuSession.setTitle(QCoreApplication.translate("MainWindow", u"Sess&ion", None))
         self.menuFile_2.setTitle(QCoreApplication.translate("MainWindow", u"&File", None))
-        self.entity_dock_widget.setWindowTitle(QCoreApplication.translate("MainWindow", u"Entity", None))
     # retranslateUi
 

--- a/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
+++ b/spinetoolbox/spine_db_editor/ui/spine_db_editor_window.ui
@@ -857,36 +857,6 @@
    <addaction name="menuSession"/>
    <addaction name="menuHelp"/>
   </widget>
-  <widget class="QDockWidget" name="entity_dock_widget">
-   <property name="windowTitle">
-    <string>Entity</string>
-   </property>
-   <attribute name="dockWidgetArea">
-    <number>1</number>
-   </attribute>
-   <widget class="QWidget" name="dockWidgetContents_4">
-    <layout class="QVBoxLayout" name="verticalLayout_3">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QTableView" name="entity_table_view"/>
-     </item>
-    </layout>
-   </widget>
-  </widget>
   <action name="actionCommit">
    <property name="enabled">
     <bool>true</bool>

--- a/spinetoolbox/ui/project_settings_dialog.py
+++ b/spinetoolbox/ui/project_settings_dialog.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'project_settings_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -63,7 +63,6 @@ class Ui_Form(object):
 
         self.name_line_edit = QLineEdit(Form)
         self.name_line_edit.setObjectName(u"name_line_edit")
-        self.name_line_edit.setEnabled(False)
         self.name_line_edit.setReadOnly(True)
 
         self.formLayout.setWidget(0, QFormLayout.ItemRole.FieldRole, self.name_line_edit)

--- a/spinetoolbox/ui/project_settings_dialog.ui
+++ b/spinetoolbox/ui/project_settings_dialog.ui
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http:\/\/www.gnu.org\/licenses\/>.
+######################################################################################################################
+-->
 <ui version="4.0">
  <class>Form</class>
  <widget class="QWidget" name="Form">


### PR DESCRIPTION
The dock somehow slipped to master from a development branch.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
