### PR TITLE
Square macOS tooltips (#3346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 - The parameter name column in parameter value tables now shows the parameter definition's
   description as a tooltip on hover.
+- Tooltips in the Spine database editor no longer render as rounded pills with a large shadow on
+  macOS; they now use the same square frame as on the other platforms.
 
 ### Security
 

--- a/spinetoolbox/helpers.py
+++ b/spinetoolbox/helpers.py
@@ -1719,6 +1719,23 @@ def list_to_rich_text(data: Iterable[str]) -> str:
     return plain_to_rich("<br>".join(data))
 
 
+def macos_tooltip_style_sheet() -> str:
+    """QToolTip rule that forces a square, opaque frame in place of the rounded native macOS tooltip."""
+    palette = QApplication.palette()
+    background = palette.color(QPalette.ColorRole.ToolTipBase).name()
+    text = palette.color(QPalette.ColorRole.ToolTipText).name()
+    border = palette.color(QPalette.ColorRole.Mid).name()
+    return (
+        "QToolTip {"
+        f" background-color: {background};"
+        f" color: {text};"
+        f" border: 1px solid {border};"
+        " border-radius: 0px;"
+        " padding: 2px;"
+        "}"
+    )
+
+
 def plain_to_tool_tip(text: str | None) -> str | None:
     """Turns plain strings into rich text and empty strings/Nones to None.
 

--- a/spinetoolbox/spine_db_editor/main.py
+++ b/spinetoolbox/spine_db_editor/main.py
@@ -17,7 +17,7 @@ import sys
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
 from spinetoolbox.font import TOOLBOX_FONT
-from spinetoolbox.helpers import pyside6_version_check
+from spinetoolbox.helpers import macos_tooltip_style_sheet, pyside6_version_check
 from spinetoolbox.spine_db_editor.widgets.multi_spine_db_editor import MultiSpineDBEditor
 from spinetoolbox.spine_db_manager import SpineDBManager
 
@@ -31,6 +31,8 @@ def main():
     app = QApplication(sys.argv)
     TOOLBOX_FONT.get_family_from_font_database()
     locale.setlocale(locale.LC_NUMERIC, "C")
+    if sys.platform == "darwin":
+        app.setStyleSheet(macos_tooltip_style_sheet())
     settings = QSettings("SpineProject", "Spine Toolbox")
     db_mngr = SpineDBManager(settings, None)
     editor = MultiSpineDBEditor(db_mngr)

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -58,10 +58,10 @@ from spine_engine.utils.helpers import resolve_julia_executable, resolve_julia_p
 from spinetoolbox.server.engine_client import ClientSecurityModel, EngineClient, RemoteEngineInitFailed
 from .config import (
     DEFAULT_WORK_DIR,
+    LATEST_PROJECT_VERSION,
     ONLINE_DOCUMENTATION_URL,
     SPINE_DB_API_DOCUMENTATION_URL,
     SPINE_TOOLBOX_REPO_URL,
-    LATEST_PROJECT_VERSION
 )
 from .helpers import (
     ChildCyclingKeyPressFilter,
@@ -78,13 +78,13 @@ from .helpers import (
     make_icons_theme_aware,
     open_url,
     recursive_overwrite,
+    remove_path_from_recent_projects,
     same_path,
     set_taskbar_icon,
     solve_connection_file,
     supported_img_formats,
     unique_name,
     update_recent_projects,
-    remove_path_from_recent_projects,
 )
 from .kernel_fetcher import KernelFetcher
 from .link import JUMP_COLOR, LINK_COLOR, JumpLink, JumpOrLink, Link

--- a/spinetoolbox/ui_main.py
+++ b/spinetoolbox/ui_main.py
@@ -74,6 +74,7 @@ from .helpers import (
     create_dir,
     ensure_window_is_on_screen,
     format_log_message,
+    macos_tooltip_style_sheet,
     make_icons_theme_aware,
     open_url,
     recursive_overwrite,
@@ -410,7 +411,7 @@ class ToolboxUI(QMainWindow):
         )
 
     @staticmethod
-    def set_app_style():
+    def set_app_style() -> None:
         """Sets application style appropriate for each platform.
 
         The user can override the theme via appSettings/theme ("os", "light", or "dark").
@@ -426,10 +427,11 @@ class ToolboxUI(QMainWindow):
         use_dark = theme == "dark" or (
             theme == "os" and QApplication.instance().styleHints().colorScheme() == Qt.ColorScheme.Dark
         )
+        style_sheet_parts = []
         if use_dark:
             QApplication.setStyle("Fusion")
             QApplication.setPalette(_make_dark_palette())
-            QApplication.instance().setStyleSheet(
+            style_sheet_parts.append(
                 "QDockWidget {"
                 "    titlebar-close-icon: url(:/icons/menu_icons/times-white.svg);"
                 "    titlebar-normal-icon: url(:/icons/menu_icons/float-white.svg);"
@@ -438,6 +440,10 @@ class ToolboxUI(QMainWindow):
         elif theme == "light":
             QApplication.setStyle("Fusion")
             QApplication.setPalette(_make_light_palette())
+        if sys.platform == "darwin":
+            style_sheet_parts.append(macos_tooltip_style_sheet())
+        if style_sheet_parts:
+            QApplication.instance().setStyleSheet("\n".join(style_sheet_parts))
 
     @staticmethod
     def set_error_mode():

--- a/tests/test_ToolboxUI.py
+++ b/tests/test_ToolboxUI.py
@@ -916,5 +916,19 @@ class MockQueue:
         return "persistent_execution_msg", {"type": "persistent_started", "key": "123"}
 
 
+def test_set_app_style_adds_macos_tooltip_rule(application, monkeypatch):
+    monkeypatch.setattr("spinetoolbox.ui_main.sys.platform", "darwin")
+    settings = mock.MagicMock()
+    settings.value.return_value = "os"
+    monkeypatch.setattr("spinetoolbox.ui_main.QSettings", mock.MagicMock(return_value=settings))
+    app = QApplication.instance()
+    original_style_sheet = app.styleSheet()
+    try:
+        ToolboxUI.set_app_style()
+        assert "QToolTip" in app.styleSheet()
+    finally:
+        app.setStyleSheet(original_style_sheet)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,7 +20,7 @@ import unittest
 from unittest import mock
 from PySide6.QtCore import QObject, Qt, Signal
 from PySide6.QtGui import QAction, QKeySequence, QPalette, QStandardItem, QStandardItemModel
-from PySide6.QtWidgets import QLineEdit, QWidget, QMessageBox
+from PySide6.QtWidgets import QLineEdit, QMessageBox, QWidget
 import pytest
 from spinetoolbox.helpers import (
     DB_ITEM_SEPARATOR,
@@ -28,6 +28,7 @@ from spinetoolbox.helpers import (
     LogMessageHtmlParser,
     add_keyboard_shortcut_to_tool_tip,
     add_keyboard_shortcuts_to_action_tool_tips,
+    clear_recent_projects,
     copy_files,
     create_dir,
     dir_is_valid,
@@ -43,6 +44,7 @@ from spinetoolbox.helpers import (
     home_dir,
     interpret_icon_id,
     list_to_rich_text,
+    macos_tooltip_style_sheet,
     make_icon_id,
     merge_dicts,
     normcase_database_url_path,
@@ -52,6 +54,7 @@ from spinetoolbox.helpers import (
     plain_to_rich,
     plain_to_tool_tip,
     recursive_overwrite,
+    remove_path_from_recent_projects,
     rename_dir,
     rows_to_row_count_tuples,
     select_directory_with_dialog,
@@ -63,8 +66,6 @@ from spinetoolbox.helpers import (
     tuple_itemgetter,
     unique_name,
     update_recent_projects,
-    remove_path_from_recent_projects,
-    clear_recent_projects,
 )
 from tests.mock_helpers import TestCaseWithQApplication, q_object
 
@@ -749,3 +750,10 @@ class TestRecentProjects:
         remove_path_from_recent_projects(qsettings_file, "C:/Projects/DoesNotExist")
         recents = qsettings_file.value("appSettings/recentProjects")
         assert recents.split("\n") == ["ProjectA<>C:/Projects/A", "ProjectB<>C:/Projects/B"]
+
+
+class TestMacosTooltipStyleSheet(TestCaseWithQApplication):
+    def test_forces_a_square_frame(self):
+        style_sheet = macos_tooltip_style_sheet()
+        self.assertTrue(style_sheet.startswith("QToolTip {"))
+        self.assertIn("border-radius: 0px;", style_sheet)


### PR DESCRIPTION
Fixes #3346.

## Problem
On macOS, DB editor tooltips (e.g. entity tree item names) render as rounded "pill" shapes. `ToolboxUI.set_app_style()` applies `windowsvista` on Windows and `Fusion` on Linux — both draw square tooltips — but leaves macOS on its native style, which rounds tooltip corners heavily. Ubuntu and Windows are unaffected.

## Fix
On macOS only, apply a `QToolTip` style sheet that forces a square, opaque frame. A new `macos_tooltip_style_sheet()` helper reads `ToolTipBase`/`ToolTipText`/`Mid` from the current palette, so light and dark both look correct. It's wired into `set_app_style()` (refactored to accumulate one `setStyleSheet` call so it coexists with the existing dark-mode `QDockWidget` rule) and into the standalone DB editor entry point, which doesn't call `set_app_style()`.

## Notes / limitations
- Removing an opaque background + border (not just `border-radius`) is what actually squares the frame; `border-radius: 0` alone is not reliable on the native macOS style.
- This removes the rounding. The residual native macOS window shadow stays, but now tightly follows a square frame instead of a large pill — full shadow removal is out of scope.
- Colors are captured at startup, matching existing behavior; a light/dark toggle already requires a restart to take effect.
- Guarded by `sys.platform == "darwin"`, so Linux/Windows are untouched.

I don't have a Mac to confirm visually — a quick check of a tree-item tooltip on macOS (light and dark) would be appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)