### PR TITLE
Display project versions in tooltips

### DIFF
--- a/execution_tests/active_by_default/execution_test.py
+++ b/execution_tests/active_by_default/execution_test.py
@@ -28,7 +28,9 @@ class ActiveByDefault(unittest.TestCase):
             self._check_addition(db_map.add_entity_class_item(name="VisibleByDefault", active_by_default=True))
             self._check_addition(db_map.add_entity_item(name="visible", entity_class_name="VisibleByDefault"))
             self._check_addition(db_map.add_scenario_item(name="base_scenario"))
-            self._check_addition(db_map.add_scenario_alternative_item(scenario_name="base_scenario", alternative_name="Base", rank=0))
+            self._check_addition(
+                db_map.add_scenario_alternative_item(scenario_name="base_scenario", alternative_name="Base", rank=0)
+            )
             db_map.commit_session("Add test data.")
         db_map.close()
 
@@ -47,5 +49,5 @@ class ActiveByDefault(unittest.TestCase):
         self.assertCountEqual(entities, expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/alternative_filters/execution_test.py
+++ b/execution_tests/alternative_filters/execution_test.py
@@ -74,5 +74,5 @@ class AlternativeFilters(unittest.TestCase):
         self.assertCountEqual(entities, expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/conftest.py
+++ b/execution_tests/conftest.py
@@ -13,6 +13,4 @@ import asyncio
 import sys
 
 if sys.platform == "win32":
-    asyncio.set_event_loop_policy(
-        asyncio.WindowsSelectorEventLoopPolicy()
-    )
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/execution_tests/conftest.py
+++ b/execution_tests/conftest.py
@@ -1,0 +1,18 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import asyncio
+import sys
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(
+        asyncio.WindowsSelectorEventLoopPolicy()
+    )

--- a/execution_tests/export_entities_with_entity_alternatives/execution_test.py
+++ b/execution_tests/export_entities_with_entity_alternatives/execution_test.py
@@ -120,5 +120,5 @@ class ExportEntitiesWithEntityAlternatives(unittest.TestCase):
         self.assertCountEqual(entities, expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/hello_world_on_server/execution_test.py
+++ b/execution_tests/hello_world_on_server/execution_test.py
@@ -92,5 +92,5 @@ class RunHelloWorldOnServer(unittest.TestCase):
         self.assertEqual("Hello! World!", text)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/import_file_packs/execution_test.py
+++ b/execution_tests/import_file_packs/execution_test.py
@@ -48,5 +48,5 @@ class ModifyConnectionFilterByScript(unittest.TestCase):
         self.assertEqual(values["e"], -50.0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/loop_condition_with_cmd_line_args/execution_test.py
+++ b/execution_tests/loop_condition_with_cmd_line_args/execution_test.py
@@ -46,5 +46,5 @@ class LoopConditionWithCmdLineArgs(unittest.TestCase):
         self.assertEqual(output_value, Map(expected_x, expected_y))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/merger_write_order/execution_test.py
+++ b/execution_tests/merger_write_order/execution_test.py
@@ -46,5 +46,5 @@ class MergerWriteOrder(unittest.TestCase):
         db_map.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/modify_connection_filter_by_script/execution_test.py
+++ b/execution_tests/modify_connection_filter_by_script/execution_test.py
@@ -85,5 +85,5 @@ class ModifyConnectionFilterByScript(unittest.TestCase):
             return filter_id_file.readline().strip()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/scenario_filters/execution_test.py
+++ b/execution_tests/scenario_filters/execution_test.py
@@ -65,5 +65,5 @@ class ScenarioFilters(unittest.TestCase):
             return filter_id_file.readline().strip()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/execution_tests/simple_importer_on_server/execution_test.py
+++ b/execution_tests/simple_importer_on_server/execution_test.py
@@ -80,5 +80,5 @@ class RunSimpleImporterOnServer(unittest.TestCase):
         db_map.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -753,11 +753,14 @@ class ProjectDirectoryIconProvider(QFileIconProvider):
         if not info.isDir():
             return super().icon(info)
         p = info.filePath()
-        # logging.debug("In dir:{0}".format(p))
-        if os.path.exists(os.path.join(p, ".spinetoolbox")):
-            # logging.debug("found project dir:{0}".format(p))
+        if is_spine_toolbox_project_dir(p):
             return self.spine_icon
         return super().icon(info)
+
+
+def is_spine_toolbox_project_dir(p):
+    """Returns True when given path looks like it contains a valid Spine Toolbox project."""
+    return os.path.isfile(os.path.join(p, ".spinetoolbox", "project.json"))
 
 
 def basic_console_icon(language: str) -> QIcon:

--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1731,47 +1731,6 @@ def plain_to_tool_tip(text: str | None) -> str | None:
     return plain_to_rich(text) if text else None
 
 
-class CustomPopupMenu(QMenu):
-    """Popup menu master class for several popup menus."""
-
-    def __init__(self, parent: QWidget):
-        """
-        Args:
-            parent: Parent widget of this pop-up menu
-        """
-        super().__init__(parent=parent)
-        self._parent = parent
-
-    def add_action(
-        self,
-        text: str,
-        slot: Callable[[], None],
-        enabled: bool = True,
-        tooltip: str | None = None,
-        icon: QIcon | None = None,
-    ) -> QAction:
-        """Adds an action to the popup menu.
-
-        Args:
-            text: Text description of the action
-            slot: Method to connect to action's triggered signal
-            enabled: Is action enabled?
-            tooltip: Tool tip for the action
-            icon: Action icon
-
-        Returns:
-            The added action.
-        """
-        if icon is not None:
-            action = self.addAction(icon, text, slot)
-        else:
-            action = self.addAction(text, slot)
-        action.setEnabled(enabled)
-        if tooltip is not None:
-            action.setToolTip(tooltip)
-        return action
-
-
 _SPLIT_PATTERN = re.compile(r"(\d+)")
 
 
@@ -1871,3 +1830,71 @@ def find_section_in_table_model_header(
         if model.headerData(section, orientation) == data:
             return section
     raise ValueError(f"{data} not found in header")
+
+
+def remove_path_from_recent_projects(settings: QSettings, p: str) -> None:
+    """Removes entry that contains given path from the recent project files list in QSettings.
+
+    Args:
+        settings (QSettings): Application settings object
+        p (str): Full path to a project directory
+    """
+    recents = settings.value("appSettings/recentProjects", defaultValue=None)
+    if not recents:
+        return
+    recents = str(recents)
+    recents_list = recents.split("\n")
+    for entry in recents_list:
+        _, path = entry.split("<>")
+        if same_path(path, p):
+            recents_list.pop(recents_list.index(entry))
+            break
+    updated_recents = "\n".join(recents_list)
+    # Save updated recent paths
+    settings.setValue("appSettings/recentProjects", updated_recents)
+    settings.sync()  # Commit change immediately
+
+
+def clear_recent_projects(parent: QWidget, settings: QSettings) -> None:
+    """Clears recent projects list in File->Open recent menu."""
+    msg = "Are you sure?"
+    title = "Clear recent projects?"
+    message_box = QMessageBox(
+        QMessageBox.Icon.Question,
+        title,
+        msg,
+        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        parent=parent,
+    )
+    answer = message_box.exec()
+    if answer == QMessageBox.StandardButton.No:
+        return
+    settings.remove("appSettings/recentProjects")
+    settings.remove("appSettings/recentProjectStorages")
+    settings.sync()
+
+
+def update_recent_projects(settings: QSettings, project_name: str, project_dir: str) -> None:
+    """Adds a recent project entry to QSettings if not already present. Max amount of recent projects is 20."""
+    recents = settings.value("appSettings/recentProjects", defaultValue=None)
+    entry = project_name + "<>" + project_dir
+    if not recents:
+        updated_recents = entry
+    else:
+        recents = str(recents)
+        recents_list = recents.split("\n")
+        normalized_recents = list(map(os.path.normcase, recents_list))
+        try:
+            index = normalized_recents.index(os.path.normcase(entry))
+        except ValueError:
+            # Add path only if it's not in the list already
+            recents_list.insert(0, entry)
+            if len(recents_list) > 20:
+                recents_list.pop()
+        else:
+            # If entry was on the list, move it as the first item
+            recents_list.insert(0, recents_list.pop(index))
+        updated_recents = "\n".join(recents_list)
+    # Save updated recent paths
+    settings.setValue("appSettings/recentProjects", updated_recents)
+    settings.sync()  # Commit change immediately

--- a/spinetoolbox/spine_db_editor/widgets/custom_menus.py
+++ b/spinetoolbox/spine_db_editor/widgets/custom_menus.py
@@ -23,10 +23,10 @@ from spinedb_api.helpers import ItemType
 from spinedb_api.temp_id import TempId
 from ...database_display_names import NameRegistry
 from ...fetch_parent import FlexibleFetchParent
-from ...helpers import CustomPopupMenu, DBMapPublicItems
+from ...helpers import DBMapPublicItems
 from ...mvcmodels.filter_checkbox_list_model import SimpleFilterCheckboxListModel
 from ...spine_db_manager import SpineDBManager
-from ...widgets.custom_menus import FilterMenuBase
+from ...widgets.custom_menus import FilterMenuBase, CustomPopupMenu
 from ..mvcmodels.compound_models import CompoundStackedModel
 from ..mvcmodels.lazy_filter_checkbox_list_model import LazyFilterCheckboxListModel
 from ..mvcmodels.utils import field_index

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -82,6 +82,8 @@ from .helpers import (
     solve_connection_file,
     supported_img_formats,
     unique_name,
+    update_recent_projects,
+    remove_path_from_recent_projects,
 )
 from .kernel_fetcher import KernelFetcher
 from .link import JUMP_COLOR, LINK_COLOR, JumpLink, JumpOrLink, Link
@@ -600,7 +602,7 @@ class ToolboxUI(QMainWindow):
                 f"Cannot open previously opened project. "
                 f"Directory <b>{project_dir}</b> may have been moved or deleted."
             )
-            self.remove_path_from_recent_projects(project_dir)
+            remove_path_from_recent_projects(self._qsettings, project_dir)
             return
         project_dict = load_project_dict(project_dir)
         version = project_dict.get("project", {}).get("version")
@@ -675,7 +677,7 @@ class ToolboxUI(QMainWindow):
         self.update_window_title()
         self.ui.graphicsView.reset_zoom()
         # Update recentProjects
-        self.update_recent_projects()
+        update_recent_projects(self._qsettings, self._project.name, self._project.project_dir)
         # Update recentProjectStorages
         OpenProjectDialog.update_recents(os.path.abspath(os.path.join(proj_dir, os.path.pardir)), self.qsettings())
         self.save_project()
@@ -755,14 +757,14 @@ class ToolboxUI(QMainWindow):
             self.msg_error.emit(str(error))
             success = False
         if not success:
-            self.remove_path_from_recent_projects(self._project.project_dir)
+            remove_path_from_recent_projects(self._qsettings, self._project.project_dir)
             return False
         self._enable_project_actions()
         self._plugin_manager.reload_plugins_with_local_data()
         self._project.settings_updated.connect(self._handle_project_settings_update)
         # Reset zoom on Design View
         self.ui.graphicsView.reset_zoom()
-        self.update_recent_projects()
+        update_recent_projects(self._qsettings, self._project.name, self._project.project_dir)
         self.msg.emit(f"Project <b>{self._project.name}</b> is now open")
         return True
 
@@ -2067,71 +2069,6 @@ class ToolboxUI(QMainWindow):
             self.save_project()
         return True
 
-    def remove_path_from_recent_projects(self, p):
-        """Removes entry that contains given path from the recent project files list in QSettings.
-
-        Args:
-            p (str): Full path to a project directory
-        """
-        recents = self._qsettings.value("appSettings/recentProjects", defaultValue=None)
-        if not recents:
-            return
-        recents = str(recents)
-        recents_list = recents.split("\n")
-        for entry in recents_list:
-            _, path = entry.split("<>")
-            if same_path(path, p):
-                recents_list.pop(recents_list.index(entry))
-                break
-        updated_recents = "\n".join(recents_list)
-        # Save updated recent paths
-        self._qsettings.setValue("appSettings/recentProjects", updated_recents)
-        self._qsettings.sync()  # Commit change immediately
-
-    def clear_recent_projects(self):
-        """Clears recent projects list in File->Open recent menu."""
-        msg = "Are you sure?"
-        title = "Clear recent projects?"
-        message_box = QMessageBox(
-            QMessageBox.Icon.Question,
-            title,
-            msg,
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            parent=self,
-        )
-        answer = message_box.exec()
-        if answer == QMessageBox.StandardButton.No:
-            return
-        self._qsettings.remove("appSettings/recentProjects")
-        self._qsettings.remove("appSettings/recentProjectStorages")
-        self._qsettings.sync()
-
-    def update_recent_projects(self):
-        """Adds a recent project entry to a QSettings variable if not already present.
-        The max amount of recent projects is 20."""
-        recents = self._qsettings.value("appSettings/recentProjects", defaultValue=None)
-        entry = self.project().name + "<>" + self.project().project_dir
-        if not recents:
-            updated_recents = entry
-        else:
-            recents = str(recents)
-            recents_list = recents.split("\n")
-            normalized_recents = list(map(os.path.normcase, recents_list))
-            try:
-                index = normalized_recents.index(os.path.normcase(entry))
-            except ValueError:
-                # Add path only if it's not in the list already
-                recents_list.insert(0, entry)
-                if len(recents_list) > 20:
-                    recents_list.pop()
-            else:
-                # If entry was on the list, move it as the first item
-                recents_list.insert(0, recents_list.pop(index))
-            updated_recents = "\n".join(recents_list)
-        # Save updated recent paths
-        self._qsettings.setValue("appSettings/recentProjects", updated_recents)
-        self._qsettings.sync()  # Commit change immediately
-
     def closeEvent(self, event):
         """Method for handling application exit.
 
@@ -2150,7 +2087,7 @@ class ToolboxUI(QMainWindow):
             self._qsettings.setValue("appSettings/previousProject", "")
         else:
             self._qsettings.setValue("appSettings/previousProject", self._project.project_dir)
-            self.update_recent_projects()
+            update_recent_projects(self._qsettings, self._project.name, self._project.project_dir)
         self._qsettings.setValue("appSettings/toolbarIconOrdering", self.items_toolbar.icon_ordering())
         self._qsettings.setValue("mainWindow/windowSize", self.size())
         self._qsettings.setValue("mainWindow/windowPosition", self.pos())

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -56,7 +56,13 @@ from spine_engine.project_item.project_item_specification_factory import Project
 from spine_engine.spine_engine import _set_resource_limits
 from spine_engine.utils.helpers import resolve_julia_executable, resolve_julia_project, resolve_python_interpreter
 from spinetoolbox.server.engine_client import ClientSecurityModel, EngineClient, RemoteEngineInitFailed
-from .config import DEFAULT_WORK_DIR, ONLINE_DOCUMENTATION_URL, SPINE_DB_API_DOCUMENTATION_URL, SPINE_TOOLBOX_REPO_URL
+from .config import (
+    DEFAULT_WORK_DIR,
+    ONLINE_DOCUMENTATION_URL,
+    SPINE_DB_API_DOCUMENTATION_URL,
+    SPINE_TOOLBOX_REPO_URL,
+    LATEST_PROJECT_VERSION
+)
 from .helpers import (
     ChildCyclingKeyPressFilter,
     ColoredIcon,
@@ -79,7 +85,7 @@ from .helpers import (
 )
 from .kernel_fetcher import KernelFetcher
 from .link import JUMP_COLOR, LINK_COLOR, JumpLink, JumpOrLink, Link
-from .load_project import ProjectLoadingFailed
+from .load_project import ProjectLoadingFailed, load_project_dict
 from .load_project_items import load_project_items
 from .load_specification import (
     SpecificationLoadingFailed,
@@ -590,8 +596,26 @@ class ToolboxUI(QMainWindow):
             # Now we just give up.
             return
         if not os.path.isdir(project_dir):
-            self.msg_error.emit(f"Cannot open previous project. Directory <b>{project_dir}</b> may have been moved.")
+            self.msg_error.emit(
+                f"Cannot open previously opened project. "
+                f"Directory <b>{project_dir}</b> may have been moved or deleted."
+            )
             self.remove_path_from_recent_projects(project_dir)
+            return
+        project_dict = load_project_dict(project_dir)
+        version = project_dict.get("project", {}).get("version")
+        if not version:
+            self.msg_error.emit(
+                f"Cannot open previously opened project <b>'{project_dir}'</b>. "
+                f"Project version information is missing."
+            )
+            return
+        if version > LATEST_PROJECT_VERSION:
+            self.msg_warning.emit(
+                f"Cannot open previously opened project <b>'{project_dir}'</b>. "
+                f"Project version {version} requires a newer Spine Toolbox "
+                f"(current support: {LATEST_PROJECT_VERSION})."
+            )
             return
         self.open_project(project_dir, clear_event_log=False)
 
@@ -753,7 +777,6 @@ class ToolboxUI(QMainWindow):
         if button == QMessageBox.StandardButton.Yes:
             return True
         return False
-
 
     def _toolbars(self):
         """Yields all toolbars in the window."""
@@ -2084,7 +2107,8 @@ class ToolboxUI(QMainWindow):
         self._qsettings.sync()
 
     def update_recent_projects(self):
-        """Adds a new entry to QSettings variable that remembers twenty most recent project paths."""
+        """Adds a recent project entry to a QSettings variable if not already present.
+        The max amount of recent projects is 20."""
         recents = self._qsettings.value("appSettings/recentProjects", defaultValue=None)
         entry = self.project().name + "<>" + self.project().project_dir
         if not recents:

--- a/spinetoolbox/widgets/custom_menus.py
+++ b/spinetoolbox/widgets/custom_menus.py
@@ -12,17 +12,58 @@
 
 """Classes for custom context menus and pop-up menus."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Callable
 import os
 from typing import Generic, TypeVar
 from PySide6.QtCore import QPersistentModelIndex, Slot
 from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import QMenu, QWidget, QWidgetAction, QMessageBox
-from spinetoolbox.helpers import CustomPopupMenu
+from spinetoolbox.helpers import clear_recent_projects, remove_path_from_recent_projects
 from spinetoolbox.load_project import load_project_dict
 from spinetoolbox.config import LATEST_PROJECT_VERSION
 from spinetoolbox.mvcmodels.filter_checkbox_list_model import SimpleFilterCheckboxListModel
 from spinetoolbox.widgets.custom_qwidgets import FilterWidget
+
+
+class CustomPopupMenu(QMenu):
+    """Popup menu master class for several popup menus."""
+
+    def __init__(self, parent: QWidget):
+        """
+        Args:
+            parent: Parent widget of this pop-up menu
+        """
+        super().__init__(parent=parent)
+        self._parent = parent
+
+    def add_action(
+        self,
+        text: str,
+        slot: Callable[[], None],
+        enabled: bool = True,
+        tooltip: str | None = None,
+        icon: QIcon | None = None,
+    ) -> QAction:
+        """Adds an action to the popup menu.
+
+        Args:
+            text: Text description of the action
+            slot: Method to connect to action's triggered signal
+            enabled: Is action enabled?
+            tooltip: Tool tip for the action
+            icon: Action icon
+
+        Returns:
+            The added action.
+        """
+        if icon is not None:
+            action = self.addAction(icon, text, slot)
+        else:
+            action = self.addAction(text, slot)
+        action.setEnabled(enabled)
+        if tooltip is not None:
+            action.setToolTip(tooltip)
+        return action
 
 
 class CustomContextMenu(QMenu):
@@ -156,37 +197,41 @@ class RecentProjectsPopupMenu(CustomPopupMenu):
                 )
 
     @Slot(bool)
-    def call_clear_recents(self, checked):
+    def call_clear_recents(self, _=True):
         """Slot for Clear recents menu item.
 
         Args:
-            checked (bool): Argument sent by triggered signal
+            _ (bool): Argument sent by triggered signal
         """
-
-        self._parent.clear_recent_projects()
+        clear_recent_projects(self._parent, self._parent.qsettings())
 
     @Slot(bool, str, object)
-    def call_open_project(self, checked, p, version):
+    def call_open_project(self, _, p, version):
         """Slot for catching the user selected action from the recent projects menu.
 
         Args:
-            checked (bool): Argument sent by triggered signal
-            p (str): Full path to a project file
+            _ (bool): Argument sent by triggered signal
+            p (str): Full path to a project directory
             version (int | None): Project version
         """
+        if not os.path.exists(p):
+            # Project has been removed, remove it from recent projects list
+            remove_path_from_recent_projects(self._parent.qsettings(), p)
+            self._parent.msg_error.emit(f"Opening selected project failed. Project <b>{p}</b> may have been removed.")
+            return
+        if not version:
+            QMessageBox.warning(
+                self,
+                "Project corrupted",
+                f"Project '{p}' may be corrupted because 'version' key is missing from the project.json file.\n",
+            )
+            return
         if version > LATEST_PROJECT_VERSION:
             QMessageBox.warning(
                 self,
                 "Incompatible project",
                 f"Project '{p}' is version {version} and requires a newer Spine Toolbox.\n"
                 f"This version of Spine Toolbox supports projects up to version {LATEST_PROJECT_VERSION}.",
-            )
-            return
-        if not os.path.exists(p):
-            # Project has been removed, remove it from recent projects list
-            self._parent.remove_path_from_recent_projects(p)
-            self._parent.msg_error.emit(
-                f"Opening selected project failed. Project file <b>{p}</b> may have been removed."
             )
             return
         # Check if the same project is already open

--- a/spinetoolbox/widgets/custom_menus.py
+++ b/spinetoolbox/widgets/custom_menus.py
@@ -17,8 +17,10 @@ import os
 from typing import Generic, TypeVar
 from PySide6.QtCore import QPersistentModelIndex, Slot
 from PySide6.QtGui import QAction, QIcon
-from PySide6.QtWidgets import QMenu, QWidget, QWidgetAction
+from PySide6.QtWidgets import QMenu, QWidget, QWidgetAction, QMessageBox
 from spinetoolbox.helpers import CustomPopupMenu
+from spinetoolbox.load_project import load_project_dict
+from spinetoolbox.config import LATEST_PROJECT_VERSION
 from spinetoolbox.mvcmodels.filter_checkbox_list_model import SimpleFilterCheckboxListModel
 from spinetoolbox.widgets.custom_qwidgets import FilterWidget
 
@@ -124,10 +126,33 @@ class RecentProjectsPopupMenu(CustomPopupMenu):
             recents_list = recents.split("\n")
             for entry in recents_list:
                 name, filepath = entry.split("<>")
+                version = None
+                if os.path.isdir(filepath):
+                    project_dict = load_project_dict(filepath)
+                    version = project_dict.get("project", {}).get("version")
+                if version is None:
+                    tt = filepath
+                else:
+                    version = int(version)
+                    if version == LATEST_PROJECT_VERSION:
+                        tt = f"{filepath}\nProject version: {version} (current)"
+                    elif version < LATEST_PROJECT_VERSION:
+                        tt = (
+                            f"{filepath}\nProject version: {version} (upgrades "
+                            f"to {LATEST_PROJECT_VERSION} when opened)"
+                        )
+                    else:
+                        name = f"[Incompatible] " + name
+                        tt = (
+                            f"{filepath}\nProject version: {version} "
+                            f"(requires newer Spine Toolbox, current support: {LATEST_PROJECT_VERSION})"
+                        )
                 self.add_action(
                     name,
-                    lambda checked=False, filepath=filepath: self.call_open_project(checked, filepath),
-                    tooltip=filepath,
+                    lambda checked=False, filepath=filepath, version=version: self.call_open_project(
+                        checked, filepath, version
+                    ),
+                    tooltip=tt,
                 )
 
     @Slot(bool)
@@ -140,14 +165,23 @@ class RecentProjectsPopupMenu(CustomPopupMenu):
 
         self._parent.clear_recent_projects()
 
-    @Slot(bool, str)
-    def call_open_project(self, checked, p):
+    @Slot(bool, str, object)
+    def call_open_project(self, checked, p, version):
         """Slot for catching the user selected action from the recent projects menu.
 
         Args:
             checked (bool): Argument sent by triggered signal
             p (str): Full path to a project file
+            version (int | None): Project version
         """
+        if version > LATEST_PROJECT_VERSION:
+            QMessageBox.warning(
+                self,
+                "Incompatible project",
+                f"Project '{p}' is version {version} and requires a newer Spine Toolbox.\n"
+                f"This version of Spine Toolbox supports projects up to version {LATEST_PROJECT_VERSION}.",
+            )
+            return
         if not os.path.exists(p):
             # Project has been removed, remove it from recent projects list
             self._parent.remove_path_from_recent_projects(p)

--- a/spinetoolbox/widgets/open_project_dialog.py
+++ b/spinetoolbox/widgets/open_project_dialog.py
@@ -327,6 +327,10 @@ class OpenProjectDialog(QDialog):
             # Prevent opening incompatible projects version > LATEST_PROJECT_VERSION
             project_dict = load_project_dict(self.selection())
             version = project_dict.get("project", {}).get("version")
+            if not version:
+                notification = Notification(self, f"Project corrupted. Version info missing from project.json.")
+                notification.show()
+                return
             if version is not None and version > LATEST_PROJECT_VERSION:
                 notification = Notification(
                     self,
@@ -438,16 +442,17 @@ class CustomQFileSystemModel(QFileSystemModel):
             if is_spine_toolbox_project_dir(p):
                 project_dict = load_project_dict(p)
                 version = project_dict.get("project", {}).get("version")
-                if version:
-                    if version == LATEST_PROJECT_VERSION:
-                        return f"Version {version} (current)"
-                    elif version < LATEST_PROJECT_VERSION:
-                        return f"Version {version} (upgrades to {LATEST_PROJECT_VERSION} when opened)"
-                    else:
-                        return (
-                            f"Version {version} (requires newer Spine "
-                            f"Toolbox, current support: {LATEST_PROJECT_VERSION})"
-                        )
+                if not version:
+                    return f"Corrupted project. No version information found."
+                if version == LATEST_PROJECT_VERSION:
+                    return f"Version {version} (current)"
+                elif version < LATEST_PROJECT_VERSION:
+                    return f"Version {version} (upgrades to {LATEST_PROJECT_VERSION} when opened)"
+                else:
+                    return (
+                        f"Version {version} (requires newer Spine "
+                        f"Toolbox, current support: {LATEST_PROJECT_VERSION})"
+                    )
         return super().data(index, role)
 
 

--- a/spinetoolbox/widgets/open_project_dialog.py
+++ b/spinetoolbox/widgets/open_project_dialog.py
@@ -16,7 +16,9 @@ import os
 from PySide6.QtCore import QDir, QModelIndex, QStandardPaths, Qt, Slot, QPoint, QTimer
 from PySide6.QtGui import QAction, QKeySequence, QValidator
 from PySide6.QtWidgets import QAbstractItemView, QComboBox, QDialog, QFileSystemModel, QApplication
-from spinetoolbox.helpers import ProjectDirectoryIconProvider
+from spinetoolbox.helpers import ProjectDirectoryIconProvider, is_spine_toolbox_project_dir
+from spinetoolbox.config import LATEST_PROJECT_VERSION
+from spinetoolbox.load_project import load_project_dict
 from spinetoolbox.widgets.custom_menus import OpenProjectDialogComboBoxContextMenu
 from spinetoolbox.widgets.notification import Notification
 
@@ -322,6 +324,17 @@ class OpenProjectDialog(QDialog):
                 notification = Notification(self, "Not a valid Spine Toolbox project")
                 notification.show()
                 return
+            # Prevent opening incompatible projects version > LATEST_PROJECT_VERSION
+            project_dict = load_project_dict(self.selection())
+            version = project_dict.get("project", {}).get("version")
+            if version is not None and version > LATEST_PROJECT_VERSION:
+                notification = Notification(
+                    self,
+                    f"Cannot open project. Version {version} requires a newer Spine Toolbox "
+                    f"(supports up to version {LATEST_PROJECT_VERSION}).",
+                )
+                notification.show()
+                return
             # self.selection() now contains a valid Spine Toolbox project directory.
             # Add the parent directory of selected directory to qsettings
             self.update_recents(os.path.abspath(os.path.join(self.selection(), os.path.pardir)), self._qsettings)
@@ -418,6 +431,24 @@ class CustomQFileSystemModel(QFileSystemModel):
     def columnCount(self, parent=QModelIndex()):
         """Returns one."""
         return 1
+
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
+        if role == Qt.ItemDataRole.ToolTipRole:
+            p = self.filePath(index)
+            if is_spine_toolbox_project_dir(p):
+                project_dict = load_project_dict(p)
+                version = project_dict.get("project", {}).get("version")
+                if version:
+                    if version == LATEST_PROJECT_VERSION:
+                        return f"Version {version} (current)"
+                    elif version < LATEST_PROJECT_VERSION:
+                        return f"Version {version} (upgrades to {LATEST_PROJECT_VERSION} when opened)"
+                    else:
+                        return (
+                            f"Version {version} (requires newer Spine "
+                            f"Toolbox, current support: {LATEST_PROJECT_VERSION})"
+                        )
+        return super().data(index, role)
 
 
 class DirValidator(QValidator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,4 +152,10 @@ def db_editor(db_mngr, db_map, monkeypatch):
 @pytest.fixture
 def qsettings_file(tmp_path):
     settings_file = tmp_path / "settings.ini"
-    return QSettings(str(settings_file), QSettings.IniFormat)
+    return QSettings(str(settings_file), QSettings.Format.IniFormat)
+
+
+@pytest.fixture
+def parent_widget_with_settings(parent_widget, qsettings_file):
+    parent_widget.qsettings = lambda: qsettings_file
+    return parent_widget

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 from unittest import mock
-from PySide6.QtCore import QObject, QTimer
+from PySide6.QtCore import QObject, QTimer, QSettings
 from PySide6.QtWidgets import QApplication, QWidget
 import pytest
 from spinetoolbox.spine_db_editor.widgets.spine_db_editor import SpineDBEditor
@@ -147,3 +147,9 @@ def db_editor(db_mngr, db_map, monkeypatch):
         commit_at_exit_setting.return_value = "0"  # Discard changes and close.
         db_editor.close()
     db_editor.deleteLater()
+
+
+@pytest.fixture
+def qsettings_file(tmp_path):
+    settings_file = tmp_path / "settings.ini"
+    return QSettings(str(settings_file), QSettings.IniFormat)

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -51,8 +51,9 @@ def create_toolboxui():
 
 def create_project(toolbox, project_dir):
     """Creates a project for the given ToolboxUI."""
-    with (mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),):
+    with (mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp,):
         toolbox.create_project(project_dir)
+        mock_urp.assert_called()
 
 
 def create_toolboxui_with_project(project_dir):

--- a/tests/test_SpineToolboxProject.py
+++ b/tests/test_SpineToolboxProject.py
@@ -410,8 +410,7 @@ class TestSpineToolboxProject(TestCaseWithQApplication):
     def test_rename_project(self):
         new_name = "New Project Name"
         new_short_name = "new_project_name"
-        with mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"):
-            self.toolbox.project().set_name(new_name)
+        self.toolbox.project().set_name(new_name)
         self.assertEqual(self.toolbox.project().name, new_name)
         self.assertEqual(self.toolbox.project().short_name, new_short_name)
 
@@ -610,11 +609,12 @@ class TestSpineToolboxProject(TestCaseWithQApplication):
         project.save()
         self.assertTrue(self.toolbox.close_project(ask_confirmation=False))
         with (
-            mock.patch.object(self.toolbox, "update_recent_projects"),
             mock.patch.object(self.toolbox, "project_item_properties_ui"),
             mock.patch.object(self.toolbox, "project_item_icon"),
         ):
-            self.assertTrue(self.toolbox.restore_project(self._temp_dir.name, ask_confirmation=False))
+            with mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp:
+                self.assertTrue(self.toolbox.restore_project(self._temp_dir.name, ask_confirmation=False))
+                mock_urp.assert_called()
         self.assertEqual(self.toolbox.project().settings.mode, "consumer")
 
     def test_load_when_storing_item_local_data(self):
@@ -629,11 +629,12 @@ class TestSpineToolboxProject(TestCaseWithQApplication):
         self.assertTrue(self.toolbox.close_project(ask_confirmation=False))
         self.toolbox.item_factories = {"Tester": _MockItemFactoryForLocalDataTests()}
         with (
-            mock.patch.object(self.toolbox, "update_recent_projects"),
             mock.patch.object(self.toolbox, "project_item_properties_ui"),
             mock.patch.object(self.toolbox, "project_item_icon"),
         ):
-            self.assertTrue(self.toolbox.restore_project(self._temp_dir.name, ask_confirmation=False))
+            with mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp:
+                self.assertTrue(self.toolbox.restore_project(self._temp_dir.name, ask_confirmation=False))
+                mock_urp.assert_called()
         item = self.toolbox.project().get_item("test item")
         self.assertEqual(item.kwargs, {"type": "Tester", "a": {"b": 1, "c": 2, "d": 3}})
 

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -97,9 +97,10 @@ class TestToolboxUI(TestCaseWithQApplication):
             mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"),
             mock.patch("spinetoolbox.project.create_dir"),
             mock.patch("spinetoolbox.project_item.project_item.create_dir"),
-            mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),
+            mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp,
         ):
             self.toolbox.open_project(project_dir)
+            mock_urp.assert_called()
         self.assertIsInstance(self.toolbox.project(), SpineToolboxProject)
         # Check that project contains four items
         self.assertEqual(self.toolbox.project().n_items, 4)
@@ -156,9 +157,10 @@ class TestToolboxUI(TestCaseWithQApplication):
             mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"),
             mock.patch("spinetoolbox.project.create_dir"),
             mock.patch("spinetoolbox.project_item.project_item.create_dir"),
-            mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),
+            mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp,
         ):
             self.toolbox.init_project(project_dir)
+            mock_urp.assert_called()
         self.assertIsNotNone(self.toolbox.project())
         self.assertEqual(self.toolbox.project().name, "Project Directory")
 
@@ -184,9 +186,10 @@ class TestToolboxUI(TestCaseWithQApplication):
             mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"),
             mock.patch("spinetoolbox.project.create_dir"),
             mock.patch("spinetoolbox.project_item.project_item.create_dir"),
-            mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),
+            mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp,
         ):
             self.toolbox.open_project(self._temp_dir.name)
+            mock_urp.assert_called()
         self.assertIsNotNone(self.toolbox.project())
         self.assertEqual(self.toolbox.project().get_item("DC").name, "DC")
 
@@ -208,7 +211,7 @@ class TestToolboxUI(TestCaseWithQApplication):
             mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"),
             mock.patch("spinetoolbox.project.create_dir"),
             mock.patch("spinetoolbox.project_item.project_item.create_dir"),
-            mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),
+            mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp,
             mock.patch.object(QMessageBox, "exec", return_value=QMessageBox.StandardButton.Cancel),
         ):
             # Selecting cancel on the project close confirmation
@@ -218,6 +221,7 @@ class TestToolboxUI(TestCaseWithQApplication):
                 warning_msg.assert_called_with(
                     f"Cancelled opening project {self._temp_dir.name}. Current project has unsaved changes."
                 )
+            mock_urp.assert_not_called()
         self.assertIsNotNone(self.toolbox.project())
         self.assertEqual(self.toolbox.project().get_item("DC1").name, "DC1")
         self.assertEqual(self.toolbox.project().get_item("DC2").name, "DC2")
@@ -533,9 +537,10 @@ class TestToolboxUI(TestCaseWithQApplication):
         self.assertIsNone(self.toolbox.project())
         with (
             mock.patch("spinetoolbox.ui_main.ToolboxUI.save_project"),
-            mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),
+            mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp,
         ):
             self.toolbox.open_project(project_dir)
+            mock_urp.assert_called()
         # Tool spec model must be empty at this point
         self.assertEqual(0, self.toolbox.specification_model.rowCount())
         tool_spec_path = os.path.abspath(
@@ -760,10 +765,11 @@ class TestToolboxUI(TestCaseWithQApplication):
         self.assertIn("appSettings/toolbarIconOrdering", saved_dict)
 
     def test_enable_execute_all_project_setting_is_respected(self):
-        with mock.patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"), TemporaryDirectory() as temp_dir:
+        with mock.patch("spinetoolbox.ui_main.update_recent_projects") as mock_urp, TemporaryDirectory() as temp_dir:
             with mock.patch.object(self.toolbox, "_qsettings"):
                 self.toolbox.create_project(temp_dir)
             self.toolbox.close_project(ask_confirmation=False)
+            mock_urp.assert_called()
             project_json = pathlib.Path(temp_dir) / ".spinetoolbox" / "project.json"
             self.assertTrue(project_json.is_file())
             with open(project_json) as project_file:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -64,7 +64,7 @@ from spinetoolbox.helpers import (
     unique_name,
     update_recent_projects,
     remove_path_from_recent_projects,
-    clear_recent_projects
+    clear_recent_projects,
 )
 from tests.mock_helpers import TestCaseWithQApplication, q_object
 
@@ -720,12 +720,16 @@ class TestRecentProjects:
         update_recent_projects(qsettings_file, "ProjectA", "C:/Projects/A")
         recents = qsettings_file.value("appSettings/recentProjects")
         assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectB<>C:/Projects/B"]
-        with mock.patch("spinetoolbox.helpers.QMessageBox.exec", return_value=QMessageBox.StandardButton.No) as mock_exec1:
+        with mock.patch(
+            "spinetoolbox.helpers.QMessageBox.exec", return_value=QMessageBox.StandardButton.No
+        ) as mock_exec1:
             clear_recent_projects(parent_widget, qsettings_file)
             mock_exec1.assert_called()
             recents = qsettings_file.value("appSettings/recentProjects")
             assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectB<>C:/Projects/B"]
-        with mock.patch("spinetoolbox.helpers.QMessageBox.exec", return_value=QMessageBox.StandardButton.Yes) as mock_exec2:
+        with mock.patch(
+            "spinetoolbox.helpers.QMessageBox.exec", return_value=QMessageBox.StandardButton.Yes
+        ) as mock_exec2:
             clear_recent_projects(parent_widget, qsettings_file)
             mock_exec2.assert_called()
             assert qsettings_file.value("appSettings/recentProjects") is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,10 +17,10 @@ import re
 import sys
 from tempfile import TemporaryDirectory
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 from PySide6.QtCore import QObject, Qt, Signal
 from PySide6.QtGui import QAction, QKeySequence, QPalette, QStandardItem, QStandardItemModel
-from PySide6.QtWidgets import QLineEdit, QWidget
+from PySide6.QtWidgets import QLineEdit, QWidget, QMessageBox
 import pytest
 from spinetoolbox.helpers import (
     DB_ITEM_SEPARATOR,
@@ -62,6 +62,9 @@ from spinetoolbox.helpers import (
     try_number_from_string,
     tuple_itemgetter,
     unique_name,
+    update_recent_projects,
+    remove_path_from_recent_projects,
+    clear_recent_projects
 )
 from tests.mock_helpers import TestCaseWithQApplication, q_object
 
@@ -99,7 +102,7 @@ class TestHelpers(TestCaseWithQApplication):
             file_in_dir = Path(old_dir, "file.fff")
             file_in_dir.touch()
             new_dir = Path(temp_dir, "new directory")
-            logger = MagicMock()
+            logger = mock.MagicMock()
             self.assertTrue(rename_dir(str(old_dir), str(new_dir), logger, "box_title"))
             self.assertFalse(old_dir.exists())
             self.assertTrue(new_dir.exists())
@@ -112,8 +115,8 @@ class TestHelpers(TestCaseWithQApplication):
             old_dir.mkdir()
             new_dir = Path(temp_dir, "new directory")
             new_dir.mkdir()
-            logger = MagicMock()
-            with unittest.mock.patch("spinetoolbox.helpers.QMessageBox") as mock_msg_box:
+            logger = mock.MagicMock()
+            with mock.patch("spinetoolbox.helpers.QMessageBox") as mock_msg_box:
                 self.assertFalse(rename_dir(str(old_dir), str(new_dir), logger, "box_title"))
                 mock_msg_box.assert_called_once()
             self.assertTrue(old_dir.exists())
@@ -191,7 +194,7 @@ class TestHelpers(TestCaseWithQApplication):
             (destination_dir / sub_dir).mkdir()
             overwritten_file = destination_dir / sub_dir / file_name
             overwritten_file.touch()
-            logger = MagicMock()
+            logger = mock.MagicMock()
             recursive_overwrite(logger, str(source_dir), str(destination_dir))
             with open(overwritten_file) as input_:
                 self.assertEqual(input_.readline(), "source")
@@ -224,12 +227,12 @@ class TestHelpers(TestCaseWithQApplication):
             line_edit = QLineEdit()
             parent_widget = QWidget()
             if sys.platform == "win32":
-                with patch("spinetoolbox.helpers.win32gui.GetOpenFileNameW") as mock_native_dialog:
+                with mock.patch("spinetoolbox.helpers.win32gui.GetOpenFileNameW") as mock_native_dialog:
                     mock_native_dialog.return_value = [str(executable)]
                     select_julia_executable(parent_widget, line_edit)
                     mock_native_dialog.assert_called()
             else:
-                with patch("spinetoolbox.helpers.QFileDialog.getOpenFileName", lambda *args: [str(executable)]):
+                with mock.patch("spinetoolbox.helpers.QFileDialog.getOpenFileName", lambda *args: [str(executable)]):
                     select_julia_executable(None, line_edit)
             self.assertEqual(line_edit.text(), str(executable))
             line_edit.deleteLater()
@@ -239,7 +242,7 @@ class TestHelpers(TestCaseWithQApplication):
         with TemporaryDirectory() as temp_dir:
             project_dir = Path(temp_dir, "project")
             project_dir.mkdir()
-            with patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory", lambda *args: str(project_dir)):
+            with mock.patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory", lambda *args: str(project_dir)):
                 line_edit = QLineEdit()
                 select_julia_project(None, line_edit)
                 self.assertEqual(line_edit.text(), str(project_dir))
@@ -252,12 +255,12 @@ class TestHelpers(TestCaseWithQApplication):
             line_edit = QLineEdit()
             parent_widget = QWidget()
             if sys.platform == "win32":
-                with patch("spinetoolbox.helpers.win32gui.GetOpenFileNameW") as mock_native_dialog:
+                with mock.patch("spinetoolbox.helpers.win32gui.GetOpenFileNameW") as mock_native_dialog:
                     mock_native_dialog.return_value = [str(executable)]
                     select_python_interpreter(parent_widget, line_edit)
                     mock_native_dialog.assert_called()
             else:
-                with patch("spinetoolbox.helpers.QFileDialog.getOpenFileName", lambda *args: [str(executable)]):
+                with mock.patch("spinetoolbox.helpers.QFileDialog.getOpenFileName", lambda *args: [str(executable)]):
                     select_python_interpreter(None, line_edit)
             self.assertEqual(line_edit.text(), str(executable))
             line_edit.deleteLater()
@@ -273,15 +276,15 @@ class TestHelpers(TestCaseWithQApplication):
             line_edit.setPlaceholderText(python_in_path)
             parent_widget = QWidget()
             if sys.platform == "win32":
-                with patch("spinetoolbox.helpers.win32gui.GetOpenFileNameW") as mock_native_dialog:
+                with mock.patch("spinetoolbox.helpers.win32gui.GetOpenFileNameW") as mock_native_dialog:
                     mock_native_dialog.return_value = [str(executable)]
                     select_python_interpreter(parent_widget, line_edit)
                     # initial dir should be according to the text in line edit
                     self.assertEqual(mock_native_dialog.call_args[1]["File"], str(executable))
                     self.assertEqual(mock_native_dialog.call_args[1]["InitialDir"], home_dir())
                     with (
-                        patch("spinetoolbox.helpers.os.path.exists") as mock_exists,
-                        patch("spinetoolbox.helpers.os.path.abspath") as mock_abspath,
+                        mock.patch("spinetoolbox.helpers.os.path.exists") as mock_exists,
+                        mock.patch("spinetoolbox.helpers.os.path.abspath") as mock_abspath,
                     ):
                         mock_exists.return_value = True
                         mock_abspath.return_value = python_in_path
@@ -299,14 +302,14 @@ class TestHelpers(TestCaseWithQApplication):
                     self.assertEqual(mock_native_dialog.call_args[1]["File"], "")
                     self.assertEqual(mock_native_dialog.call_args[1]["InitialDir"], home_dir())
             else:  # Linux et al.
-                with patch("spinetoolbox.helpers.QFileDialog.getOpenFileName") as mock_open_file_dialog:
+                with mock.patch("spinetoolbox.helpers.QFileDialog.getOpenFileName") as mock_open_file_dialog:
                     mock_open_file_dialog.return_value = [str(executable)]
                     select_python_interpreter(None, line_edit)
                     # initial dir should be according to the text in line edit
                     mock_open_file_dialog.assert_called_with(None, "Select Python Interpreter", str(executable))
                     with (
-                        patch("spinetoolbox.helpers.os.path.exists") as mock_exists,
-                        patch("spinetoolbox.helpers.os.path.abspath") as mock_abspath,
+                        mock.patch("spinetoolbox.helpers.os.path.exists") as mock_exists,
+                        mock.patch("spinetoolbox.helpers.os.path.abspath") as mock_abspath,
                     ):
                         mock_exists.return_value = True
                         mock_abspath.return_value = python_in_path
@@ -328,12 +331,12 @@ class TestHelpers(TestCaseWithQApplication):
         with TemporaryDirectory() as temp_dir:
             file_path = Path(temp_dir, "file")
             file_path.touch()
-            with patch("spinetoolbox.helpers.QMessageBox"):
+            with mock.patch("spinetoolbox.helpers.QMessageBox"):
                 self.assertTrue(file_is_valid(None, str(file_path), "Message title"))
 
     def test_dir_is_valid(self):
         with TemporaryDirectory() as temp_dir:
-            with patch("spinetoolbox.helpers.QMessageBox"):
+            with mock.patch("spinetoolbox.helpers.QMessageBox"):
                 self.assertTrue(dir_is_valid(None, temp_dir, "Message title"))
 
     def test_unique_name(self):
@@ -637,7 +640,7 @@ class TestSelectDirectoryWithDialog:
         default_path = Path(__file__).parent
         selected_path = Path(sys.executable).parent
         with q_object(QLineEdit()) as line_edit:
-            with patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory") as mock_dialog:
+            with mock.patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory") as mock_dialog:
                 mock_dialog.return_value = selected_path.as_posix()  # The dialog returns a POSIX path even on Windows.
                 select_directory_with_dialog(line_edit, "Select test directory", line_edit, str(default_path))
                 mock_dialog.assert_called_once_with(line_edit, "Select test directory", str(default_path))
@@ -648,7 +651,7 @@ class TestSelectDirectoryWithDialog:
         selected_path = Path(sys.executable).parent
         with q_object(QLineEdit()) as line_edit:
             line_edit.setText(str(tmp_path))
-            with patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory") as mock_dialog:
+            with mock.patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory") as mock_dialog:
                 mock_dialog.return_value = selected_path.as_posix()  # The dialog returns a POSIX path even on Windows.
                 select_directory_with_dialog(line_edit, "Select test directory", line_edit, str(default_path))
                 mock_dialog.assert_called_once_with(line_edit, "Select test directory", str(tmp_path))
@@ -659,7 +662,7 @@ class TestSelectDirectoryWithDialog:
         current_path = Path(sys.executable).parent
         with q_object(QLineEdit()) as line_edit:
             line_edit.setText(str(current_path))
-            with patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory") as mock_dialog:
+            with mock.patch("spinetoolbox.helpers.QFileDialog.getExistingDirectory") as mock_dialog:
                 mock_dialog.return_value = ""
                 select_directory_with_dialog(line_edit, "Select test directory", line_edit, str(default_path))
                 mock_dialog.assert_called_once_with(line_edit, "Select test directory", str(current_path))
@@ -685,3 +688,60 @@ class TestFindSectionInTableModelHeader:
             model.setHorizontalHeaderLabels(["a", "b", "c"])
             with pytest.raises(ValueError, match="^d not found in header$"):
                 find_section_in_table_model_header("d", model)
+
+
+class TestRecentProjects:
+    def test_update_recent_projects(self, qsettings_file):
+        # Test add first project
+        update_recent_projects(qsettings_file, "ProjectA", "C:/Projects/A")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        assert recents == "ProjectA<>C:/Projects/A"
+        # Add second and check that it goes to the front
+        update_recent_projects(qsettings_file, "ProjectB", "C:/Projects/B")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        assert recents.split("\n") == ["ProjectB<>C:/Projects/B", "ProjectA<>C:/Projects/A"]
+        # Test duplicate is not created, but it's moved to the front
+        update_recent_projects(qsettings_file, "ProjectC", "C:/Projects/C")
+        update_recent_projects(qsettings_file, "ProjectA", "C:/Projects/A")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectC<>C:/Projects/C", "ProjectB<>C:/Projects/B"]
+
+    def test_recent_projects_limited_to_twenty(self, qsettings_file):
+        for i in range(21):
+            update_recent_projects(qsettings_file, f"Project{i}", f"C:/Projects/{i}")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        items = recents.split("\n")
+        assert len(items) == 20
+        assert items[0] == "Project20<>C:/Projects/20"
+        assert "Project0<>C:/Projects/0" not in items
+
+    def test_clear_recent_projects(self, application, parent_widget, qsettings_file):
+        update_recent_projects(qsettings_file, "ProjectB", "C:/Projects/B")
+        update_recent_projects(qsettings_file, "ProjectA", "C:/Projects/A")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectB<>C:/Projects/B"]
+        with mock.patch("spinetoolbox.helpers.QMessageBox.exec", return_value=QMessageBox.StandardButton.No) as mock_exec1:
+            clear_recent_projects(parent_widget, qsettings_file)
+            mock_exec1.assert_called()
+            recents = qsettings_file.value("appSettings/recentProjects")
+            assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectB<>C:/Projects/B"]
+        with mock.patch("spinetoolbox.helpers.QMessageBox.exec", return_value=QMessageBox.StandardButton.Yes) as mock_exec2:
+            clear_recent_projects(parent_widget, qsettings_file)
+            mock_exec2.assert_called()
+            assert qsettings_file.value("appSettings/recentProjects") is None
+            assert qsettings_file.value("appSettings/recentProjectStorages") is None
+
+    def test_remove_path_from_recent_projects(self, qsettings_file):
+        update_recent_projects(qsettings_file, "ProjectC", "C:/Projects/C")
+        update_recent_projects(qsettings_file, "ProjectB", "C:/Projects/B")
+        update_recent_projects(qsettings_file, "ProjectA", "C:/Projects/A")
+        remove_path_from_recent_projects(qsettings_file, "C:/Projects/B")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectC<>C:/Projects/C"]
+
+    def test_remove_nonexistent_path_from_recent_projects(self, qsettings_file):
+        update_recent_projects(qsettings_file, "ProjectB", "C:/Projects/B")
+        update_recent_projects(qsettings_file, "ProjectA", "C:/Projects/A")
+        remove_path_from_recent_projects(qsettings_file, "C:/Projects/DoesNotExist")
+        recents = qsettings_file.value("appSettings/recentProjects")
+        assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectB<>C:/Projects/B"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,7 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""Unit tests for the helpers module."""
+"""Unit tests for the ``helpers`` module."""
 
 from pathlib import Path
 import re

--- a/tests/widgets/test_custom_menus.py
+++ b/tests/widgets/test_custom_menus.py
@@ -1,0 +1,107 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Toolbox contributors
+# This file is part of Spine Toolbox.
+# Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+"""Unit tests for the custom_menus module."""
+from unittest import mock
+from PySide6.QtWidgets import QMessageBox
+from spinetoolbox.widgets.custom_menus import RecentProjectsPopupMenu
+from spinetoolbox.helpers import update_recent_projects
+from spinetoolbox.config import LATEST_PROJECT_VERSION
+
+
+class TestRecentProjectsPopUpMenu:
+    def test_recent_projects_with_different_versions(self, parent_widget_with_settings):
+        menu = self.make_menu_with_projects(parent_widget_with_settings)
+        actions = menu.actions()
+        # Test in LIFO order
+        assert actions[0].text() == "unknown"
+        assert actions[0].toolTip() == "/toolbox/unknown"
+        assert "future" in actions[1].text()
+        assert "requires newer Spine Toolbox" in actions[1].toolTip()
+        assert actions[2].text() == "old"
+        assert "upgrades to" in actions[2].toolTip()
+        assert actions[3].text() == "current"
+        assert "(current)" in actions[3].toolTip()
+        assert actions[4].text() == ""  # separator
+        assert actions[5].text() == "Clear"
+
+    def test_clear_menu(self, application, parent_widget_with_settings):
+        update_recent_projects(parent_widget_with_settings.qsettings(), "A", "/toolbox/A")
+        update_recent_projects(parent_widget_with_settings.qsettings(), "B", "/toolbox/B")
+        menu = RecentProjectsPopupMenu(parent_widget_with_settings)
+        assert len(menu.actions()) == 4
+        assert menu.actions()[0].text() == "B"
+        assert menu.actions()[1].text() == "A"
+        assert menu.actions()[2].text() == ""
+        assert menu.actions()[3].text() == "Clear"
+        with mock.patch("spinetoolbox.helpers.QMessageBox.exec") as mock_exec:
+            mock_exec.return_value = QMessageBox.StandardButton.Yes
+            menu.actions()[3].trigger()  # Clicks Clear button
+        menu.close()
+        menu = RecentProjectsPopupMenu(parent_widget_with_settings)
+        assert len(menu.actions()) == 2
+        assert menu.actions()[0].text() == ""
+        assert menu.actions()[1].text() == "Clear"
+
+    def test_open_project(self, application, parent_widget_with_settings):
+        menu = self.make_menu_with_projects(parent_widget_with_settings)
+        parent_widget_with_settings.open_project = mock.Mock()
+        with (
+            mock.patch("spinetoolbox.widgets.custom_menus.os.path.exists", return_value=True),
+            mock.patch("spinetoolbox.widgets.custom_menus.QMessageBox.warning") as mock_warning
+        ):
+            menu.actions()[0].trigger()  # Trigger unknown project
+            assert mock_warning.call_count == 1
+            parent_widget_with_settings.open_project.assert_not_called()
+            menu.actions()[1].trigger()  # Trigger future project
+            assert mock_warning.call_count == 2
+            parent_widget_with_settings.open_project.assert_not_called()
+            # Project already open
+            project = mock.Mock()
+            project.project_dir = "/toolbox/current"
+            parent_widget_with_settings.project = mock.Mock(return_value=project)
+            parent_widget_with_settings.msg = mock.Mock()
+            menu.actions()[3].trigger()  # Trigger current project
+            parent_widget_with_settings.msg.emit.assert_called_once_with("Project already open")
+            parent_widget_with_settings.open_project.assert_not_called()
+            # Project not already open
+            parent_widget_with_settings.open_project.reset_mock()
+            project.project_dir = "/something/else"
+            parent_widget_with_settings.project = mock.Mock(return_value=project)
+            parent_widget_with_settings.msg = mock.Mock()
+            menu.actions()[3].trigger()
+            parent_widget_with_settings.open_project.assert_called_once_with("/toolbox/current")
+
+    @staticmethod
+    def make_menu_with_projects(parent_widget_with_settings):
+        update_recent_projects(parent_widget_with_settings.qsettings(), "current", "/toolbox/current")
+        update_recent_projects(parent_widget_with_settings.qsettings(), "old", "/toolbox/old")
+        update_recent_projects(parent_widget_with_settings.qsettings(), "future", "/toolbox/future")
+        update_recent_projects(parent_widget_with_settings.qsettings(), "unknown", "/toolbox/unknown")
+        versions = {
+            "/toolbox/current": LATEST_PROJECT_VERSION,
+            "/toolbox/old": LATEST_PROJECT_VERSION - 1,
+            "/toolbox/future": LATEST_PROJECT_VERSION + 1,
+        }
+
+        def mock_isdir(path):
+            return path != "/toolbox/unknown"
+
+        def mock_load_project_dict(path):
+            return {"project": {"version": versions[path]}}
+
+        with (
+            mock.patch("spinetoolbox.widgets.custom_menus.os.path.isdir", side_effect=mock_isdir),
+            mock.patch("spinetoolbox.widgets.custom_menus.load_project_dict", side_effect=mock_load_project_dict),
+        ):
+            menu = RecentProjectsPopupMenu(parent_widget_with_settings)
+        return menu

--- a/tests/widgets/test_custom_menus.py
+++ b/tests/widgets/test_custom_menus.py
@@ -10,7 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""Unit tests for the custom_menus module."""
+"""Unit tests for the ``custom_menus`` module."""
 from unittest import mock
 from PySide6.QtWidgets import QMessageBox
 from spinetoolbox.widgets.custom_menus import RecentProjectsPopupMenu

--- a/tests/widgets/test_custom_menus.py
+++ b/tests/widgets/test_custom_menus.py
@@ -11,6 +11,7 @@
 ######################################################################################################################
 
 """Unit tests for the ``custom_menus`` module."""
+
 from unittest import mock
 from PySide6.QtWidgets import QMessageBox
 from spinetoolbox.widgets.custom_menus import RecentProjectsPopupMenu
@@ -57,7 +58,7 @@ class TestRecentProjectsPopUpMenu:
         parent_widget_with_settings.open_project = mock.Mock()
         with (
             mock.patch("spinetoolbox.widgets.custom_menus.os.path.exists", return_value=True),
-            mock.patch("spinetoolbox.widgets.custom_menus.QMessageBox.warning") as mock_warning
+            mock.patch("spinetoolbox.widgets.custom_menus.QMessageBox.warning") as mock_warning,
         ):
             menu.actions()[0].trigger()  # Trigger unknown project
             assert mock_warning.call_count == 1

--- a/tests/widgets/test_open_project_dialog.py
+++ b/tests/widgets/test_open_project_dialog.py
@@ -15,9 +15,10 @@
 import os
 import json
 from unittest import mock
-from PySide6.QtCore import QPoint, QDir, QModelIndex
+from PySide6.QtCore import QPoint, QDir, QModelIndex, Qt
 from PySide6.QtWidgets import QDialog
-from spinetoolbox.widgets.open_project_dialog import OpenProjectDialog
+from PySide6.QtGui import QValidator
+from spinetoolbox.widgets.open_project_dialog import OpenProjectDialog, CustomQFileSystemModel, DirValidator
 from spinetoolbox.config import LATEST_PROJECT_VERSION
 
 
@@ -137,7 +138,9 @@ class TestOpenProjectDialog:
 
     @mock.patch("spinetoolbox.widgets.open_project_dialog.Notification")
     @mock.patch("spinetoolbox.widgets.open_project_dialog.load_project_dict")
-    def test_done_incompatible_version(self, mock_load_project_dict, mock_notification, parent_widget_with_settings, tmp_path):
+    def test_done_incompatible_version(
+        self, mock_load_project_dict, mock_notification, parent_widget_with_settings, tmp_path
+    ):
         project_dir = tmp_path / "project"
         (project_dir / ".spinetoolbox").mkdir(parents=True)
         (project_dir / ".spinetoolbox" / "project.json").write_text("{}")
@@ -149,16 +152,121 @@ class TestOpenProjectDialog:
         assert "Cannot open project" in mock_notification.call_args[0][1]
 
     @mock.patch("spinetoolbox.widgets.open_project_dialog.load_project_dict")
-    def test_done_valid_project(self, mock_load_project_dict, parent_widget_with_settings,tmp_path):
+    def test_done_valid_project(self, mock_load_project_dict, parent_widget_with_settings, tmp_path):
         project_dir = tmp_path / "project"
         (project_dir / ".spinetoolbox").mkdir(parents=True)
-        project_json = (project_dir / ".spinetoolbox" / "project.json")
+        project_json = project_dir / ".spinetoolbox" / "project.json"
         project_json.write_text(json.dumps({"project": {"version": LATEST_PROJECT_VERSION}}))
         mock_load_project_dict.return_value = {"project": {"version": LATEST_PROJECT_VERSION}}
         opw = OpenProjectDialog(parent_widget_with_settings)
         with (
             mock.patch.object(opw, "selection", return_value=str(project_dir)),
-            mock.patch.object(opw, "update_recents") as mock_update_recents
+            mock.patch.object(opw, "update_recents") as mock_update_recents,
         ):
             opw.done(QDialog.DialogCode.Accepted)
         mock_update_recents.assert_called_once()
+
+
+class TestCustomQFileSystemModel:
+    def test_data_tooltip_role(self):
+        model = CustomQFileSystemModel()
+        assert model.columnCount() == 1
+        index = QModelIndex()
+        with mock.patch.object(model, "filePath", return_value="/some/project"):
+            # Not a Spine Toolbox project
+            with mock.patch(
+                "spinetoolbox.widgets.open_project_dialog.is_spine_toolbox_project_dir",
+                return_value=False,
+            ):
+                result = model.data(index, Qt.ItemDataRole.ToolTipRole)
+                assert result is None
+            # Missing version info
+            with (
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.is_spine_toolbox_project_dir",
+                    return_value=True,
+                ),
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.load_project_dict",
+                    return_value={"project": {}},
+                ),
+            ):
+                result = model.data(index, Qt.ItemDataRole.ToolTipRole)
+                assert result == "Corrupted project. No version information found."
+            # Current version
+            with (
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.is_spine_toolbox_project_dir",
+                    return_value=True,
+                ),
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.load_project_dict",
+                    return_value={"project": {"version": LATEST_PROJECT_VERSION}},
+                ),
+            ):
+                result = model.data(index, Qt.ItemDataRole.ToolTipRole)
+                assert result == f"Version {LATEST_PROJECT_VERSION} (current)"
+            # Older version
+            old_version = LATEST_PROJECT_VERSION - 1
+            with (
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.is_spine_toolbox_project_dir",
+                    return_value=True,
+                ),
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.load_project_dict",
+                    return_value={"project": {"version": old_version}},
+                ),
+            ):
+                result = model.data(index, Qt.ItemDataRole.ToolTipRole)
+                assert result == f"Version {old_version} " f"(upgrades to {LATEST_PROJECT_VERSION} when opened)"
+            # Newer version
+            new_version = LATEST_PROJECT_VERSION + 1
+            with (
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.is_spine_toolbox_project_dir",
+                    return_value=True,
+                ),
+                mock.patch(
+                    "spinetoolbox.widgets.open_project_dialog.load_project_dict",
+                    return_value={"project": {"version": new_version}},
+                ),
+            ):
+                result = model.data(index, Qt.ItemDataRole.ToolTipRole)
+                assert result == (
+                    f"Version {new_version} "
+                    f"(requires newer Spine Toolbox, "
+                    f"current support: {LATEST_PROJECT_VERSION})"
+                )
+
+
+class TestDirValidator:
+    def test_validate(self, tmp_path):
+        validator = DirValidator()
+        changed = mock.Mock()
+        validator.changed.connect(changed)
+        # Empty text -> Intermediate
+        state = validator.validate("", 0)
+        assert state == QValidator.State.Intermediate
+        assert validator.state == QValidator.State.Intermediate
+        assert changed.call_count == 1
+        # Same state again -> no signal
+        state = validator.validate("does_not_exist", 0)
+        assert state == QValidator.State.Intermediate
+        assert validator.state == QValidator.State.Intermediate
+        assert changed.call_count == 1
+        # Existing directory -> Acceptable
+        state = validator.validate(str(tmp_path), 0)
+        assert state == QValidator.State.Acceptable
+        assert validator.state == QValidator.State.Acceptable
+        assert changed.call_count == 2
+        # Same state again -> no signal
+        state = validator.validate(str(tmp_path), 0)
+        assert state == QValidator.State.Acceptable
+        assert validator.state == QValidator.State.Acceptable
+        assert changed.call_count == 2
+        # Back to invalid -> state changes, signal emitted
+        state = validator.validate("does_not_exist", 0)
+        assert state == QValidator.State.Intermediate
+        assert validator.state == QValidator.State.Intermediate
+        assert changed.call_count == 3

--- a/tests/widgets/test_open_project_dialog.py
+++ b/tests/widgets/test_open_project_dialog.py
@@ -12,83 +12,153 @@
 
 """Unit tests for the ``open_project_dialog`` module."""
 
-from tempfile import TemporaryDirectory
+import os
+import json
 from unittest import mock
-from PySide6.QtCore import QPoint
-from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import QPoint, QDir, QModelIndex
+from PySide6.QtWidgets import QDialog
 from spinetoolbox.widgets.open_project_dialog import OpenProjectDialog
-from tests.mock_helpers import TestCaseWithQApplication
+from spinetoolbox.config import LATEST_PROJECT_VERSION
 
 
-class TestOpenProjectDialog(TestCaseWithQApplication):
-    def test_open_project_dialog(self):
-        widget = QWidget()
-        opw = OpenProjectDialog(DummyToolbox(widget))
+class TestOpenProjectDialog:
+    def test_open_project_dialog(self, application, parent_widget_with_settings, tmp_path):
+        # Add two dirs to recentProjectStorages. (one that exists and one that doesn't)
+        temp_dir1 = tmp_path / "dir1"
+        temp_dir1.mkdir()
+        recents_list = [str(temp_dir1), "/some/projects"]
+        recents = "\n".join(recents_list)
+        parent_widget_with_settings.qsettings().setValue("appSettings/recentProjectStorages", recents)
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        assert opw.ui.comboBox_current_path.count() == 2
+        assert opw.ui.comboBox_current_path.currentText() == str(temp_dir1)
         opw.go_root_action.trigger()
         opw.go_home_action.trigger()
         opw.go_documents_action.trigger()
         opw.go_desktop_action.trigger()
+        # Selecting non-existing path from the combobox should remove it from qsettings
+        opw.ui.comboBox_current_path.setCurrentIndex(1)
+        entries = parent_widget_with_settings.qsettings().value("appSettings/recentProjectStorages")
+        assert entries == str(temp_dir1)
+        opw.ui.comboBox_current_path.setCurrentIndex(0)
+        assert opw.ui.comboBox_current_path.currentText() == str(temp_dir1)
+        # Clear recent project storages
         with mock.patch(
             "spinetoolbox.widgets.open_project_dialog.OpenProjectDialogComboBoxContextMenu.get_action"
         ) as mock_cb_context_menu:
             mock_cb_context_menu.return_value = "Clear history"
             opw.show_context_menu(QPoint(0, 0))
             mock_cb_context_menu.assert_called()
+        assert os.path.samefile(opw.ui.comboBox_current_path.currentText(), QDir.rootPath())
         opw.close()
 
-    def test_update_recents_remove_recents(self):
-        widget = QWidget()
-        with TemporaryDirectory() as temp_dir1:
-            with TemporaryDirectory() as temp_dir2:
-                opw = OpenProjectDialog(DummyToolbox(widget))
-                opw.expand_and_resize(temp_dir1)
-                # Add path
-                opw.update_recents(temp_dir1, opw._qsettings)
-                expected_str1 = temp_dir1
-                self.assertEqual(expected_str1, opw._qsettings.recent_storages)
-                # Add a second one
-                opw.update_recents(temp_dir2, opw._qsettings)
-                expected_str2 = f"{temp_dir2}" + "\n" + f"{temp_dir1}"
-                self.assertEqual(expected_str2, opw._qsettings.recent_storages)
-                # Try to add the same path again
-                opw.update_recents(temp_dir2, opw._qsettings)
-                self.assertEqual(expected_str2, opw._qsettings.recent_storages)
-                # Remove the paths one by one
-                opw.remove_directory_from_recents(temp_dir1, opw._qsettings)
-                expected_str3 = temp_dir2
-                self.assertEqual(expected_str3, opw._qsettings.recent_storages)
-                opw.remove_directory_from_recents(temp_dir2, opw._qsettings)
-                expected_str4 = ""
-                self.assertEqual(expected_str4, opw._qsettings.recent_storages)
+    def test_update_recents_remove_recents(self, parent_widget_with_settings, tmp_path):
+        temp_dir1 = tmp_path / "dir1"
+        temp_dir2 = tmp_path / "dir2"
+        temp_dir1.mkdir()
+        temp_dir2.mkdir()
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        opw.expand_and_resize(str(temp_dir1))
+        # Add path
+        opw.update_recents(str(temp_dir1), opw._qsettings)
+        assert opw._qsettings.value("appSettings/recentProjectStorages") == str(temp_dir1)
+        # Add second path
+        opw.update_recents(str(temp_dir2), opw._qsettings)
+        assert opw._qsettings.value("appSettings/recentProjectStorages") == f"{temp_dir2}\n{temp_dir1}"
+        # Add same path again
+        opw.update_recents(str(temp_dir2), opw._qsettings)
+        assert opw._qsettings.value("appSettings/recentProjectStorages") == f"{temp_dir2}\n{temp_dir1}"
+        # Remove first path
+        opw.remove_directory_from_recents(str(temp_dir1), opw._qsettings)
+        assert opw._qsettings.value("appSettings/recentProjectStorages") == str(temp_dir2)
+        # Remove second path
+        opw.remove_directory_from_recents(str(temp_dir2), opw._qsettings)
+        assert opw._qsettings.value("appSettings/recentProjectStorages") == ""
 
+    def test_open_project(self, parent_widget_with_settings, tmp_path):
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        # Test that invalid indexes don't call done
+        with mock.patch.object(opw, "done") as mock_done:
+            opw.open_project(QModelIndex())
+        mock_done.assert_not_called()
+        # Create a valid QModelIndex mock
+        valid_index = mock.Mock(spec=QModelIndex)
+        valid_index.isValid.return_value = True
+        # Test that non-project directories don't call done
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with mock.patch.object(opw, "selection", return_value=str(project_dir)):
+            with mock.patch.object(opw, "done") as mock_done:
+                opw.open_project(valid_index)
+        mock_done.assert_not_called()
+        # Test that valid project directories call done
+        project_dict = {"project": {"version": LATEST_PROJECT_VERSION}}
+        (project_dir / ".spinetoolbox").mkdir()
+        (project_dir / ".spinetoolbox" / "project.json").write_text(json.dumps(project_dict))
+        with mock.patch.object(opw, "selection", return_value=str(project_dir)):
+            with mock.patch.object(opw, "done") as mock_done:
+                opw.open_project(valid_index)
+        mock_done.assert_called_once_with(QDialog.DialogCode.Accepted)
 
-class DummyToolbox(QWidget):
-    def __init__(self, parent):
-        super().__init__(parent)
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.Notification")
+    def test_done_nonexistent_path(self, mock_notification, parent_widget_with_settings):
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        with mock.patch.object(opw, "selection", return_value="/does/not/exist"):
+            opw.done(QDialog.DialogCode.Accepted)
+        mock_notification.assert_called_once_with(opw, "Path does not exist")
 
-    def qsettings(self):
-        return MockQSettings()
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.Notification")
+    def test_done_not_a_project(self, mock_notification, parent_widget_with_settings, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        with mock.patch.object(opw, "selection", return_value=str(project_dir)):
+            opw.done(QDialog.DialogCode.Accepted)
+        mock_notification.assert_called_once_with(opw, "Not a valid Spine Toolbox project")
 
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.Notification")
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.load_project_dict")
+    def test_done_missing_version(
+        self,
+        mock_load_project_dict,
+        mock_notification,
+        parent_widget_with_settings,
+        tmp_path,
+    ):
+        project_dir = tmp_path / "project"
+        (project_dir / ".spinetoolbox").mkdir(parents=True)
+        (project_dir / ".spinetoolbox" / "project.json").write_text("{}")
+        mock_load_project_dict.return_value = {}
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        with mock.patch.object(opw, "selection", return_value=str(project_dir)):
+            opw.done(QDialog.DialogCode.Accepted)
+        mock_notification.assert_called_once()
+        assert "Version info missing" in mock_notification.call_args[0][1]
 
-class MockQSettings:
-    """Fake QSettings class for testing the update of recent project storages in Custom Open Project Dialog."""
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.Notification")
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.load_project_dict")
+    def test_done_incompatible_version(self, mock_load_project_dict, mock_notification, parent_widget_with_settings, tmp_path):
+        project_dir = tmp_path / "project"
+        (project_dir / ".spinetoolbox").mkdir(parents=True)
+        (project_dir / ".spinetoolbox" / "project.json").write_text("{}")
+        mock_load_project_dict.return_value = {"project": {"version": LATEST_PROJECT_VERSION + 1}}
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        with mock.patch.object(opw, "selection", return_value=str(project_dir)):
+            opw.done(QDialog.DialogCode.Accepted)
+        mock_notification.assert_called_once()
+        assert "Cannot open project" in mock_notification.call_args[0][1]
 
-    def __init__(self):
-        self.recent_storages = None
-
-    # noinspection PyMethodMayBeStatic, PyPep8Naming
-    def value(self, key, defaultValue=""):
-        """Returns the default value"""
-        if key == "appSettings/recentProjectStorages":
-            return self.recent_storages
-        return defaultValue
-
-    # noinspection PyPep8Naming
-    def setValue(self, key, value):
-        """Returns without modifying anything."""
-        if key == "appSettings/recentProjectStorages":
-            self.recent_storages = value
-
-    @staticmethod
-    def sync():
-        return True
+    @mock.patch("spinetoolbox.widgets.open_project_dialog.load_project_dict")
+    def test_done_valid_project(self, mock_load_project_dict, parent_widget_with_settings,tmp_path):
+        project_dir = tmp_path / "project"
+        (project_dir / ".spinetoolbox").mkdir(parents=True)
+        project_json = (project_dir / ".spinetoolbox" / "project.json")
+        project_json.write_text(json.dumps({"project": {"version": LATEST_PROJECT_VERSION}}))
+        mock_load_project_dict.return_value = {"project": {"version": LATEST_PROJECT_VERSION}}
+        opw = OpenProjectDialog(parent_widget_with_settings)
+        with (
+            mock.patch.object(opw, "selection", return_value=str(project_dir)),
+            mock.patch.object(opw, "update_recents") as mock_update_recents
+        ):
+            opw.done(QDialog.DialogCode.Accepted)
+        mock_update_recents.assert_called_once()


### PR DESCRIPTION
- Show project version in the 'Recent projects' list as a tooltip
- Show project version in the Open Project Dialog as a tooltip when hovering over a Spine Toolbox directory
- Prevent opening projects that are newer than the currently supported toolbox version.

The last bullet point fixes a very old bug that showed a traceback when opening a project version that is newer than the latest project version that Spine Toolbox can handle. This happenend mostly when working on a new project version in a feature branch and then jumping back to the 'master' version but could also happen when projects were shared among people with different versions of toolbox. 

@jkiviluo maybe you can try this out. I'm not 100% sure if this was the requested feature in the issue but I think this is a good improvement anyway.

Fixes #2736

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
