### PR TITLE
Show parameter definition description as tooltip in parameter value tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- The parameter name column in parameter value tables now shows the parameter definition's
+  description as a tooltip on hover.
+
 ### Security
 
 ## [0.10.9]

--- a/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/single_models.py
@@ -397,7 +397,7 @@ class ParameterMixin:
         return {
             "entity_class_name": ("entity_class_id", "entity_class"),
             "entity_byname": ("entity_id", "entity"),
-            "parameter_name": (self.parameter_definition_id_key, "parameter_definition"),
+            "parameter_definition_name": (self.parameter_definition_id_key, "parameter_definition"),
             "value_list_name": ("value_list_id", "parameter_value_list"),
             "description": ("id", "parameter_definition"),
             "value": ("id", "parameter_value"),

--- a/tests/spine_db_editor/mvcmodels/test_single_models.py
+++ b/tests/spine_db_editor/mvcmodels/test_single_models.py
@@ -12,6 +12,7 @@
 
 """Unit tests for the ``single_models`` module."""
 
+from PySide6.QtCore import Qt
 import pytest
 from spinetoolbox.mvcmodels.shared import DB_MAP_ROLE, HAS_METADATA_ROLE
 from spinetoolbox.spine_db_editor.mvcmodels.compound_models import (
@@ -28,6 +29,7 @@ from spinetoolbox.spine_db_editor.mvcmodels.utils import (
     ENTITY_FIELD_MAP,
     PARAMETER_DEFINITION_FIELD_MAP,
     PARAMETER_VALUE_FIELD_MAP,
+    field_index,
 )
 
 ENTITY_PARAMETER_VALUE_HEADER = [
@@ -125,6 +127,45 @@ class TestSingleParameterValueModel:
         for column in range(model.columnCount()):
             assert model.index(0, column).data(HAS_METADATA_ROLE)
             assert not model.index(1, column).data(HAS_METADATA_ROLE)
+
+    def test_parameter_name_column_tooltip_shows_definition_description(
+        self, single_parameter_value_model, db_map, gadget
+    ):
+        with db_map:
+            my_parameter = db_map.add_parameter_definition(
+                entity_class_id=gadget["id"], name="my_parameter", description="The description of my parameter."
+            )
+            my_object = db_map.add_entity(class_id=gadget["id"], name="my_object")
+            parameter_value = db_map.add_parameter_value(
+                entity_class_id=gadget["id"],
+                entity_id=my_object["id"],
+                parameter_definition_id=my_parameter["id"],
+                alternative_name="Base",
+                parsed_value=2.3,
+            )
+        model = single_parameter_value_model
+        model.add_rows([parameter_value["id"]])
+        column = field_index("parameter_definition_name", PARAMETER_VALUE_FIELD_MAP)
+        tooltip = model.index(0, column).data(Qt.ItemDataRole.ToolTipRole)
+        assert tooltip == "<qt>The description of my parameter.</qt>"
+
+    def test_parameter_name_column_tooltip_falls_back_to_name_without_description(
+        self, single_parameter_value_model, db_map, gadget
+    ):
+        with db_map:
+            my_parameter = db_map.add_parameter_definition(entity_class_id=gadget["id"], name="my_parameter")
+            my_object = db_map.add_entity(class_id=gadget["id"], name="my_object")
+            parameter_value = db_map.add_parameter_value(
+                entity_class_id=gadget["id"],
+                entity_id=my_object["id"],
+                parameter_definition_id=my_parameter["id"],
+                alternative_name="Base",
+                parsed_value=2.3,
+            )
+        model = single_parameter_value_model
+        model.add_rows([parameter_value["id"]])
+        column = field_index("parameter_definition_name", PARAMETER_VALUE_FIELD_MAP)
+        assert model.index(0, column).data(Qt.ItemDataRole.ToolTipRole) == "my_parameter"
 
 
 @pytest.fixture


### PR DESCRIPTION
Parameter value tables now show the parameter definition's description as a hover tooltip on the **parameter name** column.

The `ToolTipRole` handling in `SingleModelBase.data()` already renders a reference item's `description` for columns whose field is registered in `ParameterMixin._references`. The parameter-name reference was keyed under `parameter_name`, but the value model's name column uses the field `parameter_definition_name` (per `PARAMETER_VALUE_FIELD_MAP`), so the lookup never matched and no tooltip appeared. This corrects the key so the existing tooltip machinery resolves the parameter definition and displays its description. No new data fetching or view changes are needed — the description is already a fetched field on parameter-definition items.

Fixes #3309

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)