### PR TITLE
Fix Traceback when editing the regex search fields of Parameter value list

### DIFF
--- a/spinetoolbox/mvcmodels/minimal_tree_model.py
+++ b/spinetoolbox/mvcmodels/minimal_tree_model.py
@@ -13,12 +13,15 @@
 """Models to represent items in a tree."""
 
 from __future__ import annotations
-from typing import Optional
+from typing import ClassVar, Optional
 from PySide6.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
+from spinedb_api.helpers import ItemType
 
 
 class TreeItem:
     """A tree item that can fetch its children."""
+
+    item_type: ClassVar[ItemType] = None
 
     def __init__(self, model):
         """
@@ -32,6 +35,10 @@ class TreeItem:
         self._set_up_once = False
         self._has_children_initially = False
         self._created_children = {}
+
+    @property
+    def visible_children(self) -> list:
+        return self._children
 
     def set_has_children_initially(self, has_children_initially):
         self._has_children_initially = has_children_initially

--- a/spinetoolbox/mvcmodels/time_series_model_variable_resolution.py
+++ b/spinetoolbox/mvcmodels/time_series_model_variable_resolution.py
@@ -15,6 +15,7 @@
 import numpy as np
 from PySide6.QtCore import QModelIndex, Qt, Slot
 from spinedb_api import TimeSeriesVariableResolution
+from spinedb_api.parameter_value import NUMPY_DATETIME64_UNIT
 from .indexed_value_table_model import IndexedValueTableModel
 
 
@@ -157,7 +158,9 @@ class TimeSeriesModelVariableResolution(IndexedValueTableModel):
             try:
                 self._value.indexes[row] = value
             except ValueError:
-                self._value.indexes[row] = np.datetime64()  # pylint: disable=no-value-for-parameter
+                self._value.indexes[row] = np.datetime64(
+                    "nat", NUMPY_DATETIME64_UNIT
+                )  # pylint: disable=no-value-for-parameter
         else:
             try:
                 self._value.values[row] = value

--- a/spinetoolbox/spine_db_editor/mvcmodels/level_filter.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/level_filter.py
@@ -184,12 +184,7 @@ class LevelFilterMixin:
         return matches
 
     def has_visible_match(self) -> bool:
-        """Returns whether any real item on the deepest filtered level is currently visible.
-
-        Used by the view to decide, once the filter has settled, whether to expand the tree onto the
-        matches or collapse it because nothing matched. With no filter active this is trivially True. The
-        phantom add-row is ignored, so an otherwise empty tree does not count as a match.
-        """
+        """Returns whether any real item on the deepest filtered level is currently visible."""
         if self._deepest_filtered_type() is None:
             return True
         return bool(self.collect_visible_matches())
@@ -203,32 +198,16 @@ class LevelFilterMixin:
 
     @Slot()
     def _run_force_fetch(self) -> None:
-        """Drives the lazy child fetch so a lower-level filter is accurate across collapsed parents.
-
-        Does nothing unless a lower-level filter is active. Otherwise it walks the tree and fetches every
-        item that (a) is not hidden by an upper-level filter and (b) still has children to fetch down to the
-        deepest filtered level. Fetching is async and batched, so as children land the insert hook continues
-        the cascade (see :meth:`_schedule_level_filter_refresh`) until nothing is left to fetch.
-        """
+        """Drives the lazy child fetch so a lower-level filter is accurate across collapsed parents."""
         if not self.lower_level_filter_active():
             self._force_fetching = False
             return
         self._force_fetching = self._force_fetch_lower_levels()
         if self._force_fetching:
-            # Keep driving the cascade until nothing is left to fetch. A fetch that lands no new rows still
-            # needs one more pass to flip ``can_fetch_more`` off, and deeper levels only become fetchable
-            # once their parents' children have arrived; the batched fetch keeps the UI responsive meanwhile.
             self._force_fetch_timer.start(FORCE_FETCH_CONTINUE_INTERVAL)
 
     def _force_fetch_lower_levels(self) -> bool:
         """Advances the force-fetch cascade by one step over a frontier of still-fetchable items.
-
-        Instead of re-walking the whole subtree from the root on every 0 ms reschedule (which re-tested
-        already-settled branches, making the cascade O(cascade steps x tree size)), this keeps a frontier
-        worklist: only items that may still need fetching are examined, and a fetched item's children are
-        enqueued once they have arrived. The scoping is unchanged - a child is only visited when it is under
-        a parent that passes its own filter, down to the deepest active level - so the cascade fetches
-        exactly the same set of branches as before, just without the repeated rescans.
 
         Returns:
             whether any fetch was issued (i.e. the cascade has not settled yet)

--- a/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/multi_db_tree_item.py
@@ -17,7 +17,6 @@ from collections.abc import Callable
 from typing import ClassVar
 from PySide6.QtCore import Qt
 from spinedb_api import DatabaseMapping
-from spinedb_api.helpers import ItemType
 from spinedb_api.temp_id import TempId
 from ...fetch_parent import FetchIndex, FlexibleFetchParent
 from ...helpers import bisect_chunks, order_key, rows_to_row_count_tuples
@@ -28,7 +27,6 @@ from ...mvcmodels.shared import ITEM_ID_ROLE
 class MultiDBTreeItem(FilterableChildrenMixin, TreeItem):
     """A tree item that may belong in multiple databases."""
 
-    item_type: ClassVar[ItemType] = None
     """Item type identifier string. Should be set to a meaningful value by subclasses."""
     visual_key: ClassVar[list[str]] = ["name"]
 
@@ -43,8 +41,6 @@ class MultiDBTreeItem(FilterableChildrenMixin, TreeItem):
             db_map_ids = {}
         self._db_map_ids = db_map_ids
         self._child_map: dict[DatabaseMapping, dict[TempId, int]] = {}
-        # Memoized filtered child list, rebuilt in lockstep with ``_child_map`` so that ``child``/
-        # ``row_count`` (list access) and ``child_number`` (``_child_map`` lookup) always agree.
         self._visible_children_cache: list | None = None
         self._fetch_index: FetchIndex | None = None
         self._fetch_parent = FlexibleFetchParent(
@@ -60,11 +56,7 @@ class MultiDBTreeItem(FilterableChildrenMixin, TreeItem):
 
     @property
     def visible_children(self) -> list:
-        """Returns the memoized filtered child list, building it (and the child map) on first access.
-
-        The list is cached and rebuilt only by :meth:`rebuild_child_map`, which every structural change and
-        every filter (re)apply already calls - so paint/scroll queries never recompute the filter.
-        """
+        """Returns the memoized filtered child list, building it (and the child map) on first access."""
         if self._visible_children_cache is None:
             self.rebuild_child_map()
         return self._visible_children_cache
@@ -82,10 +74,7 @@ class MultiDBTreeItem(FilterableChildrenMixin, TreeItem):
         return 0
 
     def rebuild_child_map(self) -> None:
-        """Recomputes the child map without emitting any layout-change signal.
-
-        Kept separate so a model can rebuild many items' maps under a single layout change.
-        """
+        """Recomputes the child map without emitting any layout-change signal."""
         self._child_map.clear()
         visible = self._compute_visible_children()
         self._visible_children_cache = visible

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_item_utility.py
@@ -25,7 +25,6 @@ from spinetoolbox.mvcmodels.shared import DB_MAP_ROLE, ITEM_ID_ROLE
 class StandardTreeItem(FilterableChildrenMixin, TreeItem):
     """A tree item that fetches their children as they are inserted."""
 
-    item_type: ClassVar[str] = None
     icon_code: ClassVar[str] = None
 
     def __init__(self, *args, **kwargs):
@@ -103,13 +102,7 @@ class StandardTreeItem(FilterableChildrenMixin, TreeItem):
 
     @property
     def visible_children(self) -> list:
-        """Returns the children that pass the active level filters, plus the phantom add-row.
-
-        When no level filter is active this is ``self.children`` unchanged, so the filtered path adds no
-        overhead to normal operation. Otherwise the filtered list is memoized and only recomputed when the
-        model's :attr:`~.level_filter.LevelFilterMixin.filter_generation` moves, so repeated Qt
-        layout/paint/scroll queries are served from the cache rather than rebuilt every time.
-        """
+        """Returns the children that pass the active level filters."""
         if not self.model.has_level_filters():
             return self.children
         self._ensure_visible_cache()

--- a/spinetoolbox/spine_db_editor/mvcmodels/tree_model_base.py
+++ b/spinetoolbox/spine_db_editor/mvcmodels/tree_model_base.py
@@ -34,13 +34,7 @@ class TreeModelBase(LevelFilterMixin, MinimalTreeModel):
         return str(item.data(0, Qt.ItemDataRole.DisplayRole))
 
     def item_is_visible(self, item) -> bool:
-        """Returns whether a tree item passes the active level filters.
-
-        The phantom add-row is always visible. An item on a filtered level must match its own regex. When a
-        lower level has an active filter, a parent is kept only if a LOADED descendant matches, or -
-        optimistically - if it can still fetch more (no fetch is forced); it is hidden only once it is fully
-        loaded and nothing matches. Items on unfiltered levels (e.g. the db root) always pass.
-        """
+        """Returns whether a tree item passes the active level filters."""
         if item.item_type not in self.LEVEL_ITEM_TYPES or item.is_empty_row():
             return True
         if not self.item_passes_own_filter(item):
@@ -53,11 +47,7 @@ class TreeModelBase(LevelFilterMixin, MinimalTreeModel):
         return True
 
     def _apply_level_filters(self) -> None:
-        """Refreshes the whole tree so the current level filters take effect.
-
-        These trees keep no child-position map, so a single ``layoutAboutToBeChanged``/``layoutChanged`` pair
-        is enough for the view to re-query the visible rows.
-        """
+        """Refreshes the whole tree so the current level filters take effect."""
         self.layoutAboutToBeChanged.emit()
         self._bump_filter_generation()
         self.layoutChanged.emit()

--- a/tests/mvcmodels/test_TimeSeriesModelVariableResolution.py
+++ b/tests/mvcmodels/test_TimeSeriesModelVariableResolution.py
@@ -15,6 +15,7 @@
 import numpy
 from PySide6.QtCore import QObject, Qt
 from spinedb_api import TimeSeriesVariableResolution
+from spinedb_api.parameter_value import NUMPY_DATETIME64_UNIT
 from spinetoolbox.mvcmodels.time_series_model_variable_resolution import TimeSeriesModelVariableResolution
 from tests.mock_helpers import TestCaseWithQApplication
 
@@ -228,7 +229,9 @@ class TestTimeSeriesModelVariableResolution(TestCaseWithQApplication):
         model_index = model.index(0, 0)
         model.setData(model_index, "what happened to Tuesday")
         # pylint: disable=no-value-for-parameter
-        expected = TimeSeriesVariableResolution([numpy.datetime64(), "1992-01-01T13:30"], [2.3, -5.0], True, False)
+        expected = TimeSeriesVariableResolution(
+            [numpy.datetime64("nat", NUMPY_DATETIME64_UNIT), "1992-01-01T13:30"], [2.3, -5.0], True, False
+        )
         self.assertEqual([str(x) for x in model.value.indexes], [str(x) for x in expected.indexes])
         self.assertTrue(numpy.array_equal(model.value.values, expected.values))
         self.assertEqual(model.value.ignore_year, expected.ignore_year)


### PR DESCRIPTION
This fixes a bug where editing the search fields on Parameter value list dock in DB editor would cause a Traceback when the editor tab did not have a database open.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
