### PR TITLE
Fix adding entities in Graph view

### DIFF
--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -426,6 +426,25 @@ class TestAddEntitiesDialog(TestBase):
         self.assertEqual(model.index(0, 2).data(), None)
         self.assertEqual(model.index(0, 3).data(), self.db_codename)
 
+    def test_select_entity_class_with_combo_box_when_no_entity_is_selected_in_entity_tree(self):
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Object_1", "active_by_default": False}]})
+        root_index = self._db_editor.entity_tree_model.index(0, 0)
+        root_item = self._db_editor.entity_tree_model.item_from_index(root_index)
+        dialog = AddEntitiesDialog(self._db_editor, root_item, self._db_mngr, self._db_map)
+        model = dialog.model
+        dialog.ent_cls_combo_box.setCurrentText("Object_1")
+        model.fetchMore(QModelIndex())
+        self.assertEqual(model.columnCount(), 4)
+        self.assertEqual(model.headerData(0), "entity name")
+        self.assertEqual(model.headerData(1), "alternative")
+        self.assertEqual(model.headerData(2), "entity group")
+        self.assertEqual(model.headerData(3), "databases")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.index(0, 0).data(), None)
+        self.assertEqual(model.index(0, 1).data(), "Base")
+        self.assertEqual(model.index(0, 2).data(), None)
+        self.assertEqual(model.index(0, 3).data(), self.db_codename)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug where opening the Add entities dialog from the popup menu in Graph view would result in a Traceback.

Fixes #3179, #3181

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
