### PR TITLE
Fix white-on-white regex search field on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 
 - The parameter name column in parameter value tables now shows the parameter definition's
   description as a tooltip on hover.
+- Active regex search fields in the Spine database editor no longer show white text on a white
+  background on macOS; the intended dark-red highlight is now drawn.
 
 ### Security
 

--- a/spinetoolbox/spine_db_editor/widgets/search_bar_base.py
+++ b/spinetoolbox/spine_db_editor/widgets/search_bar_base.py
@@ -16,8 +16,9 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QApplication, QLineEdit
 
 # A search field that holds a pattern is highlighted so it stands out in both light and dark themes.
-# Explicit colors override the theme deliberately.
-SEARCH_FIELD_ACTIVE_STYLE = "QLineEdit { background: #8b0000; color: white; }"
+# Explicit colors override the theme deliberately. The border forces Qt off the native macOS
+# text field, which otherwise ignores the background and leaves white text on a white field.
+SEARCH_FIELD_ACTIVE_STYLE = "QLineEdit { background-color: #8b0000; color: white; border: 1px solid #8b0000; }"
 
 
 def is_unmapped_alt(event) -> bool:


### PR DESCRIPTION
## Problem
On macOS, the regex/search filter fields in the Spine DB editor show **white text on a white background** when a filter is active, instead of the intended dark-red highlight that makes an active filter stand out. Ubuntu and Windows render it correctly.

## Cause
`SEARCH_FIELD_ACTIVE_STYLE` used the CSS `background` shorthand:
```
QLineEdit { background: #8b0000; color: white; }
```
The native macOS `QLineEdit` (NSTextField-backed) doesn't repaint from the `background` shorthand, so the red fill is dropped — but `color: white` still applies, giving white-on-white.

## Fix
Use `background-color` and add a matching `border`, which forces Qt onto its own styled paint path on macOS so the fill renders:
```
QLineEdit { background-color: #8b0000; color: white; border: 1px solid #8b0000; }
```
The border is the same dark red, so it blends in and doesn't read as an outline. No visual change on Linux/Windows.

Existing tests (`test_column_search_row.py`, `test_search_row_helpers.py`) compare against the imported constant, so they stay valid — 36 pass.

I don't have a Mac to confirm visually; a quick check that an active filter field shows the red fill on macOS would be appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)