### PR TITLE
Improve Add entities and Add entity classes dialogs

### DIFF
--- a/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/entity_tree_item.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """Classes to represent entities in a tree."""
+from typing import TypeAlias
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QBrush, QFont, QIcon
 from spinetoolbox.fetch_parent import FetchIndex, FlexibleFetchParent
@@ -88,6 +89,9 @@ class EntityTreeRootItem(MultiDBTreeItem):
             child.set_has_children_initially(
                 any(child.db_map_id(db_map) in db_map_entity_class_ids.get(db_map, ()) for db_map in child.db_maps)
             )
+
+
+EntityClassVisualKey: TypeAlias = tuple[str, tuple[str, ...], str | None]
 
 
 class EntityClassItem(MultiDBTreeItem):

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -281,6 +281,7 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
     @Slot()
     def accept(self):
         """Collect info from dialog and try to add items."""
+        self._commit_open_edits()
         db_map_data = {}
         header_labels = self.model.horizontal_header_labels()
         name_column = header_labels.index("entity class name")
@@ -608,6 +609,7 @@ class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):
     @Slot()
     def accept(self):
         """Collect info from dialog and try to add items."""
+        self._commit_open_edits()
         db_map_data = self.get_db_map_data()
         if db_map_data is None:
             return

--- a/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/add_items_dialogs.py
@@ -187,6 +187,7 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
         self.setWindowTitle("Add entity classes")
         self.model = EmptyAddEntityOrClassRowModel(self)
         self.model.force_default = force_default
+        self.model.rowsInserted.connect(self._focus_on_table)
         self.table_view.setModel(self.model)
         self.dimension_count_widget = QWidget(self)
         layout = QHBoxLayout(self.dimension_count_widget)
@@ -350,6 +351,12 @@ class AddEntityClassesDialog(ShowIconColorEditorMixin, GetEntityClassesMixin, Ad
     def dialog_item_name():
         return "entity class name"
 
+    @Slot(QModelIndex, int, int)
+    def _focus_on_table(self, parent: QModelIndex, first: int, last: int) -> None:
+        self.model.rowsInserted.disconnect(self._focus_on_table)
+        self.table_view.setCurrentIndex(self.model.index(0, 0))
+        self.table_view.setFocus()
+
 
 class AddEntitiesOrManageElementsDialog(GetEntityClassesMixin, GetEntitiesMixin, AddItemsDialog):
     """A dialog to query user's preferences for new entities."""
@@ -363,6 +370,7 @@ class AddEntitiesOrManageElementsDialog(GetEntityClassesMixin, GetEntitiesMixin,
         """
         super().__init__(parent, db_mngr, *db_maps)
         self.model = self.make_model()
+        self.model.rowsInserted.connect(self._focus_on_table)
         self.table_view.setModel(self.model)
         self.header_widget = QWidget(self)
         layout = QHBoxLayout(self.header_widget)
@@ -430,6 +438,12 @@ class AddEntitiesOrManageElementsDialog(GetEntityClassesMixin, GetEntitiesMixin,
             el_names = [n for n in (self.model.index(row, j).data() for j in range(dimension_count)) if n]
             entity_name = name_from_elements(el_names)
             self.model.setData(self.model.index(row, dimension_count), entity_name, role=Qt.ItemDataRole.UserRole)
+
+    @Slot(QModelIndex, int, int)
+    def _focus_on_table(self, parent: QModelIndex, first: int, last: int) -> None:
+        self.model.rowsInserted.disconnect(self._focus_on_table)
+        self.table_view.setCurrentIndex(self.model.index(0, 0))
+        self.table_view.setFocus()
 
 
 class AddEntitiesDialog(AddEntitiesOrManageElementsDialog):

--- a/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
+++ b/spinetoolbox/spine_db_editor/widgets/manage_items_dialogs.py
@@ -74,6 +74,8 @@ class DialogWithTableAndButtons(DialogWithButtons):
     def showEvent(self, ev):
         super().showEvent(ev)
         self.resize_window_to_columns()
+        if self.table_view.currentIndex() is None:
+            self.table_view.setFocus()
 
     def make_table_view(self) -> QTableWidget:
         raise NotImplementedError()

--- a/tests/spine_db_editor/widgets/test_add_items_dialog.py
+++ b/tests/spine_db_editor/widgets/test_add_items_dialog.py
@@ -445,6 +445,13 @@ class TestAddEntitiesDialog(TestBase):
         self.assertEqual(model.index(0, 2).data(), None)
         self.assertEqual(model.index(0, 3).data(), self.db_codename)
 
+    def test_get_db_map_data_when_dialog_is_empty(self):
+        self._db_mngr.add_items("entity_class", {self._db_map: [{"name": "Object_1", "active_by_default": False}]})
+        root_index = self._db_editor.entity_tree_model.index(0, 0)
+        root_item = self._db_editor.entity_tree_model.item_from_index(root_index)
+        dialog = AddEntitiesDialog(self._db_editor, root_item, self._db_mngr, self._db_map)
+        self.assertEqual(dialog.get_db_map_data(), {})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Fixed a Traceback when an empty Add entities dialog was accepted after being opened in Graph view
- The dialogs can now be accepted by **Ctrl+Enter** while the cell editor is still open - the editor's data will be committed to the table before the dialog processes the table
- The table is now focused and ready to accept input when the dialog is opened the first time

Fixes #3181

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
